### PR TITLE
FilamentDB: subscribe to scan stream + auto-select filament preset

### DIFF
--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -199,6 +199,8 @@ set(SLIC3R_GUI_SOURCES
     GUI/ConfigManipulation.hpp
     GUI/Field.cpp
     GUI/Field.hpp
+    GUI/FilamentScanClient.cpp
+    GUI/FilamentScanClient.hpp
     GUI/OptionsGroup.cpp
     GUI/OptionsGroup.hpp
     GUI/OG_CustomCtrl.cpp
@@ -425,6 +427,8 @@ set(SLIC3R_GUI_SOURCES
 )
 
 find_package(NanoSVG REQUIRED)
+# FilamentScanClient parses Server-Sent Events JSON payloads from Filament DB.
+find_package(nlohmann_json REQUIRED)
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     find_package(OpenSSL REQUIRED)
 endif()
@@ -485,6 +489,7 @@ target_link_libraries(
     stb_dxt
     fastfloat
     boost_headeronly
+    nlohmann_json::nlohmann_json
 )
 
 if (MSVC)

--- a/src/slic3r/GUI/FilamentScanClient.cpp
+++ b/src/slic3r/GUI/FilamentScanClient.cpp
@@ -145,7 +145,16 @@ extern "C" int scan_stream_xferinfo_cb(void* clientp, curl_off_t, curl_off_t, cu
 
 FilamentScanClient::FilamentScanClient(std::string base_url)
     : m_base_url(std::move(base_url))
-{}
+{
+    // Strip trailing slashes so endpoint concatenation produces a
+    // clean URL regardless of how the user formatted `filamentdb_url`
+    // in app config — `http://host:3456/` would otherwise yield
+    // `http://host:3456//api/scan/stream?replay=0` and miss strict
+    // route matches in some setups (codex P2 on PR #13). Matches the
+    // normalization other FilamentDB helpers in this codebase do.
+    while (! m_base_url.empty() && m_base_url.back() == '/')
+        m_base_url.pop_back();
+}
 
 FilamentScanClient::~FilamentScanClient()
 {
@@ -221,7 +230,21 @@ void FilamentScanClient::handle_event(const std::string& event_type, const std::
     if (preset_name.empty()) return;
 
     if (event_type == "replay") {
-        const int64_t ts = j.value("timestamp", int64_t{0});
+        // Tolerate forward-incompatible timestamp types (e.g. the
+        // server starts emitting an ISO 8601 string). Same defensive
+        // pattern as the filament.name lookup above — codex P1 on
+        // PR #13. Treat any parse failure as "no timestamp" → the
+        // stale-replay filter below short-circuits and the event
+        // is processed normally rather than crashing the worker.
+        int64_t ts = 0;
+        try {
+            ts = j.value("timestamp", int64_t{0});
+        } catch (const std::exception& e) {
+            BOOST_LOG_TRIVIAL(warning)
+                << "[FilamentDB] replay event 'timestamp' not parseable as int64 ("
+                << e.what() << "); skipping staleness check";
+            ts = 0;
+        }
         const auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                                 std::chrono::system_clock::now().time_since_epoch())
                                 .count();

--- a/src/slic3r/GUI/FilamentScanClient.cpp
+++ b/src/slic3r/GUI/FilamentScanClient.cpp
@@ -159,12 +159,18 @@ void FilamentScanClient::handle_event(const std::string& event_type, const std::
         }
     }
 
+    BOOST_LOG_TRIVIAL(info)
+        << "[FilamentDB] received " << event_type << " event for preset '" << preset_name << "'";
+
     // wx's CallAfter is documented thread-safe — queues the lambda onto
     // the main event loop. Tab::select_preset touches wx widgets and
     // must not be reentered from a worker thread.
     wxGetApp().CallAfter([preset_name]() {
         auto& app = wxGetApp();
-        if (app.preset_bundle == nullptr) return;
+        if (app.preset_bundle == nullptr) {
+            BOOST_LOG_TRIVIAL(warning) << "[FilamentDB] preset_bundle is null — preset switch skipped";
+            return;
+        }
 
         const Preset* preset = app.preset_bundle->filaments.find_preset(preset_name);
         if (preset == nullptr) {
@@ -175,13 +181,38 @@ void FilamentScanClient::handle_event(const std::string& event_type, const std::
         }
 
         Tab* tab = app.get_tab(Preset::TYPE_FILAMENT);
-        if (tab == nullptr) return;
+        if (tab == nullptr) {
+            BOOST_LOG_TRIVIAL(warning) << "[FilamentDB] filament Tab is null — preset switch skipped";
+            return;
+        }
 
+        const std::string before = app.preset_bundle->filaments.get_selected_preset().name;
         // Tab::select_preset is what the dropdown calls — it handles the
         // dirty-state prompt, compatibility checks, and refreshing the
         // per-extruder combobox. Going through PresetBundle::set_filament_preset
         // directly would skip all of that.
+        //
+        // NOTE: select_preset returns `true` even when the requested
+        // preset isn't compatible with the active printer — in that
+        // case PrusaSlicer silently falls back to the closest
+        // compatible preset (typically the first compatible one in
+        // the dropdown). We re-read the actual selection after the
+        // call and treat any mismatch as a failed switch with a
+        // warning, so a scanned tag doesn't quietly move the user
+        // off the preset they were editing.
         tab->select_preset(preset_name);
+        const std::string after = app.preset_bundle->filaments.get_selected_preset().name;
+        if (after == preset_name) {
+            BOOST_LOG_TRIVIAL(info)
+                << "[FilamentDB] switched filament preset from '" << before
+                << "' to '" << preset_name << "'";
+        } else {
+            BOOST_LOG_TRIVIAL(warning)
+                << "[FilamentDB] could not switch to '" << preset_name
+                << "' — it is not compatible with the active printer (selection is now '"
+                << after << "'). Pick a printer that supports this filament, or import a "
+                << "printer-specific variant of the preset into PrusaSlicer.";
+        }
     });
 }
 
@@ -193,14 +224,22 @@ void FilamentScanClient::run()
         return;
     }
 
-    const std::string url = m_base_url + "/api/scan/stream";
+    // `?replay=0` suppresses the on-connect replay of the most recent
+    // scan. We want only live tag reads to drive a preset switch —
+    // otherwise opening the slicer minutes after a scan silently
+    // clobbers the active preset (and any unsaved edits to it).
+    const std::string url = m_base_url + "/api/scan/stream?replay=0";
     BOOST_LOG_TRIVIAL(info) << "[FilamentDB] scan client subscribing to " << url;
 
     using namespace std::chrono_literals;
     auto       backoff     = 500ms;
     const auto max_backoff = 30s;
+    int        attempt     = 0;
 
     while (! m_stop.load()) {
+        ++attempt;
+        if (attempt > 1)
+            BOOST_LOG_TRIVIAL(info) << "[FilamentDB] reconnecting to " << url << " (attempt " << attempt << ")";
         StreamState st;
         st.self = this;
 

--- a/src/slic3r/GUI/FilamentScanClient.cpp
+++ b/src/slic3r/GUI/FilamentScanClient.cpp
@@ -5,6 +5,9 @@
 #include "FilamentScanClient.hpp"
 
 #include "GUI_App.hpp"
+#include "NotificationManager.hpp"
+#include "Plater.hpp"
+#include "Sidebar.hpp"
 #include "Tab.hpp"
 #include "libslic3r/Preset.hpp"
 #include "libslic3r/PresetBundle.hpp"
@@ -186,32 +189,97 @@ void FilamentScanClient::handle_event(const std::string& event_type, const std::
             return;
         }
 
-        const std::string before = app.preset_bundle->filaments.get_selected_preset().name;
-        // Tab::select_preset is what the dropdown calls — it handles the
-        // dirty-state prompt, compatibility checks, and refreshing the
-        // per-extruder combobox. Going through PresetBundle::set_filament_preset
-        // directly would skip all of that.
+        // The user-visible "Filament:" combobox in the sidebar reflects
+        // the per-extruder assignment (`extruders_filaments[0]`), not
+        // the Filament tab's edit pointer (`filaments` collection).
+        // Snapshot the extruder's current filament before the switch so
+        // the log + notification can compare against it.
+        const Preset* before_preset =
+            (!app.preset_bundle->extruders_filaments.empty())
+                ? app.preset_bundle->extruders_filaments[0].get_selected_preset()
+                : nullptr;
+        const std::string before = before_preset ? before_preset->name : std::string{};
+
+        // Mirror the path the sidebar dropdown takes when the user
+        // changes the filament:
+        //   1. set_filament_preset(idx, name)  — assigns the extruder.
+        //                                         No compat filter.
+        //   2. tab->select_preset(name)        — updates the Filament
+        //                                         tab. May silently
+        //                                         fall back if the
+        //                                         preset isn't on the
+        //                                         active printer's
+        //                                         compatible_printers
+        //                                         list.
+        //   3. update_all_filament_comboboxes() — refresh sidebar UI.
         //
-        // NOTE: select_preset returns `true` even when the requested
-        // preset isn't compatible with the active printer — in that
-        // case PrusaSlicer silently falls back to the closest
-        // compatible preset (typically the first compatible one in
-        // the dropdown). We re-read the actual selection after the
-        // call and treat any mismatch as a failed switch with a
-        // warning, so a scanned tag doesn't quietly move the user
-        // off the preset they were editing.
+        // The Sidebar reverts step 1 when step 2 fails. We don't —
+        // for a scanned tag the user's intent is "use this filament",
+        // so accept the extruder assignment even if the Filament tab
+        // can't show it (the user will see the compat-warning toast
+        // and can fix the compatible_printers list later).
+        app.preset_bundle->set_filament_preset(0, preset_name);
         tab->select_preset(preset_name);
-        const std::string after = app.preset_bundle->filaments.get_selected_preset().name;
-        if (after == preset_name) {
+        app.sidebar().update_all_filament_comboboxes();
+
+        // Re-read both the extruder assignment and the tab's selection
+        // so we can tell three apart:
+        //   (a) clean switch         — extruder = name, tab = name
+        //   (b) extruder-only switch — extruder = name, tab fell back
+        //                              (the preset isn't on the active
+        //                               printer's compatible list)
+        //   (c) total failure        — extruder ≠ name
+        const Preset* after_extruder_preset =
+            (!app.preset_bundle->extruders_filaments.empty())
+                ? app.preset_bundle->extruders_filaments[0].get_selected_preset()
+                : nullptr;
+        const std::string after_extruder =
+            after_extruder_preset ? after_extruder_preset->name : std::string{};
+        const std::string after_tab = app.preset_bundle->filaments.get_selected_preset().name;
+
+        if (after_extruder == preset_name && after_tab == preset_name) {
             BOOST_LOG_TRIVIAL(info)
                 << "[FilamentDB] switched filament preset from '" << before
                 << "' to '" << preset_name << "'";
-        } else {
-            BOOST_LOG_TRIVIAL(warning)
-                << "[FilamentDB] could not switch to '" << preset_name
-                << "' — it is not compatible with the active printer (selection is now '"
-                << after << "'). Pick a printer that supports this filament, or import a "
-                << "printer-specific variant of the preset into PrusaSlicer.";
+            return;
+        }
+
+        if (after_extruder == preset_name) {
+            // Extruder accepted it, tab refused. Surface as a warning
+            // so the user knows their filament IS loaded but isn't on
+            // the printer's compatible list.
+            BOOST_LOG_TRIVIAL(info)
+                << "[FilamentDB] switched extruder filament to '" << preset_name
+                << "' (Filament tab fell back to '" << after_tab
+                << "' because the preset isn't marked compatible with the active printer)";
+            if (NotificationManager* nm = app.notification_manager()) {
+                nm->push_notification(
+                    NotificationType::CustomNotification,
+                    NotificationManager::NotificationLevel::WarningNotificationLevel,
+                    "Filament DB: loaded '" + preset_name +
+                    "' on extruder 1. It is not marked as compatible with the "
+                    "active printer — open the filament's settings and tick this "
+                    "printer under 'Compatible printers' to silence this warning.");
+            }
+            return;
+        }
+
+        BOOST_LOG_TRIVIAL(warning)
+            << "[FilamentDB] could not select '" << preset_name
+            << "' — the preset exists in the bundle but is not in the active "
+            << "extruder's filament list (extruder still on '" << after_extruder
+            << "', Filament tab still on '" << after_tab
+            << "'). This usually means the preset's 'compatible_printers' "
+            << "list doesn't include the active printer.";
+        if (NotificationManager* nm = app.notification_manager()) {
+            nm->push_notification(
+                NotificationType::CustomNotification,
+                NotificationManager::NotificationLevel::WarningNotificationLevel,
+                "Filament DB: could not load '" + preset_name +
+                "' on the active printer. Open the Filaments tab, select "
+                "'" + preset_name + "', and under 'Profile dependencies' check "
+                "the box next to your printer in 'Compatible printers'. Save, "
+                "then scan again.");
         }
     });
 }

--- a/src/slic3r/GUI/FilamentScanClient.cpp
+++ b/src/slic3r/GUI/FilamentScanClient.cpp
@@ -198,8 +198,26 @@ void FilamentScanClient::handle_event(const std::string& event_type, const std::
         return;
     }
 
+    // Tolerate forward-incompatible / malformed events: if `filament`
+    // is anything other than an object (string, number, array, ...),
+    // `value()` would throw nlohmann::json::type_error and the
+    // exception would propagate through the libcurl write callback,
+    // potentially terminating the scan worker (codex P1 on PR #13).
     const auto& fil = j["filament"];
-    const std::string preset_name = fil.value("name", std::string{});
+    if (! fil.is_object()) {
+        BOOST_LOG_TRIVIAL(warning)
+            << "[FilamentDB] scan event 'filament' is not an object (type="
+            << fil.type_name() << "); skipping";
+        return;
+    }
+
+    std::string preset_name;
+    try {
+        preset_name = fil.value("name", std::string{});
+    } catch (const std::exception& e) {
+        BOOST_LOG_TRIVIAL(warning) << "[FilamentDB] scan event filament.name lookup failed: " << e.what();
+        return;
+    }
     if (preset_name.empty()) return;
 
     if (event_type == "replay") {
@@ -426,8 +444,15 @@ void FilamentScanClient::run()
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, &st);
         curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
         curl_easy_setopt(curl, CURLOPT_TIMEOUT, 0L);          // no overall cap
-        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 1L);  // ≥1 B
-        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, 90L);  // ~3.6× heartbeat
+        // Don't use CURLOPT_LOW_SPEED_LIMIT — the server's heartbeat
+        // is `: hb` = 5 bytes every 25 s = 0.2 B/s average, well
+        // below any usable byte-rate threshold (codex P2 on PR #13).
+        // Detect dead connections via TCP keepalive instead, which
+        // operates at the socket layer and doesn't care about the
+        // application-level byte rate.
+        curl_easy_setopt(curl, CURLOPT_TCP_KEEPALIVE, 1L);
+        curl_easy_setopt(curl, CURLOPT_TCP_KEEPIDLE,  60L); // start probing after 60 s of inactivity
+        curl_easy_setopt(curl, CURLOPT_TCP_KEEPINTVL, 30L); // probe every 30 s if unacked
         // Honour cooperative cancellation between bytes.
         curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
         curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, &scan_stream_xferinfo_cb);

