### PR TITLE
Virtual filaments: surface-bias offsets (data layer)

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -515,6 +515,7 @@ static std::vector<std::string> s_Preset_print_options {
     "travel_short_distance_acceleration",
     "virtual_filaments_enabled", "virtual_filament_definitions", "virtual_filament_advanced_dithering",
     "virtual_filament_gradient_mode", "virtual_filament_height_lower_bound", "virtual_filament_height_upper_bound",
+    "virtual_filament_surface_offset_enabled",
 };
 
 static std::vector<std::string> s_Preset_filament_options {

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -269,6 +269,7 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
             || opt_key == "virtual_filament_gradient_mode"
             || opt_key == "virtual_filament_height_lower_bound"
             || opt_key == "virtual_filament_height_upper_bound"
+            || opt_key == "virtual_filament_surface_offset_enabled"
             || opt_key == "parking_pos_retraction"
             || opt_key == "cooling_tube_retraction"
             || opt_key == "cooling_tube_length"

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3971,6 +3971,18 @@ void PrintConfigDef::init_fff_params()
     def->mode = comExpert;
     def->set_default_value(new ConfigOptionFloat(0.16));
 
+    def = this->add("virtual_filament_surface_offset_enabled", coBool);
+    def->label = L("Surface-bias offsets");
+    def->category = L("Virtual Filaments");
+    def->tooltip = L("When enabled, per-virtual-filament surface-bias offsets "
+                   "(set on the individual rows) shift extrusion paths for the "
+                   "dominant component radially outward, giving it a slightly "
+                   "larger surface footprint for more even perceived coverage. "
+                   "Note: offsets are stored and queried today, but are not yet "
+                   "applied to G-code output — the hook is a follow-up.");
+    def->mode = comExpert;
+    def->set_default_value(new ConfigOptionBool(false));
+
     def = this->add("perimeter_generator", coEnum);
     def->label = L("Perimeter generator");
     def->category = L("Layers and Perimeters");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1026,6 +1026,7 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
     ((ConfigOptionBool,               virtual_filament_gradient_mode))
     ((ConfigOptionFloat,              virtual_filament_height_lower_bound))
     ((ConfigOptionFloat,              virtual_filament_height_upper_bound))
+    ((ConfigOptionBool,               virtual_filament_surface_offset_enabled))
 )
 
 PRINT_CONFIG_CLASS_DERIVED_DEFINE0(

--- a/src/libslic3r/VirtualFilament.cpp
+++ b/src/libslic3r/VirtualFilament.cpp
@@ -405,7 +405,9 @@ bool parse_row(const std::string &row,
                int &distribution_mode, bool &deleted, std::string &name,
                int &local_z_max_sublayers,
                std::vector<unsigned int> &gradient_ids,
-               std::vector<int>          &gradient_weights)
+               std::vector<int>          &gradient_weights,
+               float                     &component_a_surface_offset,
+               float                     &component_b_surface_offset)
 {
     auto trim = [](const std::string &s) {
         size_t lo = 0, hi = s.size();
@@ -423,6 +425,12 @@ bool parse_row(const std::string &row,
         std::string t = trim(tok);
         if (t.empty()) return false;
         try { size_t n = 0; out = uint64_t(std::stoull(t, &n)); return n == t.size(); }
+        catch (...) { return false; }
+    };
+    auto parse_float = [&trim](const std::string &tok, float &out) {
+        std::string t = trim(tok);
+        if (t.empty()) return false;
+        try { size_t n = 0; out = std::stof(t, &n); return n == t.size(); }
         catch (...) { return false; }
     };
 
@@ -458,6 +466,8 @@ bool parse_row(const std::string &row,
     local_z_max_sublayers = 0;
     gradient_ids.clear();
     gradient_weights.clear();
+    component_a_surface_offset = 0.f;
+    component_b_surface_offset = 0.f;
 
     // Parse metadata tokens (m=mode, d=deleted, o=origin_auto, u=stable_id,
     // n=encoded name, z=local_z_max_sublayers, g=gradient ids,
@@ -490,8 +500,17 @@ bool parse_row(const std::string &row,
             gradient_ids = parse_pipe_list<unsigned int>(tok.substr(1));
         } else if (prefix == 'w') {
             gradient_weights = parse_pipe_list<int>(tok.substr(1));
+        } else if (prefix == 's' && tok.size() >= 2) {
+            // Two-char prefix: sa = component_a_surface_offset,
+            //                  sb = component_b_surface_offset.
+            const char sub = char(std::tolower((unsigned char)tok[1]));
+            float v = 0.f;
+            if (sub == 'a' && parse_float(tok.substr(2), v))
+                component_a_surface_offset = v;
+            else if (sub == 'b' && parse_float(tok.substr(2), v))
+                component_b_surface_offset = v;
         } else if (prefix == 'x') {
-            // Reserved for component surface-bias offsets (Phase 6 feature).
+            // Reserved for future per-row extension tokens.
         } else {
             // Might be a manual pattern token.
             bool valid = true;
@@ -529,7 +548,9 @@ bool VirtualFilament::operator==(const VirtualFilament &rhs) const
            name        == rhs.name &&
            local_z_max_sublayers == rhs.local_z_max_sublayers &&
            gradient_component_ids == rhs.gradient_component_ids &&
-           gradient_component_weights == rhs.gradient_component_weights;
+           gradient_component_weights == rhs.gradient_component_weights &&
+           std::fabs(component_a_surface_offset - rhs.component_a_surface_offset) < 1e-6f &&
+           std::fabs(component_b_surface_offset - rhs.component_b_surface_offset) < 1e-6f;
 }
 
 // ---------------------------------------------------------------------------
@@ -704,6 +725,12 @@ std::string VirtualFilamentManager::serialize() const
             if (any_non_unit && !vf.gradient_component_weights.empty())
                 ss << ",w" << format_pipe_list(vf.gradient_component_weights);
         }
+        // Surface-bias offsets (mm). Emit only when non-zero so the wire
+        // form stays short for the common "no bias" case.
+        if (std::fabs(vf.component_a_surface_offset) > 1e-6f)
+            ss << ",sa" << vf.component_a_surface_offset;
+        if (std::fabs(vf.component_b_surface_offset) > 1e-6f)
+            ss << ",sb" << vf.component_b_surface_offset;
         if (!vf.name.empty())
             ss << ",n" << encode_name(vf.name);
         std::string normalized = normalize_manual_pattern(vf.manual_pattern);
@@ -763,9 +790,11 @@ void VirtualFilamentManager::deserialize(const std::string &serialized,
         int z_cap = 0;
         std::vector<unsigned int> grad_ids;
         std::vector<int>          grad_weights;
+        float surf_off_a = 0.f, surf_off_b = 0.f;
 
         if (!parse_row(row, a, b, sid, en, cust, oa, mix, pattern, mode, del,
-                       name, z_cap, grad_ids, grad_weights))
+                       name, z_cap, grad_ids, grad_weights,
+                       surf_off_a, surf_off_b))
             continue;
         if (a == 0 || b == 0 || a > n || b > n || a == b)
             continue;
@@ -803,6 +832,8 @@ void VirtualFilamentManager::deserialize(const std::string &serialized,
             vf.local_z_max_sublayers     = z_cap;
             vf.gradient_component_ids    = grad_ids;
             vf.gradient_component_weights = grad_weights;
+            vf.component_a_surface_offset = surf_off_a;
+            vf.component_b_surface_offset = surf_off_b;
             rebuilt_pair_keys.insert(canonical_pair_key(vf.component_a, vf.component_b));
             rebuilt_stable_ids.insert(vf.stable_id);
             rebuilt.push_back(std::move(vf));
@@ -828,6 +859,8 @@ void VirtualFilamentManager::deserialize(const std::string &serialized,
         vf.local_z_max_sublayers     = z_cap;
         vf.gradient_component_ids    = grad_ids;
         vf.gradient_component_weights = grad_weights;
+        vf.component_a_surface_offset = surf_off_a;
+        vf.component_b_surface_offset = surf_off_b;
         rebuilt_pair_keys.insert(canonical_pair_key(vf.component_a, vf.component_b));
         rebuilt_stable_ids.insert(vf.stable_id);
         rebuilt.push_back(std::move(vf));
@@ -972,6 +1005,56 @@ unsigned int VirtualFilamentManager::resolve(unsigned int filament_id,
     // Simple layer-cycle cadence.
     const int pos = safe_mod(layer_index, cycle);
     return (pos < vf.ratio_a) ? vf.component_a : vf.component_b;
+}
+
+// Canonicalize the per-component surface bias. OrcaSlicer-FullSpectrum's
+// convention treats these as a single signed value: only one side may be
+// non-zero at a time. If both are set, the larger magnitude wins (the
+// other is treated as zero).  The returned sign is positive when B gets
+// the outward shift, negative when A does.
+static float canonical_signed_bias(float offset_a, float offset_b)
+{
+    const float abs_a = std::fabs(offset_a);
+    const float abs_b = std::fabs(offset_b);
+    if (abs_a < 1e-6f && abs_b < 1e-6f) return 0.f;
+    if (abs_b >= abs_a) return abs_b;   // B wins, positive
+    return -abs_a;                      // A wins, negative
+}
+
+float VirtualFilamentManager::component_surface_offset(unsigned int filament_id,
+                                                       size_t       num_physical,
+                                                       int          layer_index,
+                                                       float        layer_print_z,
+                                                       float        layer_height) const
+{
+    const VirtualFilament *vf = filament_from_id(filament_id, num_physical);
+    if (vf == nullptr) return 0.f;
+
+    // Multi-token manual patterns (3+ distinct components) don't map cleanly
+    // onto the binary A/B signed-bias convention — bail out.
+    const std::string normalized = normalize_manual_pattern(vf->manual_pattern);
+    if (normalized.find(',') != std::string::npos) return 0.f;
+
+    const float signed_bias = canonical_signed_bias(vf->component_a_surface_offset,
+                                                    vf->component_b_surface_offset);
+    if (std::fabs(signed_bias) < 1e-6f) return 0.f;
+
+    const unsigned int resolved = resolve(filament_id, num_physical,
+                                          layer_index, layer_print_z, layer_height);
+    if (signed_bias > 0.f && resolved == vf->component_b) return  signed_bias;
+    if (signed_bias < 0.f && resolved == vf->component_a) return -signed_bias;
+    return 0.f;
+}
+
+float VirtualFilamentManager::max_component_surface_offset() const
+{
+    float max_abs = 0.f;
+    for (const auto &vf : m_virtuals) {
+        if (vf.deleted || !vf.enabled) continue;
+        max_abs = std::max(max_abs, std::fabs(vf.component_a_surface_offset));
+        max_abs = std::max(max_abs, std::fabs(vf.component_b_surface_offset));
+    }
+    return max_abs;
 }
 
 int VirtualFilamentManager::virtual_index_from_id(unsigned int filament_id,

--- a/src/libslic3r/VirtualFilament.cpp
+++ b/src/libslic3r/VirtualFilament.cpp
@@ -1030,10 +1030,21 @@ float VirtualFilamentManager::component_surface_offset(unsigned int filament_id,
     const VirtualFilament *vf = filament_from_id(filament_id, num_physical);
     if (vf == nullptr) return 0.f;
 
-    // Multi-token manual patterns (3+ distinct components) don't map cleanly
-    // onto the binary A/B signed-bias convention — bail out.
+    // Multi-component manual patterns don't map cleanly onto the binary A/B
+    // signed-bias convention — bail out. The manual_pattern grammar uses
+    // tokens '1' (=component_a), '2' (=component_b), and '3'..'9' for direct
+    // physical IDs; any token outside {'1','2'} pulls in a third (or further)
+    // physical component and the A/B convention no longer applies.
+    // Note: normalize_manual_pattern() does not insert comma separators, so
+    // checking for ',' is not sufficient (and would never fire).
     const std::string normalized = normalize_manual_pattern(vf->manual_pattern);
-    if (normalized.find(',') != std::string::npos) return 0.f;
+    for (char c : normalized)
+        if (c != '1' && c != '2') return 0.f;
+
+    // Also bail on 3+ component gradient distributions, which emit a
+    // weighted balanced sequence over arbitrary physical IDs rather than
+    // the binary A/B cadence.
+    if (vf->gradient_component_ids.size() >= 3) return 0.f;
 
     const float signed_bias = canonical_signed_bias(vf->component_a_surface_offset,
                                                     vf->component_b_surface_offset);

--- a/src/libslic3r/VirtualFilament.hpp
+++ b/src/libslic3r/VirtualFilament.hpp
@@ -58,6 +58,21 @@ struct VirtualFilament
     std::vector<unsigned int> gradient_component_ids;
     std::vector<int>          gradient_component_weights;
 
+    // Per-component XY surface-bias offsets in millimetres. The convention
+    // (mirroring OrcaSlicer-FullSpectrum's canonical-signed-bias semantics)
+    // is that exactly one of the two offsets is non-zero at a time — the
+    // non-zero value represents the radial outward offset applied to that
+    // component's extrusion paths, while the other component stays on the
+    // nominal contour. Used to give the "dominant" colour a slight surface
+    // bulge for more even perceived coverage. Zero means no bias.
+    //
+    // These fields are data-only for now: they serialize round-trip and are
+    // queried via VirtualFilamentManager::component_surface_offset(), but
+    // the G-code generator does not yet apply the offset to extrusion paths.
+    // That wire-up is tracked as a follow-up.
+    float component_a_surface_offset = 0.f;
+    float component_b_surface_offset = 0.f;
+
     // Whether this virtual filament is available for assignment.
     bool enabled    = true;
     bool deleted    = false;
@@ -182,6 +197,26 @@ public:
                          int          layer_index,
                          float        layer_print_z = 0.f,
                          float        layer_height  = 0.f) const;
+
+    // Resolve the XY surface-bias offset for the component that the virtual
+    // filament would emit on the given layer. Returns 0 when:
+    //   * `filament_id` is not virtual
+    //   * the virtual row has no configured offset (both components are 0)
+    //   * the row uses a multi-token manual_pattern (3+ components) where
+    //     the A/B signed-bias convention doesn't map cleanly
+    // Otherwise returns the signed outward offset in mm: positive means the
+    // dominant component (the one with the configured offset) is shifted
+    // outward, zero means the other component prints on the nominal contour.
+    float component_surface_offset(unsigned int filament_id,
+                                   size_t       num_physical,
+                                   int          layer_index,
+                                   float        layer_print_z = 0.f,
+                                   float        layer_height  = 0.f) const;
+
+    // The largest absolute surface-offset configured across any enabled
+    // virtual filament, in mm. Useful for print-envelope / collision checks
+    // when the G-code integration is wired up.
+    float max_component_surface_offset() const;
 
     // Map virtual filament ID to index into m_virtuals.
     // Returns -1 if not a virtual filament.

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -7346,7 +7346,8 @@ void Plater::on_config_change(const DynamicPrintConfig &config)
             opt_key == "virtual_filament_advanced_dithering" ||
             opt_key == "virtual_filament_gradient_mode" ||
             opt_key == "virtual_filament_height_lower_bound" ||
-            opt_key == "virtual_filament_height_upper_bound") {
+            opt_key == "virtual_filament_height_upper_bound" ||
+            opt_key == "virtual_filament_surface_offset_enabled") {
             p->sidebar->update_virtual_filament_panel();
             update_scheduled = true;
         }

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1678,6 +1678,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("virtual_filament_gradient_mode");
         optgroup->append_single_option_line("virtual_filament_height_lower_bound");
         optgroup->append_single_option_line("virtual_filament_height_upper_bound");
+        optgroup->append_single_option_line("virtual_filament_surface_offset_enabled");
 
         optgroup = page->new_optgroup(L("Advanced"));
         optgroup->append_single_option_line("interface_shells");

--- a/tests/libslic3r/test_virtual_filament.cpp
+++ b/tests/libslic3r/test_virtual_filament.cpp
@@ -1231,6 +1231,32 @@ TEST_CASE("component_surface_offset larger magnitude wins when both set",
     }
 }
 
+TEST_CASE("component_surface_offset returns 0 for multi-component manual patterns",
+          "[VirtualFilamentManager][SurfaceBias]") {
+    const std::vector<std::string> palette = {"#FF0000", "#00FF00", "#0000FF"};
+    VirtualFilamentManager mgr;
+    mgr.auto_generate(palette);
+    REQUIRE(mgr.filaments().size() >= 1);
+    auto &vf = mgr.filaments()[0];
+    vf.component_b_surface_offset = 0.3f;
+
+    // Manual pattern referencing a third physical filament ('3') — bias must not apply,
+    // since the two-color surface-bias model is undefined for 3+ components.
+    vf.manual_pattern = "123";
+
+    const size_t num_physical = palette.size();
+    const unsigned int vid = unsigned(num_physical) + 1;
+    for (int i = 0; i < 6; ++i)
+        CHECK(mgr.component_surface_offset(vid, num_physical, i, 0.f, 0.f) == 0.f);
+
+    // Same guard via gradient_component_ids (3+ components).
+    vf.manual_pattern.clear();
+    vf.gradient_component_ids = {1, 2, 3};
+    vf.gradient_component_weights = {1, 1, 1};
+    for (int i = 0; i < 6; ++i)
+        CHECK(mgr.component_surface_offset(vid, num_physical, i, 0.f, 0.f) == 0.f);
+}
+
 TEST_CASE("max_component_surface_offset reports largest enabled magnitude",
           "[VirtualFilamentManager][SurfaceBias]") {
     const std::vector<std::string> palette = {"#FF0000", "#00FF00", "#0000FF"};

--- a/tests/libslic3r/test_virtual_filament.cpp
+++ b/tests/libslic3r/test_virtual_filament.cpp
@@ -551,6 +551,7 @@ TEST_CASE("PrintConfig contains virtual filament options", "[VirtualFilament][Co
     CHECK(config.virtual_filament_gradient_mode.value == false);
     CHECK(config.virtual_filament_height_lower_bound.value == Approx(0.04));
     CHECK(config.virtual_filament_height_upper_bound.value == Approx(0.16));
+    CHECK(config.virtual_filament_surface_offset_enabled.value == false);
 }
 
 TEST_CASE("DynamicPrintConfig can set virtual filament options", "[VirtualFilament][Config]") {
@@ -1128,4 +1129,154 @@ TEST_CASE("gradient_component_ids drops stale physical ids on reload", "[Virtual
     REQUIRE(mgr.filaments().size() >= 1);
     CHECK(mgr.filaments()[0].gradient_component_ids.empty());
     CHECK(mgr.filaments()[0].gradient_component_weights.empty());
+}
+
+// ---- Surface-bias offsets (Phase 6e data layer) ----
+
+TEST_CASE("component_surface_offset returns 0 for non-virtual IDs",
+          "[VirtualFilamentManager][SurfaceBias]") {
+    const std::vector<std::string> palette = {"#FF0000", "#00FF00"};
+    VirtualFilamentManager mgr;
+    mgr.auto_generate(palette);
+    // Physical ID 1 is not virtual.
+    CHECK(mgr.component_surface_offset(1, palette.size(), 0, 0.f, 0.f) == 0.f);
+    // ID beyond any virtual slot returns 0.
+    CHECK(mgr.component_surface_offset(99, palette.size(), 0, 0.f, 0.f) == 0.f);
+}
+
+TEST_CASE("component_surface_offset returns 0 when no bias is configured",
+          "[VirtualFilamentManager][SurfaceBias]") {
+    const std::vector<std::string> palette = {"#FF0000", "#00FF00"};
+    VirtualFilamentManager mgr;
+    mgr.auto_generate(palette);
+    REQUIRE(mgr.filaments().size() == 1);
+    const size_t num_physical = palette.size();
+    const unsigned int vid = unsigned(num_physical) + 1;
+    for (int i = 0; i < 4; ++i)
+        CHECK(mgr.component_surface_offset(vid, num_physical, i, 0.f, 0.f) == 0.f);
+}
+
+TEST_CASE("component_surface_offset applies B-side bias only on B layers",
+          "[VirtualFilamentManager][SurfaceBias]") {
+    const std::vector<std::string> palette = {"#FF0000", "#00FF00"};
+    VirtualFilamentManager mgr;
+    mgr.auto_generate(palette);
+    REQUIRE(mgr.filaments().size() == 1);
+    auto &vf = mgr.filaments()[0];
+    vf.ratio_a = 1;
+    vf.ratio_b = 1;
+    vf.manual_pattern.clear();
+    vf.component_b_surface_offset = 0.2f; // positive -> B outward
+
+    const size_t num_physical = palette.size();
+    const unsigned int vid = unsigned(num_physical) + 1;
+
+    // With ratio 1:1, layer_index even -> A, odd -> B.
+    const unsigned int r0 = mgr.resolve(vid, num_physical, 0, 0.f, 0.f);
+    const unsigned int r1 = mgr.resolve(vid, num_physical, 1, 0.f, 0.f);
+    const float o0 = mgr.component_surface_offset(vid, num_physical, 0, 0.f, 0.f);
+    const float o1 = mgr.component_surface_offset(vid, num_physical, 1, 0.f, 0.f);
+
+    // Whichever layer picks B gets the +0.2 offset; the A layer stays at 0.
+    if (r0 == vf.component_b) { CHECK(o0 == Approx(0.2f)); CHECK(o1 == 0.f); }
+    else                      { CHECK(o1 == Approx(0.2f)); CHECK(o0 == 0.f); }
+    CHECK(r0 != r1); // sanity: 1:1 alternates
+}
+
+TEST_CASE("component_surface_offset applies A-side bias as negative sign",
+          "[VirtualFilamentManager][SurfaceBias]") {
+    const std::vector<std::string> palette = {"#FF0000", "#00FF00"};
+    VirtualFilamentManager mgr;
+    mgr.auto_generate(palette);
+    auto &vf = mgr.filaments()[0];
+    vf.ratio_a = 1;
+    vf.ratio_b = 1;
+    vf.manual_pattern.clear();
+    vf.component_a_surface_offset = 0.15f; // A outward -> negative signed_bias
+
+    const size_t num_physical = palette.size();
+    const unsigned int vid = unsigned(num_physical) + 1;
+    // Scan a full cycle: whichever side resolves to A should get +0.15.
+    int a_offsets = 0, b_offsets = 0;
+    for (int i = 0; i < 4; ++i) {
+        const unsigned int r = mgr.resolve(vid, num_physical, i, 0.f, 0.f);
+        const float o = mgr.component_surface_offset(vid, num_physical, i, 0.f, 0.f);
+        if (r == vf.component_a) { CHECK(o == Approx(0.15f)); ++a_offsets; }
+        else                     { CHECK(o == 0.f); ++b_offsets; }
+    }
+    CHECK(a_offsets > 0);
+    CHECK(b_offsets > 0);
+}
+
+TEST_CASE("component_surface_offset larger magnitude wins when both set",
+          "[VirtualFilamentManager][SurfaceBias]") {
+    const std::vector<std::string> palette = {"#FF0000", "#00FF00"};
+    VirtualFilamentManager mgr;
+    mgr.auto_generate(palette);
+    auto &vf = mgr.filaments()[0];
+    vf.ratio_a = 1;
+    vf.ratio_b = 1;
+    vf.manual_pattern.clear();
+    vf.component_a_surface_offset = 0.1f;
+    vf.component_b_surface_offset = 0.3f; // B wins
+
+    const size_t num_physical = palette.size();
+    const unsigned int vid = unsigned(num_physical) + 1;
+    // B-biased: only B layers get 0.3; A layers get 0 (A's 0.1 is overridden).
+    for (int i = 0; i < 4; ++i) {
+        const unsigned int r = mgr.resolve(vid, num_physical, i, 0.f, 0.f);
+        const float o = mgr.component_surface_offset(vid, num_physical, i, 0.f, 0.f);
+        if (r == vf.component_b) CHECK(o == Approx(0.3f));
+        else                     CHECK(o == 0.f);
+    }
+}
+
+TEST_CASE("max_component_surface_offset reports largest enabled magnitude",
+          "[VirtualFilamentManager][SurfaceBias]") {
+    const std::vector<std::string> palette = {"#FF0000", "#00FF00", "#0000FF"};
+    VirtualFilamentManager mgr;
+    mgr.auto_generate(palette);
+    REQUIRE(mgr.filaments().size() >= 2);
+    mgr.filaments()[0].component_b_surface_offset = 0.2f;
+    mgr.filaments()[1].component_a_surface_offset = 0.5f;
+    CHECK(mgr.max_component_surface_offset() == Approx(0.5f));
+
+    // Disabled rows don't contribute.
+    mgr.filaments()[1].enabled = false;
+    CHECK(mgr.max_component_surface_offset() == Approx(0.2f));
+
+    // Deleted rows don't contribute either.
+    mgr.filaments()[0].deleted = true;
+    CHECK(mgr.max_component_surface_offset() == 0.f);
+}
+
+TEST_CASE("surface offsets serialize round-trip",
+          "[VirtualFilamentManager][SurfaceBias][Serialize]") {
+    const std::vector<std::string> palette = {"#FF0000", "#00FF00"};
+    VirtualFilamentManager mgr;
+    mgr.auto_generate(palette);
+    REQUIRE(mgr.filaments().size() >= 1);
+    mgr.filaments()[0].component_a_surface_offset = 0.05f;
+    mgr.filaments()[0].component_b_surface_offset = 0.25f;
+
+    const std::string wire = mgr.serialize();
+    CHECK(wire.find(",sa") != std::string::npos);
+    CHECK(wire.find(",sb") != std::string::npos);
+
+    VirtualFilamentManager rebuilt;
+    rebuilt.auto_generate(palette);
+    rebuilt.deserialize(wire, palette);
+    REQUIRE(rebuilt.filaments().size() >= 1);
+    CHECK(rebuilt.filaments()[0].component_a_surface_offset == Approx(0.05f));
+    CHECK(rebuilt.filaments()[0].component_b_surface_offset == Approx(0.25f));
+}
+
+TEST_CASE("surface offsets omitted from wire when zero",
+          "[VirtualFilamentManager][SurfaceBias][Serialize]") {
+    const std::vector<std::string> palette = {"#FF0000", "#00FF00"};
+    VirtualFilamentManager mgr;
+    mgr.auto_generate(palette);
+    const std::string wire = mgr.serialize();
+    CHECK(wire.find(",sa") == std::string::npos);
+    CHECK(wire.find(",sb") == std::string::npos);
 }


### PR DESCRIPTION
## Summary

Ports **Phase 6e surface-bias offsets** from OrcaSlicer-FullSpectrum as a **data-layer-only** change. G-code integration (applying the offset to extrusion paths) is deferred to a follow-up PR — this lays the groundwork.

### What it adds

Each virtual filament row gets two new fields (`component_a_surface_offset`, `component_b_surface_offset`, in mm). Semantics mirror FullSpectrum's canonical-signed-bias convention: only one side is meant to be non-zero at a time; the non-zero value is the radial outward shift applied to that component's extrusion paths on the layers it dominates. If both are set, the larger magnitude wins.

New `VirtualFilamentManager` API:
- `component_surface_offset(id, num_physical, layer_index, z, h)` — returns the signed outward shift (mm) for the component the row resolves to on a given layer. Returns 0 for non-virtual IDs, unconfigured rows, and multi-token manual patterns where the A/B convention doesn't map.
- `max_component_surface_offset()` — largest configured magnitude across enabled rows, for future print-envelope checks.

### Serialization

New row tokens `,sa<float>` and `,sb<float>`. Both omitted when zero to keep the common wire form short. `parse_row`/`deserialize` round-trip via a new two-char `s` prefix branch. Existing wire formats unaffected.

### Config plumbing

New `virtual_filament_surface_offset_enabled` bool (default off) gates the feature. Wired through:
- `PrintConfig` macro + `init_fff_params` definition (tooltip notes the G-code wire-up is pending)
- `Print::invalidate_state_by_config_options` (invalidates `psToolOrdering`)
- `Preset` compatibility list
- `Plater` change handler (refreshes virtual filament panel)
- `Tab` Advanced page

## Test plan

- [x] **363 assertions / 78 test cases pass** (`[VirtualFilament],[VirtualFilamentManager]`)
- [x] Full PrusaSlicer target builds cleanly
- [x] 8 new test cases cover: zero return for non-virtual IDs / unconfigured rows; B-side bias on B layers only (+ sign); A-side bias as negative signed-bias; larger-magnitude-wins when both set; `max_component_surface_offset()` respects enabled/deleted flags; `,sa`/`,sb` round-trip through serialize/deserialize; wire omits tokens when zero
- [x] Existing tests unaffected

## Not in this PR (follow-ups)

1. **G-code integration** — `GCode.cpp` needs to query `component_surface_offset()` during extrusion and apply an XY offset along the path's outward normal. Gated on `virtual_filament_surface_offset_enabled`.
2. **GUI editor for the offsets** — no UI control yet; users can set via the config string or via direct field mutation. Once G-code is wired, the offsets deserve a proper control in `CreateVirtualFilamentDialog` (likely two spinners next to the A/B swatches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)