### PR TITLE
Fix retraction tower base unfilled top (#14)

### DIFF
--- a/src/slic3r/GUI/CalibrationRetractionDialog.cpp
+++ b/src/slic3r/GUI/CalibrationRetractionDialog.cpp
@@ -214,9 +214,12 @@ bool CalibrationRetractionDialog::generate_and_load()
         DynamicPrintConfig& config =
             wxGetApp().preset_bundle->prints.get_edited_preset().config;
         config.set_key_value("variable_layer_height", new ConfigOptionBool(false));
-        // 0% infill and no top layers — hollow towers for stringing visibility
+        // 0% infill keeps the cylinders hollow for stringing visibility.
+        // top_solid_layers is left at the preset default so the base's top
+        // surface (the annulus around each cylinder where the cross-section
+        // shrinks at z=1mm) is solid — otherwise the cylinder first layer
+        // prints into mid air and snaps off the base.
         config.set_key_value("fill_density", new ConfigOptionPercent(0));
-        config.set_key_value("top_solid_layers", new ConfigOptionInt(0));
         // Seam nearest — places seams on the sides facing each other
         // (the nozzle travels between the towers, so "nearest" puts the
         // seam on the inward-facing side of each tower)


### PR DESCRIPTION
## Summary
- Removes the global `top_solid_layers = 0` override from the Retraction Tower calibration dialog, which was leaving the base's top annulus unfilled and causing the cylinders' first layer to print on air (issue #14).
- `fill_density = 0` alone keeps the cylinders hollow for stringing visibility; the preset's default top solid layers now properly cap the base.

## Root cause
The retraction tower geometry is a single mesh — a 1 mm rectangular base with two cylinders on top. At z = 1 mm the cross-section shrinks to just the cylinders, so PrusaSlicer detects the annulus around each cylinder as a *top surface* of the base. With `top_solid_layers = 0` that annulus never fills solid, and the cylinder walls land on unsupported air.

The override was originally added "for stringing visibility," but strings on a retraction tower are visible between the towers from the side; a tiny solid cap at the top of each 30+ mm cylinder is irrelevant.

## Test plan
- [ ] Generate a retraction tower (Calibration → Retraction) and slice; verify the top layer of the base above the cylinder rim shows solid infill in the slice preview, not perimeter-only.
- [ ] Print and confirm the cylinder first layer adheres to the base and the towers don't snap off during removal.

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)