### PR TITLE
Pass nozzle diameter on filament sync-back

### DIFF
--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2599,19 +2599,26 @@ bool TabFilament::save_current_preset(const std::string &new_name, bool detach)
     m_preset_bundle->extruders_filaments[m_active_extruder].select_filament(m_presets->get_idx_selected());
 
     // Sync the saved preset back to FilamentDB (non-fatal on error).
-    // Pass the active nozzle diameter so the server can update the
-    // correct per-nozzle calibration entry (EM, PA, retraction, etc.).
+    // Pass the active nozzle diameter and high-flow flag so the server
+    // can update the correct per-nozzle calibration entry (EM, PA, etc.).
+    // This disambiguates e.g. 0.4mm standard vs 0.4mm HF nozzles.
     try {
         std::string filamentdb_url = wxGetApp().app_config->get("filamentdb_url");
         if (!filamentdb_url.empty()) {
             const Preset &saved = m_presets->get_selected_preset();
             double nozzle_dia = 0;
+            bool high_flow = false;
+            const auto &printer_cfg = m_preset_bundle->printers.get_edited_preset().config;
             const auto *printer_nozzle = dynamic_cast<const ConfigOptionFloats *>(
-                m_preset_bundle->printers.get_edited_preset().config.option("nozzle_diameter"));
+                printer_cfg.option("nozzle_diameter"));
             if (printer_nozzle && !printer_nozzle->values.empty())
                 nozzle_dia = printer_nozzle->values[0];
+            const auto *printer_hf = dynamic_cast<const ConfigOptionBools *>(
+                printer_cfg.option("nozzle_high_flow"));
+            if (printer_hf && !printer_hf->values.empty())
+                high_flow = printer_hf->values[0] != 0;
             std::string sync_error;
-            if (!sync_filament_to_filamentdb(filamentdb_url, saved.name, saved.config, sync_error, nozzle_dia))
+            if (!sync_filament_to_filamentdb(filamentdb_url, saved.name, saved.config, sync_error, nozzle_dia, high_flow))
                 BOOST_LOG_TRIVIAL(warning) << "FilamentDB sync-back failed: " << sync_error;
         }
     } catch (const std::exception &ex) {

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2598,13 +2598,20 @@ bool TabFilament::save_current_preset(const std::string &new_name, bool detach)
     // Saved preset have to be selected for active extruder in any case
     m_preset_bundle->extruders_filaments[m_active_extruder].select_filament(m_presets->get_idx_selected());
 
-    // Sync the saved preset back to FilamentDB (non-fatal on error)
+    // Sync the saved preset back to FilamentDB (non-fatal on error).
+    // Pass the active nozzle diameter so the server can update the
+    // correct per-nozzle calibration entry (EM, PA, retraction, etc.).
     try {
         std::string filamentdb_url = wxGetApp().app_config->get("filamentdb_url");
         if (!filamentdb_url.empty()) {
             const Preset &saved = m_presets->get_selected_preset();
+            double nozzle_dia = 0;
+            const auto *printer_nozzle = dynamic_cast<const ConfigOptionFloats *>(
+                m_preset_bundle->printers.get_edited_preset().config.option("nozzle_diameter"));
+            if (printer_nozzle && !printer_nozzle->values.empty())
+                nozzle_dia = printer_nozzle->values[0];
             std::string sync_error;
-            if (!sync_filament_to_filamentdb(filamentdb_url, saved.name, saved.config, sync_error))
+            if (!sync_filament_to_filamentdb(filamentdb_url, saved.name, saved.config, sync_error, nozzle_dia))
                 BOOST_LOG_TRIVIAL(warning) << "FilamentDB sync-back failed: " << sync_error;
         }
     } catch (const std::exception &ex) {

--- a/src/slic3r/Utils/FilamentDB.cpp
+++ b/src/slic3r/Utils/FilamentDB.cpp
@@ -264,16 +264,19 @@ bool sync_filament_to_filamentdb(
     const std::string &preset_name,
     const DynamicPrintConfig &config,
     std::string &error_message,
-    double nozzle_diameter)
+    double nozzle_diameter,
+    bool high_flow)
 {
     // Build endpoint: {api_url}/api/filaments/{preset_name}
-    // Append nozzle_diameter so the server can update per-nozzle calibrations
+    // Append nozzle_diameter and high_flow so the server can update the
+    // correct per-nozzle calibration (disambiguates 0.4mm vs 0.4mm HF).
     std::string url = api_url;
     if (!url.empty() && url.back() != '/')
         url += '/';
     url += "api/filaments/" + Http::url_encode(preset_name);
     if (nozzle_diameter > 0)
-        url += "?nozzle_diameter=" + std::to_string(nozzle_diameter);
+        url += "?nozzle_diameter=" + std::to_string(nozzle_diameter)
+             + "&high_flow=" + (high_flow ? "1" : "0");
 
     // Build JSON body: {"name": "...", "config": {"key": "value", ...}}
     std::string json = "{\"name\":\"" + json_escape(preset_name) + "\",\"config\":{";

--- a/src/slic3r/Utils/FilamentDB.cpp
+++ b/src/slic3r/Utils/FilamentDB.cpp
@@ -263,13 +263,17 @@ bool sync_filament_to_filamentdb(
     const std::string &api_url,
     const std::string &preset_name,
     const DynamicPrintConfig &config,
-    std::string &error_message)
+    std::string &error_message,
+    double nozzle_diameter)
 {
     // Build endpoint: {api_url}/api/filaments/{preset_name}
+    // Append nozzle_diameter so the server can update per-nozzle calibrations
     std::string url = api_url;
     if (!url.empty() && url.back() != '/')
         url += '/';
     url += "api/filaments/" + Http::url_encode(preset_name);
+    if (nozzle_diameter > 0)
+        url += "?nozzle_diameter=" + std::to_string(nozzle_diameter);
 
     // Build JSON body: {"name": "...", "config": {"key": "value", ...}}
     std::string json = "{\"name\":\"" + json_escape(preset_name) + "\",\"config\":{";

--- a/src/slic3r/Utils/FilamentDB.hpp
+++ b/src/slic3r/Utils/FilamentDB.hpp
@@ -65,14 +65,17 @@ FilamentCalibration fetch_filament_calibration(
 );
 
 // Sync a filament preset back to the FilamentDB server.
-// Serializes the config to JSON and PUTs to /api/filaments/{name}.
+// Serializes the config to JSON and POSTs to /api/filaments/{name}.
+// When nozzle_diameter > 0 it is appended as ?nozzle_diameter=... so the
+// server can update the correct per-nozzle calibration entry (EM, PA, etc.).
 // Returns true on success, false on error (error_message is set).
 // Non-fatal — errors are logged but don't block the local save.
 bool sync_filament_to_filamentdb(
     const std::string &api_url,
     const std::string &preset_name,
     const DynamicPrintConfig &config,
-    std::string &error_message
+    std::string &error_message,
+    double nozzle_diameter = 0
 );
 
 } // namespace Slic3r

--- a/src/slic3r/Utils/FilamentDB.hpp
+++ b/src/slic3r/Utils/FilamentDB.hpp
@@ -66,8 +66,9 @@ FilamentCalibration fetch_filament_calibration(
 
 // Sync a filament preset back to the FilamentDB server.
 // Serializes the config to JSON and POSTs to /api/filaments/{name}.
-// When nozzle_diameter > 0 it is appended as ?nozzle_diameter=... so the
-// server can update the correct per-nozzle calibration entry (EM, PA, etc.).
+// When nozzle_diameter > 0 it is appended as ?nozzle_diameter=...&high_flow=0|1
+// so the server can update the correct per-nozzle calibration entry (EM, PA, etc.).
+// This disambiguates e.g. 0.4mm standard vs 0.4mm HF nozzles.
 // Returns true on success, false on error (error_message is set).
 // Non-fatal — errors are logged but don't block the local save.
 bool sync_filament_to_filamentdb(
@@ -75,7 +76,8 @@ bool sync_filament_to_filamentdb(
     const std::string &preset_name,
     const DynamicPrintConfig &config,
     std::string &error_message,
-    double nozzle_diameter = 0
+    double nozzle_diameter = 0,
+    bool high_flow = false
 );
 
 } // namespace Slic3r


### PR DESCRIPTION
## Summary
- Pass the active nozzle diameter as `?nozzle_diameter=X` query param when syncing filament presets back to Filament DB
- Allows the server to update the correct per-nozzle calibration entry (EM, PA, retraction) instead of only updating the flat settings bag
- Fixes stale calibration values in the Filament DB web UI after editing EM/PA in PrusaSlicer

## Changes
- `FilamentDB.hpp`: Add optional `nozzle_diameter` parameter (default 0) to `sync_filament_to_filamentdb`
- `FilamentDB.cpp`: Append `?nozzle_diameter=` to the sync URL when diameter > 0
- `Tab.cpp`: Read the active printer's `nozzle_diameter` and pass it to the sync function

## Test plan
- [ ] Edit extrusion multiplier for a filament in PrusaSlicer with a specific nozzle selected
- [ ] Save the preset — verify the sync POST URL includes `?nozzle_diameter=0.4`
- [ ] Check Filament DB web UI — the per-nozzle calibration EM should reflect the new value
- [ ] Verify backward compatibility: sync still works if Filament DB server doesn't support the param yet