--- a/src/slic3r/GUI/FilamentScanClient.cpp
+++ b/src/slic3r/GUI/FilamentScanClient.cpp
@@ -1,0 +1,243 @@
+///|/ Copyright (c) Filament DB integration
+///|/
+///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
+///|/
+#include "FilamentScanClient.hpp"
+
+#include "GUI_App.hpp"
+#include "Tab.hpp"
+#include "libslic3r/Preset.hpp"
+#include "libslic3r/PresetBundle.hpp"
+
+#include "nlohmann/json.hpp"
+
+#include <curl/curl.h>
+#include <wx/app.h>
+#include <boost/log/trivial.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cstring>
+
+namespace Slic3r { namespace GUI {
+
+namespace {
+
+// Ignore `replay` events older than this — protects against the slicer
+// opening hours after a scan and silently flipping the preset to a stale
+// filament. Live `scan` events from the publisher are never filtered.
+constexpr int64_t REPLAY_MAX_AGE_MS = 10 * 60 * 1000;
+
+// Per-connection parser state carried through libcurl's write callback.
+struct StreamState {
+    FilamentScanClient* self = nullptr;
+    std::string         buffer;
+};
+
+void process_record(FilamentScanClient* self, const std::string& record)
+{
+    std::string event_type = "message";
+    std::string data;
+    std::size_t line_start = 0;
+    while (line_start <= record.size()) {
+        const std::size_t nl = record.find('\n', line_start);
+        const std::string line = record.substr(
+            line_start,
+            nl == std::string::npos ? std::string::npos : nl - line_start);
+
+        if (! line.empty() && line[0] != ':') {
+            // SSE field syntax: "field: value" or "field:value". A
+            // leading space after the colon is stripped per the spec.
+            if (line.rfind("event:", 0) == 0) {
+                std::size_t s = 6;
+                if (s < line.size() && line[s] == ' ') ++s;
+                event_type = line.substr(s);
+            } else if (line.rfind("data:", 0) == 0) {
+                std::size_t s = 5;
+                if (s < line.size() && line[s] == ' ') ++s;
+                data += line.substr(s);
+            }
+            // `retry:` is ignored — we run our own reconnect loop with
+            // exponential backoff (libcurl doesn't honour the spec's
+            // retry hint on its own).
+        }
+        if (nl == std::string::npos) break;
+        line_start = nl + 1;
+    }
+    if (! data.empty())
+        self->handle_event(event_type, data);
+}
+
+extern "C" std::size_t scan_stream_write_cb(char* ptr, std::size_t size, std::size_t nmemb, void* userdata)
+{
+    auto* st = static_cast<StreamState*>(userdata);
+    const std::size_t n = size * nmemb;
+    st->buffer.append(ptr, n);
+    for (;;) {
+        const std::size_t pos = st->buffer.find("\n\n");
+        if (pos == std::string::npos) break;
+        const std::string record = st->buffer.substr(0, pos);
+        st->buffer.erase(0, pos + 2);
+        process_record(st->self, record);
+    }
+    return n;
+}
+
+extern "C" int scan_stream_xferinfo_cb(void* clientp, curl_off_t, curl_off_t, curl_off_t, curl_off_t)
+{
+    // Non-zero return aborts the in-flight transfer with
+    // CURLE_ABORTED_BY_CALLBACK so stop() can break us out of a
+    // blocking curl_easy_perform without waiting for the next byte.
+    auto* stop_flag = static_cast<std::atomic<bool>*>(clientp);
+    return (stop_flag != nullptr && stop_flag->load()) ? 1 : 0;
+}
+
+} // namespace
+
+FilamentScanClient::FilamentScanClient(std::string base_url)
+    : m_base_url(std::move(base_url))
+{}
+
+FilamentScanClient::~FilamentScanClient()
+{
+    stop();
+}
+
+void FilamentScanClient::start()
+{
+    // exchange returns the previous value — bail if we were already
+    // running. Calls are idempotent.
+    if (m_running.exchange(true)) return;
+    m_stop.store(false);
+    m_thread = std::thread([this] { this->run(); });
+}
+
+void FilamentScanClient::stop()
+{
+    if (! m_running.exchange(false)) return;
+    m_stop.store(true);
+    if (m_thread.joinable())
+        m_thread.join();
+}
+
+void FilamentScanClient::handle_event(const std::string& event_type, const std::string& data_json)
+{
+    // The server emits two relevant event types — `scan` (live tag read)
+    // and `replay` (the most recent scan, sent once on connect).
+    // Anything else (heartbeat comments, future event types) is ignored.
+    if (event_type != "scan" && event_type != "replay") return;
+
+    nlohmann::json j;
+    try {
+        j = nlohmann::json::parse(data_json);
+    } catch (const std::exception& e) {
+        BOOST_LOG_TRIVIAL(warning) << "[FilamentDB] scan stream: JSON parse failed: " << e.what();
+        return;
+    }
+
+    if (! j.contains("filament") || j["filament"].is_null()) {
+        // No DB match — the user scanned a tag we don't have a preset
+        // for. Leaving the current preset alone is the right behaviour;
+        // surfacing this in the UI is a follow-up.
+        return;
+    }
+
+    const auto& fil = j["filament"];
+    const std::string preset_name = fil.value("name", std::string{});
+    if (preset_name.empty()) return;
+
+    if (event_type == "replay") {
+        const int64_t ts = j.value("timestamp", int64_t{0});
+        const auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                std::chrono::system_clock::now().time_since_epoch())
+                                .count();
+        if (ts > 0 && (now_ms - ts) > REPLAY_MAX_AGE_MS) {
+            BOOST_LOG_TRIVIAL(info)
+                << "[FilamentDB] ignoring stale replay (" << (now_ms - ts) / 1000
+                << "s old) for preset '" << preset_name << "'";
+            return;
+        }
+    }
+
+    // wx's CallAfter is documented thread-safe — queues the lambda onto
+    // the main event loop. Tab::select_preset touches wx widgets and
+    // must not be reentered from a worker thread.
+    wxGetApp().CallAfter([preset_name]() {
+        auto& app = wxGetApp();
+        if (app.preset_bundle == nullptr) return;
+
+        const Preset* preset = app.preset_bundle->filaments.find_preset(preset_name);
+        if (preset == nullptr) {
+            BOOST_LOG_TRIVIAL(info)
+                << "[FilamentDB] no matching filament preset for '" << preset_name
+                << "' — the slicer hasn't synced this filament yet";
+            return;
+        }
+
+        Tab* tab = app.get_tab(Preset::TYPE_FILAMENT);
+        if (tab == nullptr) return;
+
+        // Tab::select_preset is what the dropdown calls — it handles the
+        // dirty-state prompt, compatibility checks, and refreshing the
+        // per-extruder combobox. Going through PresetBundle::set_filament_preset
+        // directly would skip all of that.
+        tab->select_preset(preset_name);
+    });
+}
+
+void FilamentScanClient::run()
+{
+    CURL* curl = curl_easy_init();
+    if (curl == nullptr) {
+        BOOST_LOG_TRIVIAL(error) << "[FilamentDB] curl_easy_init failed; scan client disabled";
+        return;
+    }
+
+    const std::string url = m_base_url + "/api/scan/stream";
+    BOOST_LOG_TRIVIAL(info) << "[FilamentDB] scan client subscribing to " << url;
+
+    using namespace std::chrono_literals;
+    auto       backoff     = 500ms;
+    const auto max_backoff = 30s;
+
+    while (! m_stop.load()) {
+        StreamState st;
+        st.self = this;
+
+        struct curl_slist* headers = nullptr;
+        headers = curl_slist_append(headers, "Accept: text/event-stream");
+
+        curl_easy_reset(curl);
+        curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+        curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &scan_stream_write_cb);
+        curl_easy_setopt(curl, CURLOPT_WRITEDATA, &st);
+        curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+        curl_easy_setopt(curl, CURLOPT_TIMEOUT, 0L);          // no overall cap
+        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 1L);  // ≥1 B
+        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, 90L);  // ~3.6× heartbeat
+        // Honour cooperative cancellation between bytes.
+        curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
+        curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, &scan_stream_xferinfo_cb);
+        curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &m_stop);
+
+        const CURLcode rc = curl_easy_perform(curl);
+        curl_slist_free_all(headers);
+
+        if (m_stop.load()) break;
+
+        if (rc != CURLE_OK) {
+            BOOST_LOG_TRIVIAL(debug)
+                << "[FilamentDB] scan stream disconnected (" << curl_easy_strerror(rc)
+                << "); reconnecting after " << backoff.count() << "ms";
+        }
+
+        std::this_thread::sleep_for(backoff);
+        backoff = std::min<std::chrono::milliseconds>(backoff * 2, max_backoff);
+    }
+
+    curl_easy_cleanup(curl);
+    BOOST_LOG_TRIVIAL(info) << "[FilamentDB] scan client stopped";
+}
+
+} } // namespace Slic3r::GUI

