### PR TITLE
PA calibration: don't leak filament cooling overrides; bump 1.5.2

### DIFF
--- a/src/slic3r/GUI/CalibrationPADialog.cpp
+++ b/src/slic3r/GUI/CalibrationPADialog.cpp
@@ -4,6 +4,7 @@
 ///|/
 #include "CalibrationPADialog.hpp"
 #include "GUI_App.hpp"
+#include "NotificationManager.hpp"
 #include "Plater.hpp"
 #include "Tab.hpp"
 
@@ -185,8 +186,14 @@ bool CalibrationPADialog::generate_and_load()
     std::vector<boost::filesystem::path> paths = { stl_path };
     plater->load_files(paths, true, false);
 
-    // Reset print config to saved preset
+    // Reset BOTH print and filament configs to their saved state so that
+    // the calibration overrides we're about to apply are deterministic
+    // (don't stack on top of previous calibration runs or unrelated
+    // user edits) AND so the modifications are visibly marked on the
+    // presets as "changed since saved" — letting the user revert with
+    // a single click on the preset's ⟲ button after calibration.
     wxGetApp().preset_bundle->prints.discard_current_changes();
+    wxGetApp().preset_bundle->filaments.discard_current_changes();
 
     const double test_speed = m_test_speed ? m_test_speed->GetValue() : 100.0;
 
@@ -312,6 +319,26 @@ bool CalibrationPADialog::generate_and_load()
 
     // Clean up temp file
     boost::filesystem::remove(stl_path);
+
+    // Surface the temporary preset overrides so the user knows to revert
+    // before slicing other (non-calibration) models. Both presets carry
+    // changes since their saved state (the Print preset tab and Filament
+    // preset tab will both show the ⟲ revert affordance), but a banner
+    // makes it obvious what was changed and why.
+    if (auto* nm = wxGetApp().notification_manager()) {
+        char buf[256];
+        std::snprintf(buf, sizeof(buf),
+            "PA calibration applied temporary overrides:\n"
+            "  Print preset — perimeter / infill / gap-fill speeds → %.0f mm/s\n"
+            "  Filament preset — cooling slowdown disabled, min_print_speed → %.0f mm/s\n"
+            "Revert via the ⟲ buttons on the Print and Filament preset tabs "
+            "before slicing other models.",
+            test_speed, test_speed);
+        nm->push_notification(
+            NotificationType::CustomNotification,
+            NotificationManager::NotificationLevel::WarningNotificationLevel,
+            buf);
+    }
 
     return true;
 }

--- a/version.inc
+++ b/version.inc
@@ -4,6 +4,6 @@
 set(SLIC3R_APP_NAME "PrusaSlicer")
 set(SLIC3R_APP_KEY "PrusaSlicer")
 set(SLIC3R_VERSION "2.9.4")
-set(SLIC3R_BUILD_ID "PrusaSlicer-${SLIC3R_VERSION}-Filament-Edition-1.5.1")
+set(SLIC3R_BUILD_ID "PrusaSlicer-${SLIC3R_VERSION}-Filament-Edition-1.5.2")
 set(SLIC3R_RC_VERSION "2,9,4,0")
 set(SLIC3R_RC_VERSION_DOTS "2.9.4.0")


### PR DESCRIPTION
## Summary
Address @codex's P2 feedback on PR #10 (review r3216593754).

The 1.5.1 PA-speed-override fix wrote \`slowdown_below_layer_time=0\` and \`min_print_speed=test_speed\` directly into the active filament preset without resetting state first. Any subsequent (non-calibration) slice in the same session inherited the cooling disable + elevated minimum speed — degrading quality on small-layer prints until the user manually reverted the filament preset.

## Mitigations
1. **Discard pending changes on the filament preset before applying overrides**, mirroring the existing pattern for the print preset. Makes the overrides deterministic (no stacking on prior calibration runs) AND ensures both presets cleanly show a "modified since saved" marker — single ⟲ click on each tab fully restores the user's original settings.
2. **Push a WarningNotificationLevel notification** at the end of slice setup naming the specific overrides and telling the user where to revert them. Shown on the Plater canvas where the calibration STL appears.

## Class-wide gap (not addressed here)
No calibration dialog currently discards filament changes before writing, even the ones (FanSpeed, Temp) that also modify filament config. Same regression exists in those, just less obviously because the modified settings (fan curves) are more visibly tied to the calibration intent. Follow-up PR will apply the same pattern to those dialogs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)