### PR TITLE
Virtual filaments: per-row cap editor and delete button

### DIFF
--- a/src/slic3r/GUI/CreateVirtualFilamentDialog.cpp
+++ b/src/slic3r/GUI/CreateVirtualFilamentDialog.cpp
@@ -8,6 +8,7 @@
 #include <wx/colordlg.h>
 #include <wx/stdpaths.h>
 
+#include <algorithm>
 #include <cstdio>
 
 namespace Slic3r {
@@ -59,6 +60,20 @@ CreateVirtualFilamentDialog::CreateVirtualFilamentDialog(
 {
     const std::string seed = initial_color.empty() ? std::string("#FFA500") : initial_color;
     build(seed, initial_name);
+}
+
+void CreateVirtualFilamentDialog::set_initial_local_z_max_sublayers(int value)
+{
+    if (m_cap_spin) {
+        const int clamped = std::max(0, std::min(64, value));
+        m_cap_spin->SetValue(clamped);
+    }
+}
+
+int CreateVirtualFilamentDialog::local_z_max_sublayers() const
+{
+    if (!m_cap_spin) return 0;
+    return std::max(0, m_cap_spin->GetValue());
 }
 
 std::string CreateVirtualFilamentDialog::entered_name() const
@@ -156,6 +171,31 @@ void CreateVirtualFilamentDialog::build(const std::string &initial_color,
 
     m_ratio_text = new wxStaticText(this, wxID_ANY, "");
     top->Add(m_ratio_text, 0, wxALIGN_CENTER | wxTOP | wxBOTTOM, em / 4);
+
+    top->Add(new wxStaticLine(this, wxID_ANY), 0, wxEXPAND | wxALL, em / 2);
+
+    // ---- Advanced: per-row run-length cap ----------------------------
+    auto *cap_row = new wxBoxSizer(wxHORIZONTAL);
+    auto *cap_label = new wxStaticText(this, wxID_ANY,
+        _L("Max consecutive same-component layers:"));
+    cap_row->Add(cap_label, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, em / 2);
+
+    m_cap_spin = new wxSpinCtrl(this, wxID_ANY, "0",
+                                wxDefaultPosition, wxDefaultSize,
+                                wxSP_ARROW_KEYS, 0, 64, 0);
+    m_cap_spin->SetToolTip(
+        _L("Cap the longest run of consecutive layers of the same "
+           "component when the virtual filament cycles. 0 disables the "
+           "cap. Useful for high-asymmetry ratios where streaks would "
+           "otherwise be visible."));
+    cap_row->Add(m_cap_spin, 0, wxALIGN_CENTER_VERTICAL);
+
+    auto *cap_hint = new wxStaticText(this, wxID_ANY, _L("(0 = off)"));
+    cap_hint->SetForegroundColour(
+        wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
+    cap_row->Add(cap_hint, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, em / 2);
+
+    top->Add(cap_row, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, em);
 
     top->Add(new wxStaticLine(this, wxID_ANY), 0, wxEXPAND | wxALL, em / 2);
 

--- a/src/slic3r/GUI/CreateVirtualFilamentDialog.cpp
+++ b/src/slic3r/GUI/CreateVirtualFilamentDialog.cpp
@@ -64,10 +64,15 @@ CreateVirtualFilamentDialog::CreateVirtualFilamentDialog(
 
 void CreateVirtualFilamentDialog::set_initial_local_z_max_sublayers(int value)
 {
-    if (m_cap_spin) {
-        const int clamped = std::max(0, std::min(64, value));
-        m_cap_spin->SetValue(clamped);
-    }
+    if (!m_cap_spin) return;
+    const int v = std::max(0, value);
+    // The spin control has a pragmatic default max of 64 layers, but the
+    // underlying model accepts any non-negative value. If a row was
+    // configured (e.g. via manual config) with a larger cap, widen the
+    // control's range rather than silently downgrading the user's value.
+    if (v > m_cap_spin->GetMax())
+        m_cap_spin->SetRange(0, v);
+    m_cap_spin->SetValue(v);
 }
 
 int CreateVirtualFilamentDialog::local_z_max_sublayers() const

--- a/src/slic3r/GUI/CreateVirtualFilamentDialog.hpp
+++ b/src/slic3r/GUI/CreateVirtualFilamentDialog.hpp
@@ -5,6 +5,7 @@
 #include <wx/stattext.h>
 #include <wx/panel.h>
 #include <wx/button.h>
+#include <wx/spinctrl.h>
 
 #include "libslic3r/VirtualFilament.hpp"
 
@@ -51,6 +52,12 @@ public:
     // User-supplied name (may be empty). Trimmed on read.
     std::string entered_name() const;
 
+    // Advanced per-row fields. Call before ShowModal() to seed Edit mode
+    // with the row's current value; read after ShowModal()==wxID_OK to
+    // apply the user's selection. 0 means "disabled / use global cadence".
+    void set_initial_local_z_max_sublayers(int value);
+    int  local_z_max_sublayers() const;
+
 private:
     void build(const std::string &initial_color, const std::string &initial_name);
     void on_input_changed();
@@ -74,6 +81,7 @@ private:
     wxStaticText*m_status_text    = nullptr;
     wxPanel     *m_ratio_bar_area = nullptr;
     wxBoxSizer  *m_ratio_bar_sizer= nullptr;
+    wxSpinCtrl  *m_cap_spin       = nullptr;
     wxButton    *m_ok_btn         = nullptr;
 
     VirtualFilamentManager::TargetColorSolution m_solution;

--- a/src/slic3r/GUI/Sidebar.cpp
+++ b/src/slic3r/GUI/Sidebar.cpp
@@ -1398,6 +1398,11 @@ void Sidebar::update_virtual_filament_panel()
             dlg.resolved_target_hex(), colours, 12, dlg.entered_name());
         if (idx < 0) return;
 
+        // Apply advanced per-row fields the dialog collected.
+        auto &vfs = mgr.filaments();
+        if (size_t(idx) < vfs.size())
+            vfs[idx].local_z_max_sublayers = dlg.local_z_max_sublayers();
+
         DynamicPrintConfig new_conf;
         new_conf.set_key_value("virtual_filament_definitions",
                                new ConfigOptionString(mgr.serialize()));
@@ -1426,6 +1431,8 @@ void Sidebar::update_virtual_filament_panel()
         const std::string seed_name  = filaments_view[row_idx].name;
 
         CreateVirtualFilamentDialog dlg(this, colours, seed_color, seed_name);
+        dlg.set_initial_local_z_max_sublayers(
+            filaments_view[row_idx].local_z_max_sublayers);
         if (dlg.ShowModal() != wxID_OK) return;
 
         if (!mgr.update_from_target_color(row_idx,
@@ -1433,6 +1440,11 @@ void Sidebar::update_virtual_filament_panel()
                                           dlg.entered_name(),
                                           colours))
             return;
+
+        // Apply advanced per-row fields the dialog collected.
+        auto &vfs_edit = mgr.filaments();
+        if (row_idx < vfs_edit.size())
+            vfs_edit[row_idx].local_z_max_sublayers = dlg.local_z_max_sublayers();
 
         DynamicPrintConfig new_conf;
         new_conf.set_key_value("virtual_filament_definitions",

--- a/src/slic3r/GUI/Sidebar.cpp
+++ b/src/slic3r/GUI/Sidebar.cpp
@@ -1453,6 +1453,30 @@ void Sidebar::update_virtual_filament_panel()
 
         update_virtual_filament_panel();
     };
+
+    // Wire up per-row delete button: mark the row as deleted in the manager
+    // and reserialize. The panel has already confirmed with the user.
+    m_virtual_filament_panel->on_delete_row = [this, colours](size_t row_idx) {
+        auto &config = wxGetApp().preset_bundle->prints.get_edited_preset().config;
+        VirtualFilamentManager mgr;
+        mgr.auto_generate(colours);
+        const std::string &defs = config.has("virtual_filament_definitions") ?
+            config.opt_string("virtual_filament_definitions") : "";
+        if (!defs.empty())
+            mgr.deserialize(defs, colours);
+
+        auto &vfs = mgr.filaments();
+        if (row_idx >= vfs.size()) return;
+        vfs[row_idx].deleted = true;
+        vfs[row_idx].enabled = false;
+
+        DynamicPrintConfig new_conf;
+        new_conf.set_key_value("virtual_filament_definitions",
+                               new ConfigOptionString(mgr.serialize()));
+        wxGetApp().get_tab(Preset::TYPE_PRINT)->load_config(new_conf);
+
+        update_virtual_filament_panel();
+    };
 }
 
 }}    // namespace Slic3r::GUI

--- a/src/slic3r/GUI/VirtualFilamentPanel.cpp
+++ b/src/slic3r/GUI/VirtualFilamentPanel.cpp
@@ -9,6 +9,7 @@
 #include <wx/statline.h>
 #include <wx/colour.h>
 #include <wx/bitmap.h>
+#include <wx/msgdlg.h>
 
 #include <cmath>
 #include <cstdio>
@@ -168,6 +169,32 @@ void VirtualFilamentPanel::rebuild(const VirtualFilamentManager &mgr,
             if (on_edit_row) on_edit_row(edit_capture_idx);
         });
         row_sizer->Add(edit_btn, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 4);
