### PR TITLE
Fix code review findings in calibration code

### DIFF
--- a/src/libslic3r/CalibrationModels.cpp
+++ b/src/libslic3r/CalibrationModels.cpp
@@ -7,9 +7,13 @@
 #include "MeshBoolean.hpp"
 #include "ExPolygon.hpp"
 #include "Tesselate.hpp"
+#include "libslic3r.h"  // SCALING_FACTOR, scale_(), unscale<>()
+
+#include <boost/log/trivial.hpp>
 
 #include <cmath>
 #include <string>
+#include <unordered_map>
 
 namespace Slic3r {
 
@@ -132,9 +136,8 @@ static indexed_triangle_set make_block_text(const std::string& text, double heig
 // Flow Specimen (serpentine / E-shape) — built as extruded 2D polygon
 // ---------------------------------------------------------------------------
 
-/// PrusaSlicer's Polygon uses integer coord_t (nanometer scale).
-/// Multiply mm values by FLOW_SCALE before storing as Point coordinates.
-static constexpr double FLOW_SCALE = 1e6;
+// PrusaSlicer's Polygon uses integer coord_t (nanometer scale).
+// Use the standard scale_() macro to convert mm → coord_t.
 
 /// Append n+1 arc points to a polygon.
 /// Centre (cx, cy) and radius r are in mm; angles in radians.
@@ -147,7 +150,7 @@ static void append_arc(Polygon& poly, double cx, double cy, double r,
         double a = a_start + (a_end - a_start) * i / n;
         double x = cx + r * std::cos(a);
         double y = cy + r * std::sin(a);
-        poly.points.push_back(Point(coord_t(x * FLOW_SCALE), coord_t(y * FLOW_SCALE)));
+        poly.points.push_back(Point(coord_t(scale_(x)), coord_t(scale_(y))));
     }
 }
 
@@ -180,8 +183,8 @@ static indexed_triangle_set extrude_expolygon(const ExPolygon& expoly, double he
         contour_starts.push_back(int(flat_pts.size()));
         contour_sizes.push_back(int(poly.points.size()));
         for (const Point& pt : poly.points) {
-            float x = float(double(pt.x()) / FLOW_SCALE);
-            float y = float(double(pt.y()) / FLOW_SCALE);
+            float x = float(unscale<double>(pt.x()));
+            float y = float(unscale<double>(pt.y()));
             flat_pts.push_back(Vec3f(x, y, 0.f));
         }
     };
@@ -226,19 +229,34 @@ static indexed_triangle_set extrude_expolygon(const ExPolygon& expoly, double he
         for (auto& hole : ep.holes)
             hole.make_clockwise();
 
-        // Helper: find the shared vertex index closest to (x, y) at z_level.
+        // Build a spatial hash for O(1) vertex lookup.
+        // Key: quantised (x, y) packed into int64_t.  The quantisation
+        // grid (0.001 mm) is finer than any rounding difference between
+        // the tessellator and our canonical vertices.
+        auto quantise = [](float v) -> int32_t { return int32_t(std::round(v * 1000.f)); };
+        auto pack_key = [&](float x, float y) -> int64_t {
+            return (int64_t(quantise(x)) << 32) | (int64_t(quantise(y)) & 0xFFFFFFFF);
+        };
+
+        std::unordered_map<int64_t, int> pt_index;
+        pt_index.reserve(total_pts);
+        for (int i = 0; i < total_pts; ++i)
+            pt_index[pack_key(flat_pts[i].x(), flat_pts[i].y())] = i;
+
+        // Look up the shared vertex index for a tessellated point.
         // z_offset selects bottom ring (0) or top ring (total_pts).
         auto find_nearest = [&](float x, float y, int z_offset) -> int {
+            auto it = pt_index.find(pack_key(x, y));
+            if (it != pt_index.end())
+                return base0 + z_offset + it->second;
+            // Fallback: linear scan (should not happen)
             int   best_idx  = base0 + z_offset;
             float best_dist = std::numeric_limits<float>::max();
             for (int i = 0; i < total_pts; ++i) {
                 float dx = flat_pts[i].x() - x;
                 float dy = flat_pts[i].y() - y;
                 float d  = dx * dx + dy * dy;
-                if (d < best_dist) {
-                    best_dist = d;
-                    best_idx  = base0 + z_offset + i;
-                }
+                if (d < best_dist) { best_dist = d; best_idx = base0 + z_offset + i; }
             }
             return best_idx;
         };
@@ -315,7 +333,7 @@ indexed_triangle_set make_flow_specimen(
         double arm_cy = (yb + yt) / 2.0;
 
         // Straight bottom edge of arm, then semicircular tip (-90° → +90°)
-        outer.points.push_back(Point(coord_t(slot_right_x * FLOW_SCALE), coord_t(yb * FLOW_SCALE)));
+        outer.points.push_back(Point(coord_t(scale_(slot_right_x)), coord_t(scale_(yb))));
         append_arc(outer, slot_right_x, arm_cy, outer_r, -M_PI / 2.0, M_PI / 2.0);
 
         if (i < num_arms - 1) {
@@ -324,14 +342,14 @@ indexed_triangle_set make_flow_specimen(
             double next_yb = yt + gap_width;
 
             // Bottom of slot (= top of arm i): right → left
-            outer.points.push_back(Point(coord_t(slot_left_cx * FLOW_SCALE), coord_t(yt * FLOW_SCALE)));
+            outer.points.push_back(Point(coord_t(scale_(slot_left_cx)), coord_t(scale_(yt))));
 
             // Left semicircle: -90° → +90° the LONG way through 180°,
             // i.e. -90° → -270° so the arc curves left into the spine.
             append_arc(outer, slot_left_cx, slot_cy, inner_r, -M_PI / 2.0, -3.0 * M_PI / 2.0);
 
             // Top of slot (= bottom of arm i+1): left → right
-            outer.points.push_back(Point(coord_t(slot_right_x * FLOW_SCALE), coord_t(next_yb * FLOW_SCALE)));
+            outer.points.push_back(Point(coord_t(scale_(slot_right_x)), coord_t(scale_(next_yb))));
         }
     }
 
@@ -357,12 +375,12 @@ indexed_triangle_set make_flow_specimen(
 // Base plate dimensions
 static constexpr double BASE_LENGTH     = 89.3;
 static constexpr double BASE_WIDTH      = 20.0;
-static constexpr double BASE_HEIGHT     = 1.0;
+static constexpr double BASE_HEIGHT     = TEMP_TOWER_BASE_HEIGHT;
 
 // Tier block dimensions
 static constexpr double TIER_LENGTH     = 79.0;
 static constexpr double TIER_WIDTH      = 10.0;
-static constexpr double TIER_HEIGHT     = 10.0;
+static constexpr double TIER_HEIGHT     = TEMP_TOWER_TIER_HEIGHT;
 
 // Overhang wedge X-extents (left = 45°, right = 35°)
 static constexpr double OVERHANG_45_X   = 10.0;
@@ -520,8 +538,13 @@ indexed_triangle_set make_temp_tower(int num_tiers, int start_temp, int temp_ste
 
         try {
             MeshBoolean::cgal::plus(tower, tier);
+        } catch (const std::exception& e) {
+            BOOST_LOG_TRIVIAL(warning) << "CalibrationModels: CGAL union failed for tier "
+                                       << i << ": " << e.what() << " — falling back to merge";
+            its_merge(tower, tier);
         } catch (...) {
-            // Fallback: simple merge if CGAL union fails
+            BOOST_LOG_TRIVIAL(warning) << "CalibrationModels: CGAL union failed for tier "
+                                       << i << " — falling back to merge";
             its_merge(tower, tier);
         }
     }

--- a/src/libslic3r/CalibrationModels.hpp
+++ b/src/libslic3r/CalibrationModels.hpp
@@ -9,10 +9,16 @@
 
 namespace Slic3r {
 
+// Shared geometry constants for the temperature tower.
+// Exposed so that CalibrationTempDialog can compute per-layer Z heights
+// without duplicating magic numbers.
+static constexpr double TEMP_TOWER_BASE_HEIGHT = 1.0;   // mm — base plate height
+static constexpr double TEMP_TOWER_TIER_HEIGHT = 10.0;  // mm — height per tier
+
 // Generate a temperature calibration tower mesh.
 // The tower has a 1mm base plate and num_tiers stacked 10mm tiers,
 // each with overhang features, holes, cones, cutout, protrusion,
-// and engraved temperature labels on the back face.
+// and raised temperature labels on the back face.
 // start_temp: temperature of the first (bottom) tier
 // temp_step: temperature decrease per tier (positive value)
 indexed_triangle_set make_temp_tower(int num_tiers, int start_temp, int temp_step);

--- a/src/slic3r/GUI/CalibrationFlowDialog.cpp
+++ b/src/slic3r/GUI/CalibrationFlowDialog.cpp
@@ -5,8 +5,6 @@
 #include "CalibrationFlowDialog.hpp"
 #include "GUI_App.hpp"
 #include "Plater.hpp"
-
-#include "MainFrame.hpp"
 #include "Tab.hpp"
 
 #include "libslic3r/PresetBundle.hpp"
@@ -148,8 +146,20 @@ void CalibrationFlowDialog::generate_and_load()
             nozzle_diameter = nozzle_opt->values[0];
     }
 
-    // Cross-sectional area of extrusion (approximate, ignoring die swell)
-    double extrusion_area = nozzle_diameter * layer_height;
+    // Use perimeter extrusion width if available, otherwise fall back to nozzle diameter.
+    // This gives a more accurate cross-sectional area for flow rate calculation.
+    double extrusion_width = nozzle_diameter;
+    if (preset_bundle) {
+        const Preset& print_preset2 = preset_bundle->prints.get_selected_preset();
+        const auto* ew_opt = print_preset2.config.option<ConfigOptionFloatOrPercent>("perimeter_extrusion_width");
+        if (ew_opt) {
+            double ew = ew_opt->percent ? nozzle_diameter * ew_opt->value / 100.0 : ew_opt->value;
+            if (ew > 0.0)
+                extrusion_width = ew;
+        }
+    }
+
+    double extrusion_area = extrusion_width * layer_height;
     if (extrusion_area <= 0.0)
         extrusion_area = 0.4 * 0.2;  // fallback
 

--- a/src/slic3r/GUI/CalibrationPADialog.cpp
+++ b/src/slic3r/GUI/CalibrationPADialog.cpp
@@ -29,10 +29,8 @@
 
 namespace Slic3r { namespace GUI {
 
-// Default layer height for PA pattern (must match slicer setting)
-static constexpr double PA_LAYER_HEIGHT = 0.2;
 // Number of printed layers per PA level
-static constexpr int    PA_LAYERS_PER_LEVEL = 4;
+static constexpr int PA_LAYERS_PER_LEVEL = 4;
 
 CalibrationPADialog::CalibrationPADialog(wxWindow* parent)
     : wxDialog(parent, wxID_ANY, _L("Pressure Advance Calibration"),
@@ -95,15 +93,11 @@ CalibrationPADialog::CalibrationPADialog(wxWindow* parent)
     }, wxID_OK);
 }
 
-double CalibrationPADialog::get_start_pa() const { return m_start_pa->GetValue(); }
-double CalibrationPADialog::get_end_pa()   const { return m_end_pa->GetValue(); }
-double CalibrationPADialog::get_pa_step()  const { return m_pa_step->GetValue(); }
-
 void CalibrationPADialog::generate_and_load()
 {
-    double start_pa = get_start_pa();
-    double end_pa   = get_end_pa();
-    double step     = get_pa_step();
+    double start_pa = m_start_pa->GetValue();
+    double end_pa   = m_end_pa->GetValue();
+    double step     = m_pa_step->GetValue();
 
     if (start_pa >= end_pa) {
         wxMessageBox(_L("End PA must be greater than start PA."),
@@ -123,6 +117,16 @@ void CalibrationPADialog::generate_and_load()
         return;
     }
 
+    // Read layer height from current print preset
+    double layer_height = 0.2;
+    const PresetBundle* pb = wxGetApp().preset_bundle;
+    if (pb) {
+        const auto* opt = pb->prints.get_selected_preset()
+                              .config.option<ConfigOptionFloat>("layer_height");
+        if (opt)
+            layer_height = opt->getFloat();
+    }
+
     // Total layers = levels × layers_per_level
     int total_layers = num_levels * PA_LAYERS_PER_LEVEL;
 
@@ -139,7 +143,7 @@ void CalibrationPADialog::generate_and_load()
                             << " total_layers=" << total_layers;
 
     // Generate single-chevron mesh
-    auto its = Slic3r::make_pa_pattern(total_layers, PA_LAYER_HEIGHT);
+    auto its = Slic3r::make_pa_pattern(total_layers, layer_height);
 
     // Write to temp STL
     boost::filesystem::path stl_path =
@@ -165,7 +169,7 @@ void CalibrationPADialog::generate_and_load()
     {
         DynamicPrintConfig& config =
             wxGetApp().preset_bundle->prints.get_edited_preset().config;
-        config.set_key_value("layer_height", new ConfigOptionFloat(PA_LAYER_HEIGHT));
+        config.set_key_value("layer_height", new ConfigOptionFloat(layer_height));
         config.set_key_value("variable_layer_height", new ConfigOptionBool(false));
         if (m_brim && m_brim->GetValue())
             config.set_key_value("brim_width", new ConfigOptionFloat(5.0));
@@ -179,7 +183,7 @@ void CalibrationPADialog::generate_and_load()
     info.mode = CustomGCode::SingleExtruder;
 
     for (int i = 0; i < num_levels; ++i) {
-        double z = i * PA_LAYERS_PER_LEVEL * PA_LAYER_HEIGHT + 0.1;
+        double z = i * PA_LAYERS_PER_LEVEL * layer_height + 0.1;
         double pa = start_pa + i * step;
 
         CustomGCode::Item item;

--- a/src/slic3r/GUI/CalibrationPADialog.hpp
+++ b/src/slic3r/GUI/CalibrationPADialog.hpp
@@ -20,15 +20,9 @@ class CalibrationPADialog : public wxDialog
 public:
     CalibrationPADialog(wxWindow* parent);
 
-    double get_start_pa() const;
-    double get_end_pa()   const;
-    double get_pa_step()  const;
-
-    /// Generate the chevron STL, load it onto the bed, and set per-layer
-    /// PA commands (M572 S) via custom G-code.
+private:
     void generate_and_load();
 
-private:
     wxSpinCtrlDouble* m_start_pa{nullptr};
     wxSpinCtrlDouble* m_end_pa{nullptr};
     wxSpinCtrlDouble* m_pa_step{nullptr};

--- a/src/slic3r/GUI/CalibrationTempDialog.cpp
+++ b/src/slic3r/GUI/CalibrationTempDialog.cpp
@@ -28,9 +28,9 @@
 
 namespace Slic3r { namespace GUI {
 
-// Must match CalibrationModels.cpp constants for per-layer G-code Z placement.
-static constexpr double BASE_HEIGHT = 1.0;   // mm — base plate height
-static constexpr double TIER_HEIGHT = 10.0;  // mm — height of each temperature tier
+// Use shared constants from CalibrationModels.hpp for per-layer G-code Z placement.
+static constexpr double BASE_HEIGHT = Slic3r::TEMP_TOWER_BASE_HEIGHT;
+static constexpr double TIER_HEIGHT = Slic3r::TEMP_TOWER_TIER_HEIGHT;
 
 CalibrationTempDialog::CalibrationTempDialog(wxWindow* parent)
     : wxDialog(parent, wxID_ANY, _L("Temperature Calibration Tower"),
@@ -97,6 +97,10 @@ CalibrationTempDialog::CalibrationTempDialog(wxWindow* parent)
 
     sizer->Add(grid, 0, wxALL | wxEXPAND, 15);
 
+    m_brim = new wxCheckBox(this, wxID_ANY, _L("Add 5 mm brim"));
+    m_brim->SetValue(true);
+    sizer->Add(m_brim, 0, wxLEFT | wxRIGHT | wxBOTTOM, 15);
+
     // OK / Cancel
     auto* btns = CreateStdDialogButtonSizer(wxOK | wxCANCEL);
     wxGetApp().UpdateDarkUI(FindWindowById(wxID_OK, this));
@@ -151,7 +155,14 @@ void CalibrationTempDialog::generate_and_load()
     // Reset print config to saved preset before loading, so any previous
     // calibration overrides (e.g. vase mode from flow specimen) are cleared.
     wxGetApp().preset_bundle->prints.discard_current_changes();
-    wxGetApp().get_tab(Preset::TYPE_PRINT)->reload_config();
+    {
+        DynamicPrintConfig& config =
+            wxGetApp().preset_bundle->prints.get_edited_preset().config;
+        config.set_key_value("variable_layer_height", new ConfigOptionBool(false));
+        if (m_brim && m_brim->GetValue())
+            config.set_key_value("brim_width", new ConfigOptionFloat(5.0));
+        wxGetApp().get_tab(Preset::TYPE_PRINT)->reload_config();
+    }
 
     // Generate mesh natively
     auto its = Slic3r::make_temp_tower(num_tiers, start_temp, step);

--- a/src/slic3r/GUI/CalibrationTempDialog.hpp
+++ b/src/slic3r/GUI/CalibrationTempDialog.hpp
@@ -6,6 +6,7 @@
 #define slic3r_CalibrationTempDialog_hpp_
 
 #include <wx/dialog.h>
+#include <wx/checkbox.h>
 #include <wx/spinctrl.h>
 
 namespace Slic3r { namespace GUI {
@@ -24,9 +25,10 @@ public:
     void generate_and_load();
 
 private:
-    wxSpinCtrl* m_start_temp{nullptr};
-    wxSpinCtrl* m_end_temp{nullptr};
-    wxSpinCtrl* m_temp_step{nullptr};
+    wxSpinCtrl*  m_start_temp{nullptr};
+    wxSpinCtrl*  m_end_temp{nullptr};
+    wxSpinCtrl*  m_temp_step{nullptr};
+    wxCheckBox*  m_brim{nullptr};
 };
 
 }} // namespace Slic3r::GUI


### PR DESCRIPTION
## Summary

Addresses findings from the code review of all new calibration code added to this fork.

### Fixes

| # | Severity | Fix |
|---|----------|-----|
| 1 | Medium | Replace O(n²) `find_nearest()` with spatial hash lookup in `extrude_expolygon()` |
| 3 | Low | Log CGAL union failures with `BOOST_LOG_TRIVIAL` instead of silent `catch(...)` |
| 5 | High | Replace custom `FLOW_SCALE` constant with PrusaSlicer's standard `scale_()`/`unscale<>()` |
| 6 | Medium | Move `TEMP_TOWER_BASE_HEIGHT`/`TIER_HEIGHT` to shared header; eliminate duplication |
| 7 | Low | Add optional brim checkbox to temperature dialog (was missing, inconsistent) |
| 9 | Medium | PA dialog reads `layer_height` from current print preset instead of hardcoding 0.2mm |
| 11 | Low | Remove unnecessary public getters from `CalibrationPADialog` |
| 14 | Low | Remove unused `MainFrame.hpp` include from `CalibrationFlowDialog` |
| 15 | Medium | Use `perimeter_extrusion_width` for flow area calculation instead of `nozzle_diameter` |

### Not addressed in this PR (lower priority)

- #10: M572 is Klipper-specific (Marlin uses M900) — needs firmware detection
- #12: M207 requires firmware retraction enabled — needs config check
- #13: Retraction `LAYERS_PER_LEVEL=5` may be too few — configurable in future
- #17: No undo/redo integration for calibration operations
- #18: Temp file cleanup race condition — `load_files` appears synchronous
- #19: Code duplication across dialogs — future refactor into base class

## Test plan

- [ ] Build succeeds on macOS
- [ ] Temperature tower generates correctly with brim checkbox
- [ ] Flow specimen uses accurate extrusion width for speed calculation
- [ ] PA pattern respects current layer height setting
- [ ] All calibration dialogs still functional

🤖 Generated with [Claude Code](https://claude.ai/code)