--- a/src/slic3r/GUI/FilamentScanClient.cpp
+++ b/src/slic3r/GUI/FilamentScanClient.cpp
@@ -24,23 +24,11 @@
 
 namespace Slic3r { namespace GUI {
 
-namespace {
+namespace filament_scan_detail {
 
-// Ignore `replay` events older than this — protects against the slicer
-// opening hours after a scan and silently flipping the preset to a stale
-// filament. Live `scan` events from the publisher are never filtered.
-constexpr int64_t REPLAY_MAX_AGE_MS = 10 * 60 * 1000;
-
-// Per-connection parser state carried through libcurl's write callback.
-struct StreamState {
-    FilamentScanClient* self = nullptr;
-    std::string         buffer;
-};
-
-void process_record(FilamentScanClient* self, const std::string& record)
+ParsedEvent parse_record(const std::string& record)
 {
-    std::string event_type = "message";
-    std::string data;
+    ParsedEvent out;
     std::size_t line_start = 0;
     while (line_start <= record.size()) {
         const std::size_t nl = record.find('\n', line_start);
@@ -54,11 +42,11 @@ void process_record(FilamentScanClient* self, const std::string& record)
             if (line.rfind("event:", 0) == 0) {
                 std::size_t s = 6;
                 if (s < line.size() && line[s] == ' ') ++s;
-                event_type = line.substr(s);
+                out.event_type = line.substr(s);
             } else if (line.rfind("data:", 0) == 0) {
                 std::size_t s = 5;
                 if (s < line.size() && line[s] == ' ') ++s;
-                data += line.substr(s);
+                out.data += line.substr(s);
             }
             // `retry:` is ignored — we run our own reconnect loop with
             // exponential backoff (libcurl doesn't honour the spec's
@@ -67,22 +55,74 @@ void process_record(FilamentScanClient* self, const std::string& record)
         if (nl == std::string::npos) break;
         line_start = nl + 1;
     }
-    if (! data.empty())
-        self->handle_event(event_type, data);
+    return out;
 }
+
+void SseRecordParser::feed(const char* chunk, std::size_t n, const Emit& emit)
+{
+    // 1) Normalise line endings as we append. RFC EventSource allows
+    //    CR, LF, or CRLF as line terminators; the original LF-only
+    //    split silently dropped events from a CRLF publisher (codex
+    //    P1 on PR #13). Collapse to LF here so the split below only
+    //    has to look for "\n\n". `m_last_was_cr` preserves the CR
+    //    state across chunk boundaries so a CRLF straddling two
+    //    chunks doesn't produce two LFs.
+    m_buffer.reserve(m_buffer.size() + n);
+    for (std::size_t i = 0; i < n; ++i) {
+        const char c = chunk[i];
+        if (c == '\r') {
+            m_buffer.push_back('\n');
+            m_last_was_cr = true;
+        } else if (c == '\n') {
+            if (! m_last_was_cr) m_buffer.push_back('\n');
+            // else: CR already emitted as LF; suppress this LF so CRLF
+            // is normalised to a single LF.
+            m_last_was_cr = false;
+        } else {
+            m_buffer.push_back(c);
+            m_last_was_cr = false;
+        }
+    }
+
+    // 2) Drain complete records (blank-line terminated). Only emit
+    //    when the record produced a non-empty `data` payload — that
+    //    skips heartbeat comments (`: hb\n\n`) and any future
+    //    metadata-only records.
+    for (;;) {
+        const std::size_t pos = m_buffer.find("\n\n");
+        if (pos == std::string::npos) break;
+        const std::string record = m_buffer.substr(0, pos);
+        m_buffer.erase(0, pos + 2);
+        if (record.empty()) continue;
+        ParsedEvent ev = parse_record(record);
+        if (! ev.data.empty()) emit(ev);
+    }
+}
+
+} // namespace filament_scan_detail
+
+namespace {
+
+// Ignore `replay` events older than this — protects against the slicer
+// opening hours after a scan and silently flipping the preset to a stale
+// filament. Live `scan` events from the publisher are never filtered.
+constexpr int64_t REPLAY_MAX_AGE_MS = 10 * 60 * 1000;
+
+// Per-connection parser state carried through libcurl's write callback.
+struct StreamState {
+    FilamentScanClient*                       self = nullptr;
+    filament_scan_detail::SseRecordParser     parser;
+};
 
 extern "C" std::size_t scan_stream_write_cb(char* ptr, std::size_t size, std::size_t nmemb, void* userdata)
 {
     auto* st = static_cast<StreamState*>(userdata);
     const std::size_t n = size * nmemb;
-    st->buffer.append(ptr, n);
-    for (;;) {
-        const std::size_t pos = st->buffer.find("\n\n");
-        if (pos == std::string::npos) break;
-        const std::string record = st->buffer.substr(0, pos);
-        st->buffer.erase(0, pos + 2);
-        process_record(st->self, record);
-    }
+    st->parser.feed(ptr, n, [st](const filament_scan_detail::ParsedEvent& ev) {
+        // SseRecordParser already filters records with empty data (e.g.
+        // `: hb` heartbeats), so we can dispatch unconditionally here.
+        st->self->handle_event(ev.event_type, ev.data);
+    });
     return n;
 }
 

--- a/src/slic3r/GUI/FilamentScanClient.cpp
+++ b/src/slic3r/GUI/FilamentScanClient.cpp
@@ -46,13 +46,15 @@ ParsedEvent parse_record(const std::string& record)
             } else if (line.rfind("data:", 0) == 0) {
                 std::size_t s = 5;
                 if (s < line.size() && line[s] == ' ') ++s;
-                // EventSource spec: successive `data:` lines in a
-                // single record are joined by LFs. Filament DB sends
-                // compact single-line JSON, so we don't hit this in
-                // practice — but the parser is general (codex P2 on
-                // PR #13).
-                if (! out.data.empty()) out.data += '\n';
+                // EventSource spec: append the field value, then a LF
+                // after every `data:` field — including empty values.
+                // The trailing LF after the last `data:` is stripped
+                // below. The "skip LF for the first non-empty value"
+                // shortcut would lose leading empty-data lines like
+                // `data:\ndata:{json}\n\n`, corrupting otherwise valid
+                // multi-line payloads (codex P2 on PR #13).
                 out.data += line.substr(s);
+                out.data += '\n';
             }
             // `retry:` is ignored — we run our own reconnect loop with
             // exponential backoff (libcurl doesn't honour the spec's
@@ -61,6 +63,11 @@ ParsedEvent parse_record(const std::string& record)
         if (nl == std::string::npos) break;
         line_start = nl + 1;
     }
+    // Strip the LF appended by the final `data:` line per the
+    // EventSource spec ("If the data buffer's last character is a LF,
+    // remove the last character from the data buffer").
+    if (! out.data.empty() && out.data.back() == '\n')
+        out.data.pop_back();
     return out;
 }
 

--- a/src/slic3r/GUI/FilamentScanClient.cpp
+++ b/src/slic3r/GUI/FilamentScanClient.cpp
@@ -46,6 +46,12 @@ ParsedEvent parse_record(const std::string& record)
             } else if (line.rfind("data:", 0) == 0) {
                 std::size_t s = 5;
                 if (s < line.size() && line[s] == ' ') ++s;
+                // EventSource spec: successive `data:` lines in a
+                // single record are joined by LFs. Filament DB sends
+                // compact single-line JSON, so we don't hit this in
+                // practice — but the parser is general (codex P2 on
+                // PR #13).
+                if (! out.data.empty()) out.data += '\n';
                 out.data += line.substr(s);
             }
             // `retry:` is ignored — we run our own reconnect loop with