+
+        // Delete button (× glyph). Prompts for confirmation; the on_delete_row
+        // handler is only invoked on OK. Delete marks the row as deleted in
+        // the serialized definitions; painted facets referencing the deleted
+        // virtual ID fall back to its stable-id slot (disabled rows are kept
+        // reserved, so numbering stays stable across deletes).
+        auto *del_btn = new wxButton(this, wxID_ANY, wxString::FromUTF8("\xc3\x97"), // ×
+                                     wxDefaultPosition, wxDefaultSize,
+                                     wxBU_EXACTFIT);
+        del_btn->SetToolTip(_L("Delete this virtual filament"));
+        const size_t del_capture_idx = i;
+        const wxString confirm_name = vf.name.empty()
+            ? wxString::FromUTF8(ratio_text)
+            : wxString::FromUTF8(vf.name);
+        del_btn->Bind(wxEVT_BUTTON, [this, del_capture_idx, confirm_name](wxCommandEvent &) {
+            const int answer = wxMessageBox(
+                wxString::Format(_L("Delete virtual filament \"%s\"?\n\n"
+                                   "Painted facets that reference it will "
+                                   "fall back to physical filament 1."),
+                                confirm_name),
+                _L("Delete virtual filament"),
+                wxYES_NO | wxICON_QUESTION | wxNO_DEFAULT, this);
+            if (answer == wxYES && on_delete_row)
+                on_delete_row(del_capture_idx);
+        });
+        row_sizer->Add(del_btn, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 4);
 
         // Enable checkbox
         auto *cb = new wxCheckBox(this, wxID_ANY, "");

--- a/src/slic3r/GUI/VirtualFilamentPanel.hpp
+++ b/src/slic3r/GUI/VirtualFilamentPanel.hpp
@@ -62,6 +62,12 @@ public:
     // index — same convention as on_enable_changed).
     std::function<void(size_t row_idx)> on_edit_row;
 
+    // Callback when the user clicks the delete (×) button on a row.
+    // Same `row_idx` convention as on_edit_row. The panel only emits
+    // this after the user confirms, so handlers should mark the row
+    // deleted and reserialize without prompting again.
+    std::function<void(size_t row_idx)> on_delete_row;
+
 private:
     void clear_rows();
     wxPanel *create_color_swatch(wxWindow *parent, const std::string &hex_color, int size);


### PR DESCRIPTION
## Summary

Closes the UX gaps left by #4 — per-row advanced fields and row deletion had no GUI surface.

**Run-length cap editor** — spin control (0..64, widened dynamically if a row was preconfigured with a larger value) in `CreateVirtualFilamentDialog` for `local_z_max_sublayers`. Appears in both Create and Edit flows; seeds from the row's current value in Edit mode.

**Delete button** — new `×` button next to the edit (✏) glyph on each row. Confirmation prompt quotes the row name; on confirm, marks the row `deleted=true` in the serialized definitions (existing flag — no model changes).

## Test plan

- [x] 329 assertions / 70 test cases pass
- [x] Full PrusaSlicer target builds cleanly
- [x] Manual: cap spinner defaults to 0 in Create, seeds existing value in Edit, round-trips a value > 64 unchanged
- [x] Manual: delete button prompts and removes the row from the panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)