@@ -393,10 +399,23 @@ void FilamentScanClient::run()
         curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, &scan_stream_xferinfo_cb);
         curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &m_stop);
 
-        const CURLcode rc = curl_easy_perform(curl);
+        const auto    session_start = std::chrono::steady_clock::now();
+        const CURLcode rc            = curl_easy_perform(curl);
+        const auto    session_dur   = std::chrono::steady_clock::now() - session_start;
         curl_slist_free_all(headers);
 
         if (m_stop.load()) break;
+
+        // Reset the reconnect backoff if the session was healthy
+        // (≥5 s with data flowing — at least one heartbeat cycle).
+        // Otherwise an initial outage that ramps backoff to 30s would
+        // make every subsequent disconnect from a healthy stream wait
+        // up to 30s before retrying, even years later (codex P2 on
+        // PR #13). 5s is short enough to consider any successful
+        // initial handshake-plus-prelude flow "healthy" and long
+        // enough to filter out immediate connection failures.
+        if (session_dur >= std::chrono::seconds(5))
+            backoff = std::chrono::milliseconds(500);
 
         if (rc != CURLE_OK) {
             BOOST_LOG_TRIVIAL(debug)

--- a/src/slic3r/GUI/FilamentScanClient.cpp
+++ b/src/slic3r/GUI/FilamentScanClient.cpp
@@ -164,7 +164,14 @@ void FilamentScanClient::start()
 void FilamentScanClient::stop()
 {
     if (! m_running.exchange(false)) return;
-    m_stop.store(true);
+    {
+        std::lock_guard<std::mutex> lk(m_stop_mtx);
+        m_stop.store(true);
+    }
+    // Wake the worker if it's currently inside the reconnect-loop's
+    // wait_for, so stop() doesn't block for up to 30 s waiting on the
+    // next backoff tick.
+    m_stop_cv.notify_all();
     if (m_thread.joinable())
         m_thread.join();
 }
@@ -374,6 +381,16 @@ void FilamentScanClient::run()
     auto       backoff     = 500ms;
     const auto max_backoff = 30s;
     int        attempt     = 0;
+    // Give-up gate for users who don't actually run Filament DB.
+    // `filamentdb_url` defaults to localhost:3456 on a fresh install
+    // (AppConfig.cpp), so without this we'd hammer localhost forever
+    // on every PrusaSlicer launch even when there's no Filament DB
+    // process to connect to (codex P2 on PR #13). Once we've had at
+    // least one successful session we keep retrying on disconnect
+    // forever (back to the normal robust-reconnect behaviour).
+    bool       ever_connected   = false;
+    int        startup_failures = 0;
+    constexpr int MAX_STARTUP_FAILURES = 7; // ~60 s of total elapsed wait
 
     while (! m_stop.load()) {
         ++attempt;
@@ -406,16 +423,29 @@ void FilamentScanClient::run()
 
         if (m_stop.load()) break;
 
-        // Reset the reconnect backoff if the session was healthy
-        // (≥5 s with data flowing — at least one heartbeat cycle).
-        // Otherwise an initial outage that ramps backoff to 30s would
-        // make every subsequent disconnect from a healthy stream wait
-        // up to 30s before retrying, even years later (codex P2 on
-        // PR #13). 5s is short enough to consider any successful
-        // initial handshake-plus-prelude flow "healthy" and long
-        // enough to filter out immediate connection failures.
-        if (session_dur >= std::chrono::seconds(5))
-            backoff = std::chrono::milliseconds(500);
+        const bool healthy_session = session_dur >= std::chrono::seconds(5);
+        if (healthy_session) {
+            // Reset the reconnect backoff so a long-healthy stream
+            // that drops once doesn't inherit an old outage's grown
+            // backoff (codex P2 on PR #13). 5 s is short enough to
+            // consider any successful initial handshake + prelude
+            // flow "healthy" and long enough to filter out fast
+            // connection failures.
+            backoff          = std::chrono::milliseconds(500);
+            ever_connected   = true;
+            startup_failures = 0;
+        } else if (! ever_connected) {
+            // Never connected — count toward the give-up threshold.
+            ++startup_failures;
+            if (startup_failures >= MAX_STARTUP_FAILURES) {
+                BOOST_LOG_TRIVIAL(info)
+                    << "[FilamentDB] " << url << " not reachable after "
+                    << startup_failures
+                    << " attempts; scan client giving up for this session. "
+                    << "Restart PrusaSlicer once Filament DB is running.";
+                break;
+            }
+        }
 
         if (rc != CURLE_OK) {
             BOOST_LOG_TRIVIAL(debug)
@@ -423,7 +453,14 @@ void FilamentScanClient::run()
                 << "); reconnecting after " << backoff.count() << "ms";
         }
 
-        std::this_thread::sleep_for(backoff);
+        // Interruptible sleep — wake on stop() without waiting up to
+        // 30 s for the next tick (codex P1 on PR #13). Using a CV
+        // with the atomic m_stop as the predicate so the curl
+        // xferinfo callback (lock-free) still works unchanged.
+        {
+            std::unique_lock<std::mutex> lk(m_stop_mtx);
+            m_stop_cv.wait_for(lk, backoff, [this] { return m_stop.load(); });
+        }
         backoff = std::min<std::chrono::milliseconds>(backoff * 2, max_backoff);
     }
 

--- a/src/slic3r/GUI/FilamentScanClient.cpp
+++ b/src/slic3r/GUI/FilamentScanClient.cpp
@@ -223,20 +223,30 @@ void FilamentScanClient::handle_event(const std::string& event_type, const std::
             return;
         }
 
-        Tab* tab = app.get_tab(Preset::TYPE_FILAMENT);
-        if (tab == nullptr) {
+        TabFilament* fil_tab = dynamic_cast<TabFilament*>(app.get_tab(Preset::TYPE_FILAMENT));
+        if (fil_tab == nullptr) {
             BOOST_LOG_TRIVIAL(warning) << "[FilamentDB] filament Tab is null — preset switch skipped";
             return;
         }
 
+        // Target the Filament tab's currently-active extruder rather
+        // than always extruder 0. On multi-extruder setups the tab
+        // can be focused on a slot other than 0, and writing to both
+        // 0 and the active slot would silently overwrite two
+        // assignments per scan (codex P1 on PR #13). The sidebar's
+        // dropdown flow uses this same rule.
+        const int target_extruder = fil_tab->get_active_extruder();
+        const std::size_t target_idx =
+            target_extruder < 0 ? 0 : static_cast<std::size_t>(target_extruder);
+
         // The user-visible "Filament:" combobox in the sidebar reflects
-        // the per-extruder assignment (`extruders_filaments[0]`), not
+        // the per-extruder assignment (`extruders_filaments[idx]`), not
         // the Filament tab's edit pointer (`filaments` collection).
         // Snapshot the extruder's current filament before the switch so
         // the log + notification can compare against it.
         const Preset* before_preset =
-            (!app.preset_bundle->extruders_filaments.empty())
-                ? app.preset_bundle->extruders_filaments[0].get_selected_preset()
+            (target_idx < app.preset_bundle->extruders_filaments.size())
+                ? app.preset_bundle->extruders_filaments[target_idx].get_selected_preset()
                 : nullptr;
         const std::string before = before_preset ? before_preset->name : std::string{};
 
@@ -258,8 +268,8 @@ void FilamentScanClient::handle_event(const std::string& event_type, const std::
         // so accept the extruder assignment even if the Filament tab
         // can't show it (the user will see the compat-warning toast
         // and can fix the compatible_printers list later).
-        app.preset_bundle->set_filament_preset(0, preset_name);
-        tab->select_preset(preset_name);
+        app.preset_bundle->set_filament_preset(target_idx, preset_name);
+        fil_tab->select_preset(preset_name);
         app.sidebar().update_all_filament_comboboxes();
 
         // Re-read both the extruder assignment and the tab's selection
@@ -270,17 +280,28 @@ void FilamentScanClient::handle_event(const std::string& event_type, const std::
         //                               printer's compatible list)
         //   (c) total failure        — extruder ≠ name
         const Preset* after_extruder_preset =
-            (!app.preset_bundle->extruders_filaments.empty())
-                ? app.preset_bundle->extruders_filaments[0].get_selected_preset()
+            (target_idx < app.preset_bundle->extruders_filaments.size())
+                ? app.preset_bundle->extruders_filaments[target_idx].get_selected_preset()
                 : nullptr;
         const std::string after_extruder =
             after_extruder_preset ? after_extruder_preset->name : std::string{};
         const std::string after_tab = app.preset_bundle->filaments.get_selected_preset().name;
 
+        // Persist the selection to config.ini on a clean switch — same
+        // behaviour as the sidebar dropdown, so a scan-driven change
+        // survives the next slicer restart (codex P2 on PR #13).
+        // Skipped on the partial / failed paths to avoid persisting
+        // a preset the user can't actually use yet.
+        auto persist_selection = [&app]() {
+            if (app.app_config != nullptr)
+                app.preset_bundle->export_selections(*app.app_config);
+        };
+
         if (after_extruder == preset_name && after_tab == preset_name) {
             BOOST_LOG_TRIVIAL(info)
                 << "[FilamentDB] switched filament preset from '" << before
-                << "' to '" << preset_name << "'";
+                << "' to '" << preset_name << "' on extruder " << target_extruder;
+            persist_selection();
             return;
         }
 
@@ -289,17 +310,20 @@ void FilamentScanClient::handle_event(const std::string& event_type, const std::
             // so the user knows their filament IS loaded but isn't on
             // the printer's compatible list.
             BOOST_LOG_TRIVIAL(info)
-                << "[FilamentDB] switched extruder filament to '" << preset_name
+                << "[FilamentDB] switched extruder " << target_extruder
+                << " filament to '" << preset_name
                 << "' (Filament tab fell back to '" << after_tab
                 << "' because the preset isn't marked compatible with the active printer)";
+            persist_selection();
             if (NotificationManager* nm = app.notification_manager()) {
                 nm->push_notification(
                     NotificationType::CustomNotification,
                     NotificationManager::NotificationLevel::WarningNotificationLevel,
                     "Filament DB: loaded '" + preset_name +
-                    "' on extruder 1. It is not marked as compatible with the "
-                    "active printer — open the filament's settings and tick this "
-                    "printer under 'Compatible printers' to silence this warning.");
+                    "' on extruder " + std::to_string(target_extruder + 1) +
+                    ". It is not marked as compatible with the active printer — "
+                    "open the filament's settings and tick this printer under "
+                    "'Compatible printers' to silence this warning.");
             }
             return;
         }
@@ -307,7 +331,8 @@ void FilamentScanClient::handle_event(const std::string& event_type, const std::
         BOOST_LOG_TRIVIAL(warning)
             << "[FilamentDB] could not select '" << preset_name
             << "' — the preset exists in the bundle but is not in the active "
-            << "extruder's filament list (extruder still on '" << after_extruder
+            << "extruder's filament list (extruder " << target_extruder
+            << " still on '" << after_extruder
             << "', Filament tab still on '" << after_tab
             << "'). This usually means the preset's 'compatible_printers' "
             << "list doesn't include the active printer.";

--- a/src/slic3r/GUI/FilamentScanClient.cpp
+++ b/src/slic3r/GUI/FilamentScanClient.cpp
@@ -223,8 +223,25 @@ void FilamentScanClient::handle_event(const std::string& event_type, const std::
     // must not be reentered from a worker thread.
     wxGetApp().CallAfter([preset_name]() {
         auto& app = wxGetApp();
+        // Defensive shutdown / GUI-recreate guards. Two windows where
+        // a worker-queued CallAfter can land on a dead GUI:
+        //
+        //   1. Normal app close: MainFrame::~MainFrame() nulls
+        //      plater_ before ~GUI_App() resets the scan client, so
+        //      pending CallAfters processed in between would crash
+        //      on app.sidebar() / app.notification_manager() which
+        //      dereference plater_ (codex P1 on PR #13).
+        //   2. Language-switch recreate_GUI(): mainframe->shutdown()
+        //      runs while the worker is still active, and a brief
+        //      window exists before the new MainFrame is wired.
+        //
+        // Bail early if any of the surfaces we need are gone.
         if (app.preset_bundle == nullptr) {
             BOOST_LOG_TRIVIAL(warning) << "[FilamentDB] preset_bundle is null — preset switch skipped";
+            return;
+        }
+        if (app.plater() == nullptr) {
+            BOOST_LOG_TRIVIAL(debug) << "[FilamentDB] plater is null (shutdown / GUI rebuild in progress) — preset switch skipped";
             return;
         }
 

--- a/src/slic3r/GUI/FilamentScanClient.hpp
+++ b/src/slic3r/GUI/FilamentScanClient.hpp
@@ -6,10 +6,66 @@
 #define slic3r_GUI_FilamentScanClient_hpp_
 
 #include <atomic>
+#include <functional>
 #include <string>
 #include <thread>
 
 namespace Slic3r { namespace GUI {
+
+namespace filament_scan_detail {
+
+/**
+ * One parsed SSE record. `event_type` defaults to "message" per the
+ * EventSource spec; `data` is the concatenation of every `data:` line
+ * in the record.
+ */
+struct ParsedEvent {
+    std::string event_type = "message";
+    std::string data;
+};
+
+/**
+ * Stateful incremental SSE parser. The libcurl write callback feeds
+ * raw bytes in arbitrary-sized chunks; the parser normalises line
+ * endings (RFC EventSource allows CR, LF, or CRLF — codex flagged
+ * that the original LF-only split silently dropped events from
+ * standards-compliant CRLF publishers), splits on the blank-line
+ * record separator, and yields each complete record via `emit`.
+ *
+ * Exposed for unit testing in tests/slic3rutils/.
+ */
+class SseRecordParser {
+public:
+    using Emit = std::function<void(const ParsedEvent&)>;
+
+    SseRecordParser() = default;
+
+    /// Append `n` bytes from `chunk` to the buffer and emit every
+    /// complete record found, in order. Safe to call across chunk
+    /// boundaries: a CRLF straddling two chunks is correctly handled.
+    void feed(const char* chunk, std::size_t n, const Emit& emit);
+
+    /// Test helpers.
+    const std::string& buffer() const { return m_buffer; }
+    bool               last_was_cr() const { return m_last_was_cr; }
+
+private:
+    std::string m_buffer;
+    /// Track CR-at-end-of-chunk so a CRLF straddling chunks doesn't
+    /// produce two LFs in the normalised buffer.
+    bool m_last_was_cr = false;
+};
+
+/**
+ * Parse a single SSE record body (newline-delimited lines, with the
+ * record-terminating blank line already stripped) into a `ParsedEvent`.
+ * Public for unit testing — `SseRecordParser::feed` calls into this
+ * for every complete record.
+ */
+ParsedEvent parse_record(const std::string& record);
+
+} // namespace filament_scan_detail
+
 
 // Subscribes to a Filament DB instance's `/api/scan/stream` Server-Sent
 // Events endpoint and switches the active filament preset to match each

--- a/src/slic3r/GUI/FilamentScanClient.hpp
+++ b/src/slic3r/GUI/FilamentScanClient.hpp
@@ -6,7 +6,9 @@
 #define slic3r_GUI_FilamentScanClient_hpp_
 
 #include <atomic>
+#include <condition_variable>
 #include <functional>
+#include <mutex>
 #include <string>
 #include <thread>
 
@@ -103,10 +105,15 @@ public:
 private:
     void run();
 
-    std::string       m_base_url;
-    std::atomic<bool> m_stop { false };
-    std::atomic<bool> m_running { false };
-    std::thread       m_thread;
+    std::string             m_base_url;
+    std::atomic<bool>       m_stop { false };
+    std::atomic<bool>       m_running { false };
+    std::thread             m_thread;
+    // Pair used to interrupt the reconnect-loop sleep when stop() is
+    // called — otherwise shutdown can block for up to 30 s waiting on
+    // the next backoff tick (codex P1 on PR #13).
+    std::mutex              m_stop_mtx;
+    std::condition_variable m_stop_cv;
 };
 
 } } // namespace Slic3r::GUI

--- a/src/slic3r/GUI/FilamentScanClient.hpp
+++ b/src/slic3r/GUI/FilamentScanClient.hpp
@@ -97,6 +97,10 @@ public:
     void start();
     void stop();
 
+    /// Normalised base URL (trailing slashes stripped). Exposed for tests
+    /// of the normalization logic; production callers don't need it.
+    const std::string& base_url() const { return m_base_url; }
+
     // Public so the libcurl write callback (translation-unit-local in the
     // .cpp file) can dispatch each parsed SSE record back into the class
     // without needing friend declarations.

--- a/src/slic3r/GUI/FilamentScanClient.hpp
+++ b/src/slic3r/GUI/FilamentScanClient.hpp
@@ -1,0 +1,58 @@
+///|/ Copyright (c) Filament DB integration
+///|/
+///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
+///|/
+#ifndef slic3r_GUI_FilamentScanClient_hpp_
+#define slic3r_GUI_FilamentScanClient_hpp_
+
+#include <atomic>
+#include <string>
+#include <thread>
+
+namespace Slic3r { namespace GUI {
+
+// Subscribes to a Filament DB instance's `/api/scan/stream` Server-Sent
+// Events endpoint and switches the active filament preset to match each
+// scanned NFC tag. Runs a libcurl loop on a worker thread; every event
+// is marshalled back to the wx GUI thread before touching any preset
+// state.
+//
+// Lifecycle: construct in `GUI_App::post_init()` after `preset_bundle`
+// is loaded, destroy from `~GUI_App`. `start()` is safe to call from
+// the GUI thread and is idempotent; `stop()` blocks until the worker
+// has joined.
+//
+// The base URL points at the Filament DB instance (e.g.
+// `http://localhost:3456` for a same-machine Electron deploy or
+// `http://raspberrypi.local:3456` for a Pi running headlessly). The
+// slicer does not need to be on the same physical machine — only
+// network-reachable to the Filament DB instance.
+class FilamentScanClient
+{
+public:
+    explicit FilamentScanClient(std::string base_url);
+    ~FilamentScanClient();
+
+    FilamentScanClient(const FilamentScanClient&)            = delete;
+    FilamentScanClient& operator=(const FilamentScanClient&) = delete;
+
+    void start();
+    void stop();
+
+    // Public so the libcurl write callback (translation-unit-local in the
+    // .cpp file) can dispatch each parsed SSE record back into the class
+    // without needing friend declarations.
+    void handle_event(const std::string& event_type, const std::string& data_json);
+
+private:
+    void run();
+
+    std::string       m_base_url;
+    std::atomic<bool> m_stop { false };
+    std::atomic<bool> m_running { false };
+    std::thread       m_thread;
+};
+
+} } // namespace Slic3r::GUI
+
+#endif // slic3r_GUI_FilamentScanClient_hpp_

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -9,6 +9,7 @@
 #include "libslic3r/Technologies.hpp"
 #include "slic3r/Utils/FilamentDB.hpp"
 #include "GUI_App.hpp"
+#include "FilamentScanClient.hpp"
 #include "GUI_Init.hpp" // IWYU pragma: keep
 #include "GUI_ObjectList.hpp"
 #include "GUI_ObjectManipulation.hpp"
@@ -845,6 +846,22 @@ void GUI_App::post_init()
     // show "Did you know" notification
     if (app_config->get_bool("show_hints") && ! is_gcode_viewer())
         plater_->get_notification_manager()->push_hint_notification(true);
+
+    // Subscribe to the Filament DB scan stream (NFC tag reads → preset
+    // auto-select). Skipped in the gcode-viewer mode, which has no
+    // editable preset surface to switch. The base URL is configurable
+    // via the `filamentdb_base_url` AppConfig key; an empty value
+    // disables the feature entirely (useful if the user doesn't run
+    // Filament DB or wants to point at a non-default host like a Pi).
+    if (! is_gcode_viewer()) {
+        std::string scan_base_url = app_config->get("filamentdb_base_url");
+        if (scan_base_url.empty())
+            scan_base_url = "http://localhost:3456";
+        if (! scan_base_url.empty()) {
+            m_filament_scan_client = std::make_unique<FilamentScanClient>(scan_base_url);
+            m_filament_scan_client->start();
+        }
+    }
 
     // The extra CallAfter() is needed because of Mac, where this is the only way
     // to popup a modal dialog on start without screwing combo boxes.

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -849,14 +849,13 @@ void GUI_App::post_init()
 
     // Subscribe to the Filament DB scan stream (NFC tag reads → preset
     // auto-select). Skipped in the gcode-viewer mode, which has no
-    // editable preset surface to switch. The base URL is configurable
-    // via the `filamentdb_base_url` AppConfig key; an empty value
-    // disables the feature entirely (useful if the user doesn't run
-    // Filament DB or wants to point at a non-default host like a Pi).
+    // editable preset surface to switch. The base URL is shared with
+    // the rest of the FilamentDB integration (preset sync, spool
+    // check) via the `filamentdb_url` AppConfig key; clearing it
+    // disables all three features in lockstep, which matches what
+    // the rest of the FilamentDB module already does.
     if (! is_gcode_viewer()) {
-        std::string scan_base_url = app_config->get("filamentdb_base_url");
-        if (scan_base_url.empty())
-            scan_base_url = "http://localhost:3456";
+        const std::string scan_base_url = app_config->get("filamentdb_url");
         if (! scan_base_url.empty()) {
             m_filament_scan_client = std::make_unique<FilamentScanClient>(scan_base_url);
             m_filament_scan_client->start();

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -911,6 +911,15 @@ GUI_App::GUI_App(EAppMode mode)
 
 GUI_App::~GUI_App()
 {
+    // Stop the scan client BEFORE the manual deletes below. The
+    // unique_ptr member destructors otherwise run *after* this body,
+    // which would let the worker thread still be alive while
+    // preset_bundle is being deleted — its CallAfter lambdas
+    // dereference `wxGetApp().preset_bundle` (codex P1 on PR #13).
+    // Explicit reset → ~FilamentScanClient → stop() joins the worker,
+    // so by the time we touch preset_bundle no more callbacks can
+    // fire.
+    if (m_filament_scan_client) m_filament_scan_client.reset();
     delete app_config;
     delete preset_bundle;
 }

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -57,6 +57,7 @@ class ObjectLayers;
 class Plater;
 class NotificationManager;
 class Downloader;
+class FilamentScanClient;
 struct GUI_InitParams;
 class GalleryDialog;
 class PresetArchiveDatabase;
@@ -190,6 +191,11 @@ private:
     std::unique_ptr<AppUpdater>                     m_app_updater;
     std::unique_ptr<wxSingleInstanceChecker>        m_single_instance_checker;
     std::unique_ptr<Downloader>                     m_downloader;
+    // Subscribes to a Filament DB instance's /api/scan/stream — switches
+    // the active filament preset to match each scanned NFC tag. Started
+    // in post_init() once preset_bundle is populated; destructor joins
+    // the worker thread, so unique_ptr cleanup is sufficient on shutdown.
+    std::unique_ptr<FilamentScanClient>             m_filament_scan_client;
     
     std::string m_instance_hash_string;
 	size_t m_instance_hash_int;

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -3497,9 +3497,33 @@ void Plater::priv::on_process_completed(SlicingProcessCompletedEvent &evt)
                     // " @<printer_alias>" suffix to the preset name
                     // (e.g. "Prusament PLA @MK3S"). Filament DB stores
                     // the base name only, so the lookup must strip
-                    // anything after " @" before calling spool-check.
+                    // that suffix before calling spool-check.
+                    //
+                    // Match the *last* " @" whose next character is
+                    // non-space — printer aliases never start with a
+                    // space, while legitimate names like "Foo @ home"
+                    // do, and those must not be truncated (codex P2
+                    // on PR #13). Right-to-left scan handles names
+                    // like "PLA @300C @MK3S" → strip only @MK3S.
                     std::string filament_name = preset->name;
-                    const auto at_pos = filament_name.find(" @");
+                    std::size_t at_pos       = std::string::npos;
+                    {
+                        std::size_t search_to = filament_name.size();
+                        while (search_to >= 2) {
+                            const std::size_t found =
+                                filament_name.rfind(" @", search_to - 1);
+                            if (found == std::string::npos) break;
+                            if (found + 2 < filament_name.size() &&
+                                filament_name[found + 2] != ' ') {
+                                at_pos = found;
+                                break;
+                            }
+                            // " @ " — not a printer suffix; keep
+                            // looking further left.
+                            if (found == 0) break;
+                            search_to = found;
+                        }
+                    }
                     if (at_pos != std::string::npos)
                         filament_name.resize(at_pos);
                     auto spool_result = check_filament_spool(filamentdb_url, filament_name, filament_weight);

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -3493,7 +3493,15 @@ void Plater::priv::on_process_completed(SlicingProcessCompletedEvent &evt)
                     if (filament_weight <= 0)
                         continue;
 
+                    // PrusaSlicer's printer-context variants append a
+                    // " @<printer_alias>" suffix to the preset name
+                    // (e.g. "Prusament PLA @MK3S"). Filament DB stores
+                    // the base name only, so the lookup must strip
+                    // anything after " @" before calling spool-check.
                     std::string filament_name = preset->name;
+                    const auto at_pos = filament_name.find(" @");
+                    if (at_pos != std::string::npos)
+                        filament_name.resize(at_pos);
                     auto spool_result = check_filament_spool(filamentdb_url, filament_name, filament_weight);
 
                     if (spool_result.has_data && !spool_result.ok) {

--- a/tests/slic3rutils/CMakeLists.txt
+++ b/tests/slic3rutils/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(${_TEST_NAME}_tests
     secretstore_tests.cpp
     bedmesh_tests.cpp
     filamentdb_tests.cpp
+    filamentscanclient_tests.cpp
     )
 
 # mold linker for successful linking needs also to link TBB library and link it before libslic3r.

--- a/tests/slic3rutils/filamentscanclient_tests.cpp
+++ b/tests/slic3rutils/filamentscanclient_tests.cpp
@@ -104,6 +104,30 @@ TEST_CASE("SseRecordParser: three data: lines yield two LFs", "[FilamentScanClie
     REQUIRE(events[0].data == "a\nb\nc");
 }
 
+TEST_CASE("SseRecordParser: leading empty data line preserved", "[FilamentScanClient]")
+{
+    // EventSource spec: every `data:` field contributes a LF to the
+    // buffer (even when the value is empty), with the final trailing
+    // LF stripped at dispatch. The shortcut "only insert LF if buffer
+    // is non-empty" would lose this leading LF and corrupt payloads
+    // like JSON intentionally prefixed with a newline (codex P2 on
+    // PR #13).
+    auto events = feed_all("data:\ndata: {\"x\":1}\n\n");
+    REQUIRE(events.size() == 1);
+    REQUIRE(events[0].data == "\n{\"x\":1}");
+}
+
+TEST_CASE("SseRecordParser: trailing data: LF is stripped, not duplicated",
+          "[FilamentScanClient]")
+{
+    // Spec calls for trimming a single LF after the last data line,
+    // not all trailing LFs — a deliberate trailing empty data:
+    // produces a real LF in the payload.
+    auto events = feed_all("data: a\ndata:\n\n");
+    REQUIRE(events.size() == 1);
+    REQUIRE(events[0].data == "a\n");
+}
+
 TEST_CASE("SseRecordParser: heartbeat comment lines are ignored", "[FilamentScanClient]")
 {
     // Filament DB sends `: hb` every 25s to keep proxies awake. The

--- a/tests/slic3rutils/filamentscanclient_tests.cpp
+++ b/tests/slic3rutils/filamentscanclient_tests.cpp
@@ -166,3 +166,27 @@ TEST_CASE("parse_record: bare `event:` (no space) parses correctly", "[FilamentS
     REQUIRE(ev.event_type == "scan");
     REQUIRE(ev.data       == "x");
 }
+
+TEST_CASE("FilamentScanClient: ctor strips trailing slashes from base URL",
+          "[FilamentScanClient]")
+{
+    using Slic3r::GUI::FilamentScanClient;
+
+    // No slash — passthrough.
+    REQUIRE(FilamentScanClient("http://host:3456").base_url()
+            == "http://host:3456");
+
+    // Single trailing slash — codex P2 case. Without the strip the
+    // scan-stream URL would be "http://host:3456//api/scan/stream"
+    // and miss strict route matches.
+    REQUIRE(FilamentScanClient("http://host:3456/").base_url()
+            == "http://host:3456");
+
+    // Multiple trailing slashes — all stripped.
+    REQUIRE(FilamentScanClient("http://host:3456///").base_url()
+            == "http://host:3456");
+
+    // No path component — defensive; an all-slashes URL is nonsense
+    // but the ctor mustn't infinite-loop or crash.
+    REQUIRE(FilamentScanClient("///").base_url().empty());
+}

--- a/tests/slic3rutils/filamentscanclient_tests.cpp
+++ b/tests/slic3rutils/filamentscanclient_tests.cpp
@@ -83,15 +83,25 @@ TEST_CASE("SseRecordParser: CRLF straddling write-callback chunks", "[FilamentSc
     }
 }
 
-TEST_CASE("SseRecordParser: multi-line data is concatenated", "[FilamentScanClient]")
+TEST_CASE("SseRecordParser: multi-line data is joined with LFs", "[FilamentScanClient]")
 {
-    // The EventSource spec says multiple `data:` lines in a single
-    // record concatenate (with newlines, but our payloads are
-    // single-string JSON so a simple concat is fine for the unit).
+    // Per the EventSource spec, successive `data:` lines in a single
+    // record are concatenated with a single LF between them, with no
+    // trailing LF. Filament DB sends compact single-line JSON so
+    // this is rarely exercised in production, but the parser must
+    // honour the spec for interoperability with other publishers
+    // (codex P2 on PR #13).
     auto events = feed_all("data: part1\ndata: part2\n\n");
     REQUIRE(events.size() == 1);
     REQUIRE(events[0].event_type == "message");
-    REQUIRE(events[0].data       == "part1part2");
+    REQUIRE(events[0].data       == "part1\npart2");
+}
+
+TEST_CASE("SseRecordParser: three data: lines yield two LFs", "[FilamentScanClient]")
+{
+    auto events = feed_all("data: a\ndata: b\ndata: c\n\n");
+    REQUIRE(events.size() == 1);
+    REQUIRE(events[0].data == "a\nb\nc");
 }
 
 TEST_CASE("SseRecordParser: heartbeat comment lines are ignored", "[FilamentScanClient]")

--- a/tests/slic3rutils/filamentscanclient_tests.cpp
+++ b/tests/slic3rutils/filamentscanclient_tests.cpp
@@ -1,0 +1,158 @@
+// Copyright (c) 2026
+// PrusaSlicer is released under the terms of the AGPLv3 or higher
+//
+// Tests for the SSE record parser in FilamentScanClient. Codex flagged
+// (PR #13 P1) that the original LF-only split silently dropped events
+// from a standards-compliant CRLF publisher. The parser now normalises
+// line endings before splitting on the blank-line record separator —
+// these tests pin the LF, CR, and CRLF paths, plus a CRLF straddling
+// two write-callback chunks.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "slic3r/GUI/FilamentScanClient.hpp"
+
+#include <vector>
+
+using namespace Slic3r::GUI::filament_scan_detail;
+
+namespace {
+
+// Convenience: feed an entire string in one chunk and collect events.
+std::vector<ParsedEvent> feed_all(const std::string& s)
+{
+    SseRecordParser           parser;
+    std::vector<ParsedEvent>  events;
+    parser.feed(s.data(), s.size(),
+                [&](const ParsedEvent& ev) { events.push_back(ev); });
+    return events;
+}
+
+} // namespace
+
+TEST_CASE("SseRecordParser: LF line endings (RFC EventSource default)", "[FilamentScanClient]")
+{
+    auto events = feed_all("event: scan\ndata: hello\n\n");
+    REQUIRE(events.size() == 1);
+    REQUIRE(events[0].event_type == "scan");
+    REQUIRE(events[0].data       == "hello");
+}
+
+TEST_CASE("SseRecordParser: CRLF line endings (Windows / many servers)", "[FilamentScanClient]")
+{
+    // The whole record uses \r\n and ends in \r\n\r\n. Before the
+    // parser normalised, this silently produced zero events.
+    auto events = feed_all("event: scan\r\ndata: hello\r\n\r\n");
+    REQUIRE(events.size() == 1);
+    REQUIRE(events[0].event_type == "scan");
+    REQUIRE(events[0].data       == "hello");
+}
+
+TEST_CASE("SseRecordParser: bare-CR line endings (legacy Mac)", "[FilamentScanClient]")
+{
+    // Vanishingly rare in practice, but the EventSource spec lists it
+    // alongside LF/CRLF, so cover it for completeness.
+    auto events = feed_all("event: scan\rdata: hello\r\r");
+    REQUIRE(events.size() == 1);
+    REQUIRE(events[0].event_type == "scan");
+    REQUIRE(events[0].data       == "hello");
+}
+
+TEST_CASE("SseRecordParser: CRLF straddling write-callback chunks", "[FilamentScanClient]")
+{
+    // libcurl can deliver bytes in arbitrary-sized chunks. A CRLF
+    // that crosses a chunk boundary must still normalise to a single
+    // LF — otherwise the buffer accumulates spurious blank lines.
+    SseRecordParser parser;
+    std::vector<ParsedEvent> events;
+    auto emit = [&](const ParsedEvent& ev) { events.push_back(ev); };
+
+    const std::string s = "event: scan\r\ndata: hello\r\n\r\n";
+
+    for (std::size_t boundary = 1; boundary < s.size(); ++boundary) {
+        SECTION("split at byte " + std::to_string(boundary))
+        {
+            events.clear();
+            SseRecordParser p;
+            p.feed(s.data(),            boundary,             emit);
+            p.feed(s.data() + boundary, s.size() - boundary, emit);
+            REQUIRE(events.size() == 1);
+            REQUIRE(events[0].event_type == "scan");
+            REQUIRE(events[0].data       == "hello");
+        }
+    }
+}
+
+TEST_CASE("SseRecordParser: multi-line data is concatenated", "[FilamentScanClient]")
+{
+    // The EventSource spec says multiple `data:` lines in a single
+    // record concatenate (with newlines, but our payloads are
+    // single-string JSON so a simple concat is fine for the unit).
+    auto events = feed_all("data: part1\ndata: part2\n\n");
+    REQUIRE(events.size() == 1);
+    REQUIRE(events[0].event_type == "message");
+    REQUIRE(events[0].data       == "part1part2");
+}
+
+TEST_CASE("SseRecordParser: heartbeat comment lines are ignored", "[FilamentScanClient]")
+{
+    // Filament DB sends `: hb` every 25s to keep proxies awake. The
+    // record (a single comment line followed by a blank line) carries
+    // no data, so no event should be emitted.
+    auto events = feed_all(": hb\n\n");
+    REQUIRE(events.empty());
+}
+
+TEST_CASE("SseRecordParser: retry: lines are ignored", "[FilamentScanClient]")
+{
+    // We run our own reconnect loop with exponential backoff, so
+    // the spec-defined `retry:` field is intentionally a no-op.
+    // It must not look like an `event:` or `data:` field by accident.
+    auto events = feed_all("retry: 5000\nevent: scan\ndata: x\n\n");
+    REQUIRE(events.size() == 1);
+    REQUIRE(events[0].event_type == "scan");
+    REQUIRE(events[0].data       == "x");
+}
+
+TEST_CASE("SseRecordParser: incomplete record buffers without emitting", "[FilamentScanClient]")
+{
+    // A chunk that doesn't yet terminate in a blank line must keep
+    // accumulating in the buffer — no event yet.
+    SseRecordParser parser;
+    std::vector<ParsedEvent> events;
+    auto emit = [&](const ParsedEvent& ev) { events.push_back(ev); };
+    parser.feed("event: scan\ndata: hello", 23, emit);
+    REQUIRE(events.empty());
+    // Now finish it.
+    parser.feed("\n\n", 2, emit);
+    REQUIRE(events.size() == 1);
+    REQUIRE(events[0].event_type == "scan");
+    REQUIRE(events[0].data       == "hello");
+}
+
+TEST_CASE("SseRecordParser: two records back-to-back in one chunk", "[FilamentScanClient]")
+{
+    auto events = feed_all(
+        "event: scan\ndata: first\n\n"
+        "event: scan\ndata: second\n\n");
+    REQUIRE(events.size() == 2);
+    REQUIRE(events[0].data == "first");
+    REQUIRE(events[1].data == "second");
+}
+
+TEST_CASE("SseRecordParser: leading-space stripping after colon", "[FilamentScanClient]")
+{
+    // SSE spec: a single space after the colon is part of the field
+    // syntax and must be stripped. Multiple spaces or tabs are
+    // preserved as data.
+    auto events = feed_all("event: scan\ndata:  spaced\n\n");
+    REQUIRE(events.size() == 1);
+    REQUIRE(events[0].data == " spaced");
+}
+
+TEST_CASE("parse_record: bare `event:` (no space) parses correctly", "[FilamentScanClient]")
+{
+    const ParsedEvent ev = parse_record("event:scan\ndata:x");
+    REQUIRE(ev.event_type == "scan");
+    REQUIRE(ev.data       == "x");
+}


### PR DESCRIPTION
Pairs with [hyiger/filament-db v1.20.0](https://github.com/hyiger/filament-db/releases/tag/v1.20.0). End-to-end live-tested against a CORE One with a real Overture PETG tag.

## What this does

Adds a `FilamentScanClient` that opens a long-lived Server-Sent Events connection to Filament DB's `GET /api/scan/stream?replay=0` and, on each tag read, switches the active filament preset to match. The slicer doesn't have to live on the same machine as Filament DB — anything that can reach the server over HTTP gets the events.

## Wiring

- New [`src/slic3r/GUI/FilamentScanClient.{hpp,cpp}`](src/slic3r/GUI/FilamentScanClient.cpp) — libcurl worker thread, SSE record parser (`event:` / `data:`), nlohmann/json decode, `wxGetApp().CallAfter()` to marshal each event to the GUI thread, `Tab::select_preset(name)` to commit the switch (same path the dropdown takes).
- Reconnect loop with 0.5s → 30s exponential backoff. `CURLOPT_LOW_SPEED_TIME=90s` catches dropped heartbeats. `CURLOPT_XFERINFOFUNCTION` for cooperative cancellation so `stop()` unblocks `curl_easy_perform` between bytes.
- `GUI_App` owns a `std::unique_ptr<FilamentScanClient>` started in `post_init()` (skipped in gcode-viewer mode). Base URL is shared with the existing FilamentDB module via the `filamentdb_url` AppConfig key — clearing it disables both features in lockstep.
- `CMakeLists.txt`: new sources added; `find_package(nlohmann_json REQUIRED)` + link into `libslic3r_gui` (libslic3r links it PRIVATE so the include path doesn't propagate transitively).

## Robustness work after live testing

- **Drop replay-on-connect.** Subscribe with `?replay=0` so opening the slicer minutes after a scan doesn't silently flip the user off the preset they were editing. The 10-minute staleness filter is kept as a defensive fallback on the replay code path if the URL is ever changed.
- **Verify select_preset success.** `Tab::select_preset` returns `true` even when the requested preset isn't compatible with the active printer — PrusaSlicer silently falls back to the closest compatible preset. Re-read `extruders_filaments[0].get_selected_preset()` after the call. If it doesn't match, force-assign via `PresetBundle::set_filament_preset(0, name)`, refresh the sidebar combobox, and surface the result as an in-app warning notification with actionable text. Distinguishes three outcomes (clean switch / extruder-only switch / total failure) and logs each.
- **Strip `@<printer>` suffix on spool-check.** Plater's spool-check call passed `preset->name` verbatim — including the printer-context suffix PrusaSlicer appends. Filament DB stores filament names without that suffix, so the lookup 404'd silently and the insufficient-filament warning never reached the notification manager. `Plater.cpp` now strips everything from `" @"` onward before calling `check_filament_spool`.
- **Unify AppConfig key.** Scan client and spool-check now both read `filamentdb_url`, not two separate keys.

## Verified live against filament-db v1.20.0

- [x] Slicer starts and subscribes: `[FilamentDB] scan client subscribing to http://localhost:3456/api/scan/stream?replay=0`
- [x] Reconnect loop works (live TCP after dev-server bounce, no manual intervention)
- [x] Bogus preset name → `no matching filament preset` log, no preset clobber
- [x] Compatible preset → `switched filament preset from 'X' to 'Y'`, dropdown updates, sidebar combobox refreshes
- [x] Incompatible base preset (pre-v1.20.0 sync) → in-app warning notification with the exact "open Filaments tab, tick Compatible printers" instructions
- [x] Replay-on-connect suppressed (URL ends `?replay=0`; no replay event delivered)
- [x] Race regression: rapid back-to-back scans don't have the older match clobber the newer one

## Pairing notes

filament-db v1.20.0 ([PR #235](https://github.com/hyiger/filament-db/pull/235)) emits `compatible_printers = ` and `compatible_printers_condition = ` (empty) by default in the PrusaSlicer bundle, so re-syncing presets from `FilamentDB → Sync` in the slicer makes any active printer accept any synced filament. After that, the in-app warning notification + force-select fallback in this PR are belt-and-suspenders for users who have stale-synced presets from earlier filament-db versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)