### PR TITLE
Rework retraction calibration for Buddy-firmware compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,7 +272,7 @@ This fork adds a **Calibration** menu with built-in calibration tools:
 | Temperature Tower | Multi-tier tower with overhangs, holes, cones, text labels | Per-layer `M104` |
 | Flow Rate (YOLO) | 11 rounded-rect pads with label tabs, Archimedean Chords spiral | Per-object extrusion multiplier |
 | Pressure Advance | Chevron pattern tower | Per-layer `M572 S` / `M900 K` / `SET_PRESSURE_ADVANCE` |
-| Retraction | Two cylindrical towers on base plate (seam=rear) | Per-layer `M207 S` (firmware retraction) |
+| Retraction | Two cylindrical towers on base plate (seam=nearest/inward) | Per-Z-band slicer-side retraction rewrite via in-process post-processor |
 | Max FlowRate | Serpentine E-shape specimen | Per-layer `M220 S` speed override |
 | Extrusion Multiplier | 40×40×40mm vase-mode cube | Vase mode settings |
 | Fan Speed | Two-column tower with shelves, wedges, cones, standalone cylinder | Per-layer `M106 S` |

--- a/src/libslic3r/CMakeLists.txt
+++ b/src/libslic3r/CMakeLists.txt
@@ -171,6 +171,8 @@ set(SLIC3R_SOURCES
     GCode/Thumbnails.hpp
     GCode/ConflictChecker.cpp
     GCode/ConflictChecker.hpp
+    GCode/CalibrationRetractionPostProcessor.cpp
+    GCode/CalibrationRetractionPostProcessor.hpp
     GCode/CoolingBuffer.cpp
     GCode/CoolingBuffer.hpp
     GCode/ExtrusionProcessor.cpp

--- a/src/libslic3r/GCode/CalibrationRetractionPostProcessor.cpp
+++ b/src/libslic3r/GCode/CalibrationRetractionPostProcessor.cpp
@@ -7,6 +7,8 @@
 #include "libslic3r/Exception.hpp"
 #include "libslic3r/format.hpp"
 
+#include <LocalesUtils.hpp>
+
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/log/trivial.hpp>
@@ -32,6 +34,11 @@ bool is_calibration_retraction_url(const std::string &script)
 std::string make_calibration_retraction_url(double base_retract,
                                             const std::vector<std::pair<double, double>> &levels)
 {
+    // Force the C numeric locale so the URL always uses '.' decimals.
+    // PrusaSlicer does not pin LC_NUMERIC globally, and the URL is
+    // comma-delimited — a comma decimal separator would make it ambiguous.
+    CNumericLocalesSetter locales_setter;
+
     std::ostringstream out;
     out << BUILTIN_PREFIX << "?base=";
     char buf[32];
@@ -191,6 +198,13 @@ int extrusion_mode_command(const std::string &line)
 bool run_calibration_retraction_post_processor(const std::string &url, const std::string &gcode_path)
 {
     BOOST_LOG_TRIVIAL(info) << "retraction_calibration: starting in-process post-process on " << gcode_path;
+
+    // Force the C numeric locale for the whole pass: parse_url() uses stod(),
+    // the Z tracker uses stod(), and the rewritten G-code lines are formatted
+    // with snprintf() — all of which must use '.' decimals regardless of the
+    // user's system locale (PrusaSlicer does not pin LC_NUMERIC globally).
+    CNumericLocalesSetter locales_setter;
+
     Params params = parse_url(url);
 
     boost::filesystem::path src(gcode_path);

--- a/src/libslic3r/GCode/CalibrationRetractionPostProcessor.cpp
+++ b/src/libslic3r/GCode/CalibrationRetractionPostProcessor.cpp
@@ -1,0 +1,293 @@
+///|/ Copyright (c) 2025
+///|/
+///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
+///|/
+#include "CalibrationRetractionPostProcessor.hpp"
+
+#include "libslic3r/Exception.hpp"
+#include "libslic3r/format.hpp"
+
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/log/trivial.hpp>
+#include <boost/nowide/fstream.hpp>
+
+#include <algorithm>
+#include <cctype>
+#include <cstdio>
+#include <regex>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace Slic3r {
+
+static constexpr const char *BUILTIN_PREFIX = "::builtin::retraction_calibration";
+
+bool is_calibration_retraction_url(const std::string &script)
+{
+    return boost::starts_with(script, BUILTIN_PREFIX);
+}
+
+std::string make_calibration_retraction_url(double base_retract,
+                                            const std::vector<std::pair<double, double>> &levels)
+{
+    std::ostringstream out;
+    out << BUILTIN_PREFIX << "?base=";
+    char buf[32];
+    std::snprintf(buf, sizeof(buf), "%.4f", base_retract);
+    out << buf << "&levels=";
+    for (size_t i = 0; i < levels.size(); ++i) {
+        if (i != 0) out << ',';
+        std::snprintf(buf, sizeof(buf), "%.4f", levels[i].first);
+        out << buf << ':';
+        std::snprintf(buf, sizeof(buf), "%.4f", levels[i].second);
+        out << buf;
+    }
+    return out.str();
+}
+
+namespace {
+
+struct Params {
+    double base_retract = 0.0;
+    // (z_top_exclusive, retract_mm) sorted ascending by z_top.
+    std::vector<std::pair<double, double>> levels;
+};
+
+// Throws on malformed URL.
+Params parse_url(const std::string &url)
+{
+    auto qpos = url.find('?');
+    if (qpos == std::string::npos)
+        throw Slic3r::RuntimeError(format("retraction_calibration URL has no query string: %1%", url));
+
+    Params p;
+    bool   have_base = false, have_levels = false;
+
+    std::string query = url.substr(qpos + 1);
+    size_t      pos   = 0;
+    while (pos < query.size()) {
+        size_t      amp = query.find('&', pos);
+        std::string kv  = query.substr(pos, amp == std::string::npos ? std::string::npos : amp - pos);
+        pos             = amp == std::string::npos ? query.size() : amp + 1;
+
+        size_t eq = kv.find('=');
+        if (eq == std::string::npos)
+            continue;
+        std::string key = kv.substr(0, eq);
+        std::string val = kv.substr(eq + 1);
+
+        if (key == "base") {
+            p.base_retract = std::stod(val);
+            have_base      = true;
+        } else if (key == "levels") {
+            size_t lp = 0;
+            while (lp < val.size()) {
+                size_t      comma = val.find(',', lp);
+                std::string pair  = val.substr(lp, comma == std::string::npos ? std::string::npos : comma - lp);
+                lp                = comma == std::string::npos ? val.size() : comma + 1;
+                size_t colon      = pair.find(':');
+                if (colon == std::string::npos)
+                    throw Slic3r::RuntimeError(format("retraction_calibration level missing ':': %1%", pair));
+                double z_top   = std::stod(pair.substr(0, colon));
+                double retract = std::stod(pair.substr(colon + 1));
+                p.levels.emplace_back(z_top, retract);
+            }
+            have_levels = true;
+        }
+    }
+
+    if (!have_base || !have_levels || p.levels.empty())
+        throw Slic3r::RuntimeError(format("retraction_calibration URL missing base/levels: %1%", url));
+
+    // Defense: keep levels sorted by z_top ascending so retract_for_z scans cleanly.
+    std::sort(p.levels.begin(), p.levels.end(),
+              [](const auto &a, const auto &b) { return a.first < b.first; });
+    return p;
+}
+
+double retract_for_z(double z, const Params &p)
+{
+    // Z below the first level (i.e. base layers) uses the printer's baseline.
+    // Above the last level (shouldn't normally happen — tower height is bounded)
+    // we clamp to the last test value.
+    if (p.levels.empty() || z < 1.0 - 1e-9)
+        return p.base_retract;
+    for (const auto &lvl : p.levels)
+        if (z < lvl.first - 1e-9)
+            return lvl.second;
+    return p.levels.back().second;
+}
+
+// Try to extract a number after a single-letter axis identifier. Returns true and
+// writes the value into `out` on hit. Searches the substring before any ';' comment.
+bool extract_axis(const std::string &line, char axis, double &out)
+{
+    size_t end = line.find(';');
+    size_t i   = 0;
+    while (i < (end == std::string::npos ? line.size() : end)) {
+        if (line[i] == axis || line[i] == char(std::tolower(axis))) {
+            // Make sure it's not part of an identifier (preceded by whitespace or start).
+            if (i == 0 || std::isspace(static_cast<unsigned char>(line[i - 1]))) {
+                size_t       j = i + 1;
+                const size_t bound = end == std::string::npos ? line.size() : end;
+                // Parse [+-]?[0-9.]+
+                size_t start_num = j;
+                if (j < bound && (line[j] == '+' || line[j] == '-'))
+                    ++j;
+                bool any = false;
+                while (j < bound && (std::isdigit(static_cast<unsigned char>(line[j])) || line[j] == '.')) {
+                    any = true;
+                    ++j;
+                }
+                if (any) {
+                    out = std::stod(line.substr(start_num, j - start_num));
+                    return true;
+                }
+            }
+        }
+        ++i;
+    }
+    return false;
+}
+
+// Returns true if the line is a "retract-only" G1 — has E but no X/Y/Z axis terms.
+bool is_retract_only_g1(const std::string &line)
+{
+    if (line.size() < 3 || line[0] != 'G' || line[1] != '1')
+        return false;
+    if (line.size() >= 3 && std::isdigit(static_cast<unsigned char>(line[2])))
+        return false; // G10, G11, G17 etc.
+    // Must have E.
+    double dummy;
+    if (!extract_axis(line, 'E', dummy))
+        return false;
+    // Must NOT have X, Y, or Z.
+    if (extract_axis(line, 'X', dummy)) return false;
+    if (extract_axis(line, 'Y', dummy)) return false;
+    if (extract_axis(line, 'Z', dummy)) return false;
+    return true;
+}
+
+} // namespace
+
+bool run_calibration_retraction_post_processor(const std::string &url, const std::string &gcode_path)
+{
+    BOOST_LOG_TRIVIAL(info) << "retraction_calibration: starting in-process post-process on " << gcode_path;
+    Params params = parse_url(url);
+
+    boost::filesystem::path src(gcode_path);
+
+    // Defensive: detect binary G-code. PrusaSlicer's post-process pipeline
+    // runs AFTER any binarization, so receiving a .bgcode here means the
+    // caller didn't disable `binary_gcode` for this print. Refuse loudly
+    // rather than silently rewriting zero lines.
+    {
+        boost::nowide::ifstream sniff(gcode_path, std::ios::binary);
+        char magic[4] = {};
+        sniff.read(magic, 4);
+        if (sniff.gcount() == 4 && std::string(magic, 4) == "GCDE")
+            throw Slic3r::RuntimeError(format(
+                "retraction_calibration: input %1% is binary G-code (.bgcode); "
+                "the in-process rewriter only operates on ASCII. Set binary_gcode=false "
+                "on the printer config for calibration prints.",
+                gcode_path));
+    }
+
+    boost::filesystem::path tmp = src;
+    tmp += ".retcal.tmp";
+
+    boost::nowide::ifstream in(gcode_path);
+    if (!in.is_open())
+        throw Slic3r::RuntimeError(format("retraction_calibration: cannot open %1%", gcode_path));
+    boost::nowide::ofstream out(tmp.string(), std::ios::binary | std::ios::trunc);
+    if (!out.is_open())
+        throw Slic3r::RuntimeError(format("retraction_calibration: cannot write %1%", tmp.string()));
+
+    static const std::regex z_comment(R"(^;Z:\s*([0-9.]+))");
+
+    double      current_z          = 0.0;
+    double      last_retract       = 0.0;
+    bool        has_pending_retract = false;
+    size_t      rewrites           = 0;
+    std::string line;
+    line.reserve(256);
+
+    while (std::getline(in, line)) {
+        // Strip trailing CR if present (Windows line endings).
+        if (!line.empty() && line.back() == '\r')
+            line.pop_back();
+
+        // Z tracking.
+        std::smatch m;
+        if (std::regex_search(line, m, z_comment)) {
+            current_z = std::stod(m[1].str());
+        } else {
+            double z;
+            if (extract_axis(line, 'Z', z))
+                current_z = z;
+        }
+
+        // Rewrite retract/recovery lines.
+        //
+        // Retracts use the level for the current Z. Recoveries use the *same*
+        // value as the matching prior retract — NOT a fresh lookup by Z. This
+        // matters at band boundaries: the layer-change retract emits in band N
+        // but its recovery lands at the start of layer N+1 where retract_for_z
+        // would return band N+1's value. That mismatch would dump 0.1 mm of
+        // extra plastic at every level-boundary seam (visible as tufts on the
+        // inward face of the towers).
+        if (is_retract_only_g1(line)) {
+            double e_val = 0.0;
+            extract_axis(line, 'E', e_val);
+            double new_e = 0.0;
+            char   tag   = ' ';
+            if (e_val < 0.0) {
+                last_retract        = retract_for_z(current_z, params);
+                has_pending_retract = true;
+                new_e               = -last_retract;
+                tag                 = 'r'; // retract
+            } else if (e_val > 0.0) {
+                double recovery = has_pending_retract
+                    ? last_retract
+                    : retract_for_z(current_z, params);
+                has_pending_retract = false;
+                new_e               = recovery;
+                tag                 = 'R'; // recovery (deretract)
+            }
+            // Preserve feedrate if present.
+            double f_val  = 0.0;
+            bool   have_f = extract_axis(line, 'F', f_val);
+            char   buf[128];
+            if (have_f) {
+                std::snprintf(buf, sizeof(buf), "G1 E%.4f F%g ; %c z=%.2f", new_e, f_val, tag, current_z);
+            } else {
+                std::snprintf(buf, sizeof(buf), "G1 E%.4f ; %c z=%.2f", new_e, tag, current_z);
+            }
+            line = buf;
+            ++rewrites;
+        }
+
+        out << line << '\n';
+    }
+
+    in.close();
+    out.close();
+
+    boost::system::error_code ec;
+    boost::filesystem::rename(tmp, src, ec);
+    if (ec) {
+        // Fallback: copy + remove. rename can fail across filesystems.
+        boost::filesystem::copy_file(tmp, src, boost::filesystem::copy_options::overwrite_existing, ec);
+        if (ec)
+            throw Slic3r::RuntimeError(format("retraction_calibration: failed replacing %1%: %2%",
+                                              src.string(), ec.message()));
+        boost::filesystem::remove(tmp, ec);
+    }
+
+    BOOST_LOG_TRIVIAL(info) << "retraction_calibration: rewrote " << rewrites << " retract/recovery lines";
+    return true;
+}
+
+} // namespace Slic3r

--- a/src/libslic3r/GCode/CalibrationRetractionPostProcessor.cpp
+++ b/src/libslic3r/GCode/CalibrationRetractionPostProcessor.cpp
@@ -195,10 +195,35 @@ bool run_calibration_retraction_post_processor(const std::string &url, const std
 
     boost::filesystem::path src(gcode_path);
 
-    // Defensive: detect binary G-code. PrusaSlicer's post-process pipeline
-    // runs AFTER any binarization, so receiving a .bgcode here means the
-    // caller didn't disable `binary_gcode` for this print. Refuse loudly
-    // rather than silently rewriting zero lines.
+    // Pass 1 — confirm this G-code is actually a retraction calibration print.
+    // The `post_process` hook persists in the print preset, so this runs for
+    // EVERY slice made with that preset. Only a G-code carrying the job-scoped
+    // calibration marker should be rewritten; anything else is passed through
+    // untouched. This also makes a normal .bgcode export a clean no-op (the
+    // ASCII marker cannot appear in a binarized file) rather than an error.
+    {
+        boost::nowide::ifstream scan(gcode_path);
+        if (!scan.is_open())
+            throw Slic3r::RuntimeError(format("retraction_calibration: cannot open %1%", gcode_path));
+        const std::string marker = calibration_retraction_marker();
+        bool              found  = false;
+        std::string       l;
+        while (std::getline(scan, l)) {
+            if (l.find(marker) != std::string::npos) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            BOOST_LOG_TRIVIAL(info) << "retraction_calibration: marker absent, leaving "
+                                    << gcode_path << " unchanged";
+            return false;
+        }
+    }
+
+    // Defensive: a marker-carrying file should always be ASCII (the dialog
+    // forces binary_gcode=false). Detect binary G-code anyway and refuse
+    // loudly rather than scribbling over a binarized payload.
     {
         boost::nowide::ifstream sniff(gcode_path, std::ios::binary);
         char magic[4] = {};

--- a/src/libslic3r/GCode/CalibrationRetractionPostProcessor.cpp
+++ b/src/libslic3r/GCode/CalibrationRetractionPostProcessor.cpp
@@ -278,6 +278,12 @@ bool run_calibration_retraction_post_processor(const std::string &url, const std
     // one is present (e.g. an unexpectedly short print) the body simply runs
     // to EOF.
     bool              inside_body        = false;
+    // The closing marker emits at the start of the last layer — between a
+    // layer-change retract and its recovery. Dropping out of the body there
+    // would rewrite the retract but leave the recovery at the sentinel value.
+    // When the closing marker arrives mid-pair, defer the exit until that
+    // recovery has been processed.
+    bool              closing_after_recovery = false;
     size_t            rewrites           = 0;
     std::string       line;
     line.reserve(256);
@@ -289,7 +295,12 @@ bool run_calibration_retraction_post_processor(const std::string &url, const std
 
         // Marker toggles the tower-body region.
         if (line.find(marker) != std::string::npos) {
-            inside_body = !inside_body;
+            if (!inside_body)
+                inside_body = true;                  // opening marker
+            else if (has_pending_retract)
+                closing_after_recovery = true;       // closing marker: finish the open pair first
+            else
+                inside_body = false;                 // closing marker: no open pair
             out << line << '\n';
             continue;
         }
@@ -365,6 +376,13 @@ bool run_calibration_retraction_post_processor(const std::string &url, const std
                 line = buf;
                 ++rewrites;
             }
+        }
+
+        // A closing marker arrived while a retract was still open; now that
+        // its recovery has been emitted, leave the tower body.
+        if (closing_after_recovery && !has_pending_retract) {
+            inside_body            = false;
+            closing_after_recovery = false;
         }
 
         out << line << '\n';

--- a/src/libslic3r/GCode/CalibrationRetractionPostProcessor.cpp
+++ b/src/libslic3r/GCode/CalibrationRetractionPostProcessor.cpp
@@ -262,22 +262,37 @@ bool run_calibration_retraction_post_processor(const std::string &url, const std
 
     static const std::regex z_comment(R"(^;Z:\s*([0-9.]+))");
 
-    double      current_z          = 0.0;
-    double      last_retract       = 0.0;
-    bool        has_pending_retract = false;
+    const std::string marker             = calibration_retraction_marker();
+    double            current_z          = 0.0;
+    double            last_retract       = 0.0;
+    bool              has_pending_retract = false;
     // The retract/recovery classifier keys off the sign of E, which is only
     // meaningful in relative-E mode. The calibration dialog forces relative E
     // (use_relative_e_distances=true), so default to that; track M82/M83 in
     // case a hand-edited start G-code or a future regression flips it.
-    bool        relative_e         = true;
-    size_t      rewrites           = 0;
-    std::string line;
+    bool              relative_e         = true;
+    // Only retractions *between* the two markers (first layer / last layer)
+    // belong to the tower body. Retractions before the first marker (start
+    // G-code) and after the second (end G-code) are nozzle priming / cleanup
+    // and must be left intact. The dialog emits exactly two markers; if only
+    // one is present (e.g. an unexpectedly short print) the body simply runs
+    // to EOF.
+    bool              inside_body        = false;
+    size_t            rewrites           = 0;
+    std::string       line;
     line.reserve(256);
 
     while (std::getline(in, line)) {
         // Strip trailing CR if present (Windows line endings).
         if (!line.empty() && line.back() == '\r')
             line.pop_back();
+
+        // Marker toggles the tower-body region.
+        if (line.find(marker) != std::string::npos) {
+            inside_body = !inside_body;
+            out << line << '\n';
+            continue;
+        }
 
         // Z tracking.
         std::smatch m;
@@ -293,7 +308,8 @@ bool run_calibration_retraction_post_processor(const std::string &url, const std
         if (int mode = extrusion_mode_command(line); mode != 0)
             relative_e = (mode == 83);
 
-        // Rewrite retract/recovery lines.
+        // Rewrite retract/recovery lines — but only inside the tower body, so
+        // start/end-G-code priming retracts are left untouched.
         //
         // Retracts use the level for the current Z. Recoveries use the *same*
         // value as the matching prior retract — NOT a fresh lookup by Z. This
@@ -302,7 +318,7 @@ bool run_calibration_retraction_post_processor(const std::string &url, const std
         // would return band N+1's value. That mismatch would dump 0.1 mm of
         // extra plastic at every level-boundary seam (visible as tufts on the
         // inward face of the towers).
-        if (is_retract_only_g1(line)) {
+        if (inside_body && is_retract_only_g1(line)) {
             // Sign-based retract/recovery classification is only valid in
             // relative-E mode. In absolute-E mode a retract is a smaller
             // absolute coordinate (usually still positive) and would be

--- a/src/libslic3r/GCode/CalibrationRetractionPostProcessor.cpp
+++ b/src/libslic3r/GCode/CalibrationRetractionPostProcessor.cpp
@@ -170,6 +170,22 @@ bool is_retract_only_g1(const std::string &line)
     return true;
 }
 
+// Returns 83 for an M83 line (relative E), 82 for M82 (absolute E), 0 otherwise.
+// The trailing char after the number must be a separator so M820 etc. don't match.
+int extrusion_mode_command(const std::string &line)
+{
+    if (line.size() < 3 || line[0] != 'M' || line[1] != '8')
+        return 0;
+    if (line[2] != '2' && line[2] != '3')
+        return 0;
+    if (line.size() > 3) {
+        char c = line[3];
+        if (!std::isspace(static_cast<unsigned char>(c)) && c != ';')
+            return 0;
+    }
+    return line[2] == '2' ? 82 : 83;
+}
+
 } // namespace
 
 bool run_calibration_retraction_post_processor(const std::string &url, const std::string &gcode_path)
@@ -210,6 +226,11 @@ bool run_calibration_retraction_post_processor(const std::string &url, const std
     double      current_z          = 0.0;
     double      last_retract       = 0.0;
     bool        has_pending_retract = false;
+    // The retract/recovery classifier keys off the sign of E, which is only
+    // meaningful in relative-E mode. The calibration dialog forces relative E
+    // (use_relative_e_distances=true), so default to that; track M82/M83 in
+    // case a hand-edited start G-code or a future regression flips it.
+    bool        relative_e         = true;
     size_t      rewrites           = 0;
     std::string line;
     line.reserve(256);
@@ -229,6 +250,10 @@ bool run_calibration_retraction_post_processor(const std::string &url, const std
                 current_z = z;
         }
 
+        // Extrusion-distance mode tracking.
+        if (int mode = extrusion_mode_command(line); mode != 0)
+            relative_e = (mode == 83);
+
         // Rewrite retract/recovery lines.
         //
         // Retracts use the level for the current Z. Recoveries use the *same*
@@ -239,6 +264,16 @@ bool run_calibration_retraction_post_processor(const std::string &url, const std
         // extra plastic at every level-boundary seam (visible as tufts on the
         // inward face of the towers).
         if (is_retract_only_g1(line)) {
+            // Sign-based retract/recovery classification is only valid in
+            // relative-E mode. In absolute-E mode a retract is a smaller
+            // absolute coordinate (usually still positive) and would be
+            // misread as a recovery — refuse rather than corrupt the print.
+            if (!relative_e)
+                throw Slic3r::RuntimeError(format(
+                    "retraction_calibration: %1% uses absolute E distances (M82); "
+                    "the rewriter requires relative E (M83). Set "
+                    "use_relative_e_distances=true on the printer config.",
+                    gcode_path));
             double e_val = 0.0;
             extract_axis(line, 'E', e_val);
             double new_e = 0.0;

--- a/src/libslic3r/GCode/CalibrationRetractionPostProcessor.cpp
+++ b/src/libslic3r/GCode/CalibrationRetractionPostProcessor.cpp
@@ -276,32 +276,40 @@ bool run_calibration_retraction_post_processor(const std::string &url, const std
                     gcode_path));
             double e_val = 0.0;
             extract_axis(line, 'E', e_val);
-            double new_e = 0.0;
-            char   tag   = ' ';
-            if (e_val < 0.0) {
-                last_retract        = retract_for_z(current_z, params);
-                has_pending_retract = true;
-                new_e               = -last_retract;
-                tag                 = 'r'; // retract
-            } else if (e_val > 0.0) {
-                double recovery = has_pending_retract
-                    ? last_retract
-                    : retract_for_z(current_z, params);
-                has_pending_retract = false;
-                new_e               = recovery;
-                tag                 = 'R'; // recovery (deretract)
+
+            // Only rewrite genuine retract/recovery pairs:
+            //  - a retract is a negative-E move;
+            //  - a recovery is a positive-E move that follows a retract.
+            // A standalone positive-E move with no pending retract is a
+            // prime / unload / custom-G-code command (default profiles emit
+            // e.g. `G1 E2` / `G1 E10`) and must be passed through untouched —
+            // forcing it to a retraction value would corrupt those sequences.
+            const bool is_retract  = e_val < 0.0;
+            const bool is_recovery = e_val > 0.0 && has_pending_retract;
+            if (is_retract || is_recovery) {
+                double new_e;
+                char   tag;
+                if (is_retract) {
+                    last_retract        = retract_for_z(current_z, params);
+                    has_pending_retract = true;
+                    new_e               = -last_retract;
+                    tag                 = 'r'; // retract
+                } else {
+                    new_e               = last_retract;
+                    has_pending_retract = false;
+                    tag                 = 'R'; // recovery (deretract)
+                }
+                // Preserve feedrate if present.
+                double f_val  = 0.0;
+                bool   have_f = extract_axis(line, 'F', f_val);
+                char   buf[128];
+                if (have_f)
+                    std::snprintf(buf, sizeof(buf), "G1 E%.4f F%g ; %c z=%.2f", new_e, f_val, tag, current_z);
+                else
+                    std::snprintf(buf, sizeof(buf), "G1 E%.4f ; %c z=%.2f", new_e, tag, current_z);
+                line = buf;
+                ++rewrites;
             }
-            // Preserve feedrate if present.
-            double f_val  = 0.0;
-            bool   have_f = extract_axis(line, 'F', f_val);
-            char   buf[128];
-            if (have_f) {
-                std::snprintf(buf, sizeof(buf), "G1 E%.4f F%g ; %c z=%.2f", new_e, f_val, tag, current_z);
-            } else {
-                std::snprintf(buf, sizeof(buf), "G1 E%.4f ; %c z=%.2f", new_e, tag, current_z);
-            }
-            line = buf;
-            ++rewrites;
         }
 
         out << line << '\n';

--- a/src/libslic3r/GCode/CalibrationRetractionPostProcessor.hpp
+++ b/src/libslic3r/GCode/CalibrationRetractionPostProcessor.hpp
@@ -1,0 +1,41 @@
+///|/ Copyright (c) 2025
+///|/
+///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
+///|/
+#ifndef slic3r_CalibrationRetractionPostProcessor_hpp_
+#define slic3r_CalibrationRetractionPostProcessor_hpp_
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace Slic3r {
+
+// In-process post-processor for the Filament-Edition Retraction Calibration.
+//
+// Triggered via the standard `post_process` config when one of its entries
+// starts with the `::builtin::retraction_calibration?...` prefix (see
+// is_calibration_retraction_url). Rewrites slicer-side retract/recovery
+// moves so that each Z band uses a per-band retraction distance, instead
+// of the global retract_length the slicer baked in. Targets Buddy firmware,
+// which does not implement M207/G10/G11 (so the firmware-retraction path
+// the dialog used previously is a no-op there).
+//
+// URL format:
+//     ::builtin::retraction_calibration?base=<mm>&levels=<z>:<mm>,<z>:<mm>,...
+// where each `<z>:<mm>` pair is `z_top_exclusive:retract_mm` ascending by z_top.
+
+bool is_calibration_retraction_url(const std::string &script);
+
+// Run the in-process post-processor against `gcode_path` using the parameters
+// embedded in `url`. Returns true on success. Throws Slic3r::RuntimeError on
+// malformed URL or unreadable file.
+bool run_calibration_retraction_post_processor(const std::string &url, const std::string &gcode_path);
+
+// Build a `::builtin::retraction_calibration?...` URL from a level table.
+std::string make_calibration_retraction_url(double base_retract,
+                                            const std::vector<std::pair<double, double>> &levels);
+
+} // namespace Slic3r
+
+#endif // slic3r_CalibrationRetractionPostProcessor_hpp_

--- a/src/libslic3r/GCode/CalibrationRetractionPostProcessor.hpp
+++ b/src/libslic3r/GCode/CalibrationRetractionPostProcessor.hpp
@@ -27,9 +27,22 @@ namespace Slic3r {
 
 bool is_calibration_retraction_url(const std::string &script);
 
+// Comment the calibration dialog injects into the sliced G-code (job-scoped,
+// via the model's custom per-Z G-code). The `post_process` hook lives in the
+// print *preset* and therefore runs for every subsequent slice; the
+// post-processor rewrites ONLY a G-code that carries this marker and is a
+// pass-through no-op for any normal print. The marker is wiped automatically
+// when a different model is loaded, so it cannot leak across jobs.
+inline constexpr const char *calibration_retraction_marker()
+{
+    return "PRUSASLICER_RETRACTION_CALIBRATION_TOWER";
+}
+
 // Run the in-process post-processor against `gcode_path` using the parameters
-// embedded in `url`. Returns true on success. Throws Slic3r::RuntimeError on
-// malformed URL or unreadable file.
+// embedded in `url`. Returns true if the G-code was rewritten, false if it was
+// left untouched (no calibration marker present — i.e. not a calibration
+// print). Throws Slic3r::RuntimeError on a malformed URL, an unreadable file,
+// or a marker-carrying G-code that is binary or absolute-E.
 bool run_calibration_retraction_post_processor(const std::string &url, const std::string &gcode_path);
 
 // Build a `::builtin::retraction_calibration?...` URL from a level table.

--- a/src/libslic3r/GCode/PostProcessor.cpp
+++ b/src/libslic3r/GCode/PostProcessor.cpp
@@ -4,6 +4,7 @@
 ///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
 ///|/
 #include "PostProcessor.hpp"
+#include "CalibrationRetractionPostProcessor.hpp"
 
 #include "libslic3r/Utils.hpp"
 #include "libslic3r/format.hpp"
@@ -276,6 +277,20 @@ bool run_post_process_scripts(std::string &src_path, bool make_copy, const std::
                 boost::trim(script);
                 if (script.empty())
                     continue;
+                // In-process built-ins (no external interpreter needed).
+                // Triggered by the Filament-Edition Retraction Calibration dialog.
+                if (is_calibration_retraction_url(script)) {
+                    BOOST_LOG_TRIVIAL(info) << "Running built-in post-processor: " << script;
+                    try {
+                        run_calibration_retraction_post_processor(script, gcode_file.string());
+                    } catch (const std::exception &err) {
+                        delete_copy();
+                        throw Slic3r::RuntimeError(
+                            (boost::format("Built-in post-processor %1% on file %2% failed:\n%3%")
+                                 % script % path % err.what()).str());
+                    }
+                    continue;
+                }
                 BOOST_LOG_TRIVIAL(info) << "Executing script " << script << " on file " << path;
                 std::string std_err;
                 const int result = run_script(script, gcode_file.string(), std_err);

--- a/src/slic3r/GUI/CalibrationRetractionDialog.cpp
+++ b/src/slic3r/GUI/CalibrationRetractionDialog.cpp
@@ -266,6 +266,21 @@ bool CalibrationRetractionDialog::generate_and_load()
         // accepts .gcode just fine.
         printer_config.set_key_value("binary_gcode", new ConfigOptionBool(false));
 
+        // Force relative E distances. The post-processor classifies a
+        // retract-only `G1 E…` move by the sign of E (negative = retract,
+        // positive = recovery). That only holds in relative-E mode; with
+        // absolute E a retract is just a smaller absolute coordinate and is
+        // usually still positive, so it would be misread as a recovery and
+        // rewritten to a tiny absolute position. Pinning relative E keeps the
+        // sign-based classification valid.
+        printer_config.set_key_value("use_relative_e_distances", new ConfigOptionBool(true));
+
+        // Force linear (non-volumetric) E. With volumetric extrusion the E
+        // axis is in mm^3; the post-processor writes retraction lengths in
+        // linear mm, so volumetric mode would scale every test band by the
+        // filament cross-section and invalidate the calibration.
+        printer_config.set_key_value("use_volumetric_e", new ConfigOptionBool(false));
+
         // Set retract_length to the maximum test value across every extruder
         // entry. Every travel will retract by `end` until the post-process
         // pass rewrites it.

--- a/src/slic3r/GUI/CalibrationRetractionDialog.cpp
+++ b/src/slic3r/GUI/CalibrationRetractionDialog.cpp
@@ -210,25 +210,36 @@ bool CalibrationRetractionDialog::generate_and_load()
     std::vector<boost::filesystem::path> paths = { stl_path };
     plater->load_files(paths, true, false);
 
-    // Inject a job-scoped calibration marker via the model's custom per-Z
-    // G-code. The post_process hook below lives in the print *preset* and so
-    // runs for every later slice; the post-processor only rewrites a G-code
-    // that carries this marker comment. custom_gcode_per_print_z belongs to
-    // the model, so loading any other model clears it — a normal print is
-    // then passed through untouched even while the preset still carries the
-    // hook.
+    // Inject job-scoped calibration markers via the model's custom per-Z
+    // G-code. Two markers are emitted — one at the first layer, one at the
+    // last — bracketing the tower body. They serve two purposes:
+    //  1. The post_process hook below lives in the print *preset* and runs for
+    //     every later slice; the post-processor only rewrites a G-code that
+    //     carries this marker, so a normal print is passed through untouched.
+    //     custom_gcode_per_print_z belongs to the model, so loading any other
+    //     model clears the markers.
+    //  2. The post-processor only rewrites retractions *between* the two
+    //     markers, so retracts in the user/profile start and end G-code
+    //     (nozzle priming / cleanup) are left intact.
     {
         Model& model = wxGetApp().model();
         CustomGCode::Info& cg = model.custom_gcode_per_print_z();
         cg.mode = CustomGCode::SingleExtruder;
         cg.gcodes.clear();
-        CustomGCode::Item marker;
-        marker.print_z  = layer_height / 2.0;  // mid first layer — always emitted
-        marker.type     = CustomGCode::Custom;
-        marker.extruder = 1;
-        marker.color    = "";
-        marker.extra    = std::string("; ") + calibration_retraction_marker() + "\n";
-        cg.gcodes.push_back(marker);
+        const std::string marker_line =
+            std::string("; ") + calibration_retraction_marker() + "\n";
+        auto add_marker = [&](double z) {
+            CustomGCode::Item marker;
+            marker.print_z  = z;
+            marker.type     = CustomGCode::Custom;
+            marker.extruder = 1;
+            marker.color    = "";
+            marker.extra    = marker_line;
+            cg.gcodes.push_back(marker);
+        };
+        add_marker(layer_height / 2.0);                   // start of body (first layer)
+        add_marker(actual_height - layer_height / 2.0);   // end of body (last layer)
+        std::sort(cg.gcodes.begin(), cg.gcodes.end());
     }
 
     // Reset print config and apply overrides

--- a/src/slic3r/GUI/CalibrationRetractionDialog.cpp
+++ b/src/slic3r/GUI/CalibrationRetractionDialog.cpp
@@ -313,8 +313,23 @@ bool CalibrationRetractionDialog::generate_and_load()
     {
         DynamicPrintConfig& print_config =
             wxGetApp().preset_bundle->prints.get_edited_preset().config;
-        print_config.set_key_value("post_process",
-            new ConfigOptionStrings(std::vector<std::string>{ builtin_url }));
+
+        // Append the built-in hook to any user-configured post-processing
+        // scripts rather than replacing the list — overwriting it would
+        // silently drop the user's scripts (delivery hooks, file transforms)
+        // for this slice and leave them dropped in the edited preset. Strip
+        // any stale calibration hook from a previous run so re-opening the
+        // dialog stays idempotent.
+        std::vector<std::string> scripts;
+        if (const auto* pp = print_config.option<ConfigOptionStrings>("post_process"))
+            scripts = pp->values;
+        scripts.erase(std::remove_if(scripts.begin(), scripts.end(),
+                          [](const std::string& s) {
+                              return is_calibration_retraction_url(s);
+                          }),
+                      scripts.end());
+        scripts.push_back(builtin_url);
+        print_config.set_key_value("post_process", new ConfigOptionStrings(scripts));
         wxGetApp().get_tab(Preset::TYPE_PRINT)->reload_config();
     }
 

--- a/src/slic3r/GUI/CalibrationRetractionDialog.cpp
+++ b/src/slic3r/GUI/CalibrationRetractionDialog.cpp
@@ -9,10 +9,10 @@
 
 #include "libslic3r/PresetBundle.hpp"
 #include "libslic3r/PrintConfig.hpp"
-#include "libslic3r/CustomGCode.hpp"
 #include "libslic3r/Model.hpp"
 #include "libslic3r/CalibrationModels.hpp"
 #include "libslic3r/TriangleMesh.hpp"
+#include "libslic3r/GCode/CalibrationRetractionPostProcessor.hpp"
 
 #include <wx/sizer.h>
 #include <wx/stattext.h>
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <cmath>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace Slic3r { namespace GUI {
@@ -220,9 +221,16 @@ bool CalibrationRetractionDialog::generate_and_load()
         // shrinks at z=1mm) is solid — otherwise the cylinder first layer
         // prints into mid air and snaps off the base.
         config.set_key_value("fill_density", new ConfigOptionPercent(0));
-        // Seam nearest — places seams on the sides facing each other
-        // (the nozzle travels between the towers, so "nearest" puts the
-        // seam on the inward-facing side of each tower)
+        // Seam = nearest, which places the seam on the inward face of each
+        // tower. This is REQUIRED, not cosmetic: the seam is the perimeter
+        // start/end point, and the inter-tower travel runs seam-to-seam.
+        // Inward seams route that travel straight across the observation gap,
+        // so stringing forms where it can be seen. spRear would route the
+        // travel along the back (+Y) instead — the strings would still form,
+        // just out of view, making the gap look deceptively clean.
+        // The seam also accumulates a small deretract blob each layer; that
+        // ridge is itself a valid retraction signal (thick at low-retract
+        // bands, clean at high-retract bands), not contamination.
         config.set_key_value("seam_position",
             new ConfigOptionEnum<SeamPosition>(spNearest));
         if (m_brim && m_brim->GetValue())
@@ -231,45 +239,75 @@ bool CalibrationRetractionDialog::generate_and_load()
             config.set_key_value("brim_width", new ConfigOptionFloat(0.0));
         wxGetApp().get_tab(Preset::TYPE_PRINT)->reload_config();
     }
-    // Enable firmware retraction on the printer preset so PrusaSlicer emits
-    // G10/G11 instead of slicer-side G1 E retracts. Without this, the
-    // per-layer M207 commands have no effect.
-    // Discard first so we start from the saved preset state.
+
+    // Read the printer's baseline retract_length so the base layers print
+    // with the user's normal retraction setting, only varying inside the
+    // tower section. Use the maximum test value as a slicer-side sentinel:
+    // PrusaSlicer will emit explicit `G1 E-<end>` retracts at every travel,
+    // and our post-process script rewrites each one based on Z.
+    double base_retract = 0.7;
     wxGetApp().preset_bundle->printers.discard_current_changes();
     {
         DynamicPrintConfig& printer_config =
             wxGetApp().preset_bundle->printers.get_edited_preset().config;
-        printer_config.set_key_value("use_firmware_retraction", new ConfigOptionBool(true));
+        const auto* opt_rl = printer_config.option<ConfigOptionFloats>("retract_length");
+        if (opt_rl && !opt_rl->empty())
+            base_retract = opt_rl->get_at(0);
+
+        // Buddy firmware (Core One / MK4 / MK4S / MK3.5 / MINI / iX / XL)
+        // does NOT implement M207/G10/G11. Force slicer-side retraction so
+        // PrusaSlicer emits real `G1 E-x` moves that the firmware actually
+        // honors.
+        printer_config.set_key_value("use_firmware_retraction", new ConfigOptionBool(false));
+
+        // Force ASCII G-code output. PrusaSlicer writes binary G-code directly
+        // during export and only THEN runs post-process scripts, so our text
+        // rewriter sees a sealed .bgcode and has nothing to rewrite. Buddy
+        // accepts .gcode just fine.
+        printer_config.set_key_value("binary_gcode", new ConfigOptionBool(false));
+
+        // Set retract_length to the maximum test value across every extruder
+        // entry. Every travel will retract by `end` until the post-process
+        // pass rewrites it.
+        size_t num_extruders = opt_rl ? std::max<size_t>(opt_rl->size(), 1) : 1;
+        std::vector<double> rl_values(num_extruders, end);
+        printer_config.set_key_value("retract_length", new ConfigOptionFloats(rl_values));
+
+        // Force retract == recovery so the rewrite is symmetric.
+        std::vector<double> zero_values(num_extruders, 0.0);
+        printer_config.set_key_value("retract_restart_extra", new ConfigOptionFloats(zero_values));
+
         wxGetApp().get_tab(Preset::TYPE_PRINTER)->reload_config();
     }
 
-    // Insert per-layer retraction commands (M207 S<value>)
-    auto fmt = [](double v) -> std::string {
-        char buf[32];
-        std::snprintf(buf, sizeof(buf), "%.2f", v);
-        return buf;
-    };
-
-    Model& model = wxGetApp().model();
-    auto& info = model.custom_gcode_per_print_z();
-    info.mode = CustomGCode::SingleExtruder;
-    info.gcodes.clear();
-
+    // --- Wire up the in-process post-processor ---
+    //
+    // PrusaSlicer's `post_process` config accepts a list of script paths. We
+    // use a `::builtin::` URL that PostProcessor.cpp intercepts and dispatches
+    // to `Slic3r::run_calibration_retraction_post_processor()` — no external
+    // interpreter, no temp script file, no platform dependencies.
+    std::vector<std::pair<double, double>> levels;
+    levels.reserve(num_levels);
     for (int i = 0; i < num_levels; ++i) {
-        double z = 1.0 + i * level_height + layer_height / 2.0; // 1.0 = base height
+        double z_top   = 1.0 + double(i + 1) * level_height;
         double retract = start + i * step;
-
-        CustomGCode::Item item;
-        item.print_z  = z;
-        item.type     = CustomGCode::Custom;
-        item.extruder = 1;
-        item.color    = "";
-        item.extra    = "M207 S" + fmt(retract) + " ; retraction " + fmt(retract) + "mm\n";
-        info.gcodes.push_back(item);
+        levels.emplace_back(z_top, retract);
     }
-    std::sort(info.gcodes.begin(), info.gcodes.end());
+    std::string builtin_url = make_calibration_retraction_url(base_retract, levels);
 
-    // Clean up temp file
+    {
+        DynamicPrintConfig& print_config =
+            wxGetApp().preset_bundle->prints.get_edited_preset().config;
+        print_config.set_key_value("post_process",
+            new ConfigOptionStrings(std::vector<std::string>{ builtin_url }));
+        wxGetApp().get_tab(Preset::TYPE_PRINT)->reload_config();
+    }
+
+    BOOST_LOG_TRIVIAL(info) << "Retraction calibration: post-process URL " << builtin_url
+                            << ", base_retract=" << base_retract
+                            << ", levels=" << num_levels;
+
+    // Clean up temp STL
     boost::filesystem::remove(stl_path);
 
     return true;

--- a/src/slic3r/GUI/CalibrationRetractionDialog.cpp
+++ b/src/slic3r/GUI/CalibrationRetractionDialog.cpp
@@ -10,6 +10,7 @@
 #include "libslic3r/PresetBundle.hpp"
 #include "libslic3r/PrintConfig.hpp"
 #include "libslic3r/Model.hpp"
+#include "libslic3r/CustomGCode.hpp"
 #include "libslic3r/CalibrationModels.hpp"
 #include "libslic3r/TriangleMesh.hpp"
 #include "libslic3r/GCode/CalibrationRetractionPostProcessor.hpp"
@@ -208,6 +209,27 @@ bool CalibrationRetractionDialog::generate_and_load()
 
     std::vector<boost::filesystem::path> paths = { stl_path };
     plater->load_files(paths, true, false);
+
+    // Inject a job-scoped calibration marker via the model's custom per-Z
+    // G-code. The post_process hook below lives in the print *preset* and so
+    // runs for every later slice; the post-processor only rewrites a G-code
+    // that carries this marker comment. custom_gcode_per_print_z belongs to
+    // the model, so loading any other model clears it — a normal print is
+    // then passed through untouched even while the preset still carries the
+    // hook.
+    {
+        Model& model = wxGetApp().model();
+        CustomGCode::Info& cg = model.custom_gcode_per_print_z();
+        cg.mode = CustomGCode::SingleExtruder;
+        cg.gcodes.clear();
+        CustomGCode::Item marker;
+        marker.print_z  = layer_height / 2.0;  // mid first layer — always emitted
+        marker.type     = CustomGCode::Custom;
+        marker.extruder = 1;
+        marker.color    = "";
+        marker.extra    = std::string("; ") + calibration_retraction_marker() + "\n";
+        cg.gcodes.push_back(marker);
+    }
 
     // Reset print config and apply overrides
     wxGetApp().preset_bundle->prints.discard_current_changes();

--- a/src/slic3r/GUI/CalibrationRetractionDialog.cpp
+++ b/src/slic3r/GUI/CalibrationRetractionDialog.cpp
@@ -344,12 +344,14 @@ bool CalibrationRetractionDialog::generate_and_load()
         DynamicPrintConfig& print_config =
             wxGetApp().preset_bundle->prints.get_edited_preset().config;
 
-        // Append the built-in hook to any user-configured post-processing
+        // Merge the built-in hook into any user-configured post-processing
         // scripts rather than replacing the list — overwriting it would
-        // silently drop the user's scripts (delivery hooks, file transforms)
-        // for this slice and leave them dropped in the edited preset. Strip
-        // any stale calibration hook from a previous run so re-opening the
-        // dialog stays idempotent.
+        // silently drop the user's scripts (delivery hooks, file transforms).
+        // Strip any stale calibration hook from a previous run (idempotent),
+        // then insert ours at the FRONT: run_post_process_scripts() executes
+        // entries in order, so the retraction rewrite must run before any
+        // user script that consumes or transforms the G-code (e.g. a step
+        // that re-binarizes or uploads it).
         std::vector<std::string> scripts;
         if (const auto* pp = print_config.option<ConfigOptionStrings>("post_process"))
             scripts = pp->values;
@@ -358,7 +360,7 @@ bool CalibrationRetractionDialog::generate_and_load()
                               return is_calibration_retraction_url(s);
                           }),
                       scripts.end());
-        scripts.push_back(builtin_url);
+        scripts.insert(scripts.begin(), builtin_url);
         print_config.set_key_value("post_process", new ConfigOptionStrings(scripts));
         wxGetApp().get_tab(Preset::TYPE_PRINT)->reload_config();
     }

--- a/src/slic3r/GUI/CalibrationRetractionDialog.cpp
+++ b/src/slic3r/GUI/CalibrationRetractionDialog.cpp
@@ -314,6 +314,14 @@ bool CalibrationRetractionDialog::generate_and_load()
         std::vector<double> zero_values(num_extruders, 0.0);
         printer_config.set_key_value("retract_restart_extra", new ConfigOptionFloats(zero_values));
 
+        // Disable wipe-while-retracting. With wipe on, PrusaSlicer spreads the
+        // retraction across combined `X/Y + E` moves; the post-processor only
+        // rewrites pure-E retract moves, so wiped retractions would be left at
+        // the sentinel retract_length and the bands would be wrong. A plain
+        // retract is also the right thing to test in isolation.
+        std::vector<unsigned char> wipe_off(num_extruders, 0u);
+        printer_config.set_key_value("wipe", new ConfigOptionBools(wipe_off));
+
         wxGetApp().get_tab(Preset::TYPE_PRINTER)->reload_config();
     }
 

--- a/src/slic3r/GUI/CalibrationRetractionDialog.hpp
+++ b/src/slic3r/GUI/CalibrationRetractionDialog.hpp
@@ -12,7 +12,10 @@
 namespace Slic3r { namespace GUI {
 
 /// Retraction calibration: generates two cylindrical towers.
-/// Retraction distance varies per layer group via M207 custom G-code.
+/// Retraction distance varies per layer group by emitting a post-process
+/// Python script that rewrites each `G1 E-x` retract/recovery in the
+/// sliced G-code based on the current Z. This works on Buddy firmware,
+/// which does not implement M207/G10/G11.
 class CalibrationRetractionDialog : public wxDialog
 {
 public:

--- a/tests/libslic3r/test_calibration.cpp
+++ b/tests/libslic3r/test_calibration.cpp
@@ -402,6 +402,38 @@ TEST_CASE("calibration retraction: refuses binary G-code input", "[calibration]"
     boost::filesystem::remove(path);
 }
 
+TEST_CASE("calibration retraction: refuses absolute-E (M82) input", "[calibration]")
+{
+    // In absolute-E mode the sign-based retract/recovery classifier is invalid.
+    // The rewriter must refuse once it sees M82, not corrupt the print.
+    const std::string input =
+        "M82\n"                     // absolute extrusion
+        ";Z:1.2\n"
+        "G1 E-1.6 F2700\n";
+    auto url  = make_calibration_retraction_url(0.7, {{2.0, 0.0}});
+    auto path = write_tmp_gcode(input);
+    CHECK_THROWS_WITH(run_calibration_retraction_post_processor(url, path),
+                      Catch::Matchers::ContainsSubstring("absolute E"));
+    boost::filesystem::remove(path);
+}
+
+TEST_CASE("calibration retraction: M83 after M82 re-enables rewriting", "[calibration]")
+{
+    // Mode tracking must be live: an M82 then M83 leaves us in relative mode.
+    const std::string input =
+        "M82\n"
+        "M83\n"                     // back to relative
+        ";Z:1.2\n"
+        "G1 E-1.6 F2700\n";
+    auto url  = make_calibration_retraction_url(0.7, {{2.0, 0.0}});
+    auto path = write_tmp_gcode(input);
+    REQUIRE(run_calibration_retraction_post_processor(url, path));
+    auto out = slurp(path);
+    boost::filesystem::remove(path);
+    // z=1.2 → band 0 = 0.0
+    CHECK(out.find("G1 E-0.0000") != std::string::npos);
+}
+
 TEST_CASE("calibration retraction: malformed URL throws", "[calibration]")
 {
     auto path = write_tmp_gcode("G1 E-1.6 F2700\n");

--- a/tests/libslic3r/test_calibration.cpp
+++ b/tests/libslic3r/test_calibration.cpp
@@ -4,9 +4,19 @@
 ///|/
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #include "libslic3r/CalibrationModels.hpp"
 #include "libslic3r/TriangleMesh.hpp"
+#include "libslic3r/GCode/CalibrationRetractionPostProcessor.hpp"
+
+#include <boost/filesystem.hpp>
+
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 using namespace Slic3r;
 using Catch::Approx;
@@ -223,4 +233,181 @@ TEST_CASE("make_shrinkage_gauge arm length", "[calibration]")
     CHECK(span_x >= length - 5.0);
     CHECK(span_y >= length - 5.0);
     CHECK(span_z >= length - 5.0);
+}
+
+// ---------------------------------------------------------------------------
+// Retraction Calibration Post-Processor
+// ---------------------------------------------------------------------------
+
+static std::string slurp(const std::string& path)
+{
+    std::ifstream in(path);
+    std::stringstream ss;
+    ss << in.rdbuf();
+    return ss.str();
+}
+
+static std::string write_tmp_gcode(const std::string& content)
+{
+    auto p = boost::filesystem::temp_directory_path() / boost::filesystem::unique_path("retcal-%%%%-%%%%.gcode");
+    std::ofstream f(p.string(), std::ios::binary);
+    f << content;
+    f.close();
+    return p.string();
+}
+
+TEST_CASE("calibration retraction: URL round-trip", "[calibration]")
+{
+    std::vector<std::pair<double, double>> levels = {
+        {2.0, 0.0}, {3.0, 0.2}, {4.0, 0.4}};
+    auto url = make_calibration_retraction_url(0.7, levels);
+    CHECK(is_calibration_retraction_url(url));
+    CHECK(url.find("base=0.7000") != std::string::npos);
+    CHECK(url.find("2.0000:0.0000") != std::string::npos);
+    CHECK(url.find("4.0000:0.4000") != std::string::npos);
+
+    // A non-builtin path should not be misidentified as a builtin URL
+    CHECK_FALSE(is_calibration_retraction_url("/usr/local/bin/my_script.py"));
+    CHECK_FALSE(is_calibration_retraction_url("::builtin::other_calibration?foo=bar"));
+}
+
+TEST_CASE("calibration retraction: rewrites retract/recovery by Z band", "[calibration]")
+{
+    const std::string input =
+        ";Z:0.2\n"
+        "G1 X10 Y10 E0.5 F1500\n"
+        "G1 E-1.6 F2700\n"
+        "G1 X20 Y20 F21000\n"
+        "G1 E1.6 F1500\n"
+        ";Z:1.2\n"
+        "G1 E-1.6 F2700\n"
+        "G1 X30 Y30 F21000\n"
+        "G1 E1.6 F1500\n"
+        ";Z:5.2\n"
+        "G1 E-1.6 F2700\n"
+        "G1 X40 Y40 F21000\n"
+        "G1 E1.6 F1500\n";
+
+    std::vector<std::pair<double, double>> levels = {
+        {2.0, 0.0}, {3.0, 0.2}, {4.0, 0.4}, {5.0, 0.6},
+        {6.0, 0.8}, {7.0, 1.0}, {8.0, 1.2}, {9.0, 1.4}, {10.0, 1.6}};
+    auto url  = make_calibration_retraction_url(0.7, levels);
+    auto path = write_tmp_gcode(input);
+
+    REQUIRE(run_calibration_retraction_post_processor(url, path));
+    auto out = slurp(path);
+    boost::filesystem::remove(path);
+
+    // Base layer (Z=0.2 < 1.0) uses BASE_RETRACT = 0.7
+    CHECK(out.find("G1 E-0.7000") != std::string::npos);
+    CHECK(out.find("; r z=0.20") != std::string::npos);
+
+    // Z=1.2 is in [1.0, 2.0) → level 0 = 0.0
+    CHECK(out.find("; r z=1.20") != std::string::npos);
+
+    // Z=5.2 is in [5.0, 6.0) → level 4 = 0.8
+    CHECK(out.find("G1 E-0.8000") != std::string::npos);
+    CHECK(out.find("; r z=5.20") != std::string::npos);
+    CHECK(out.find("; R z=5.20") != std::string::npos); // recovery at Z=5.2
+
+    // Sanity: extrusion lines and Z comments are preserved verbatim
+    CHECK(out.find(";Z:0.2") != std::string::npos);
+    CHECK(out.find("G1 X10 Y10 E0.5 F1500") != std::string::npos);
+    CHECK(out.find("G1 X40 Y40 F21000") != std::string::npos);
+}
+
+TEST_CASE("calibration retraction: leaves non-retract E lines untouched", "[calibration]")
+{
+    // PrusaSlicer's combined-axis G1 moves (X/Y + E) must NOT be rewritten —
+    // those are extrusion paths during printing, not retract/recovery moves.
+    const std::string input =
+        ";Z:1.2\n"
+        "G1 X10 Y10 E0.5 F1500\n"
+        "G1 X20 Y20 E-0.1 F1500\n"  // (synthetic) negative-E extrusion line
+        "G1 E-1.6 F2700\n"          // this IS a retract; rewrite to level 0 (= 0.0)
+        "G1 X30 Y30 F21000\n";
+
+    auto url  = make_calibration_retraction_url(0.7, {{2.0, 0.0}});
+    auto path = write_tmp_gcode(input);
+    REQUIRE(run_calibration_retraction_post_processor(url, path));
+    auto out = slurp(path);
+    boost::filesystem::remove(path);
+
+    // Lines with X/Y must be byte-identical
+    CHECK(out.find("G1 X10 Y10 E0.5 F1500\n") != std::string::npos);
+    CHECK(out.find("G1 X20 Y20 E-0.1 F1500\n") != std::string::npos);
+
+    // The retract-only line is rewritten
+    CHECK(out.find("G1 E-0.0000") != std::string::npos);
+}
+
+TEST_CASE("calibration retraction: Z tracking via G1 Z moves", "[calibration]")
+{
+    // Track Z even when only a `G1 Z` move appears (no `;Z:` comment).
+    const std::string input =
+        "G1 Z1.2 F720\n"
+        "G1 E-1.6 F2700\n"
+        "G1 Z5.4 F720\n"
+        "G1 E-1.6 F2700\n";
+
+    auto url  = make_calibration_retraction_url(0.7,
+        {{2.0, 0.0}, {3.0, 0.2}, {4.0, 0.4}, {5.0, 0.6}, {6.0, 0.8}});
+    auto path = write_tmp_gcode(input);
+    REQUIRE(run_calibration_retraction_post_processor(url, path));
+    auto out = slurp(path);
+    boost::filesystem::remove(path);
+
+    // First retract is at Z=1.2 → level 0 = 0.0
+    CHECK(out.find("G1 E-0.0000") != std::string::npos);
+    // Second retract is at Z=5.4 → level 4 = 0.8
+    CHECK(out.find("G1 E-0.8000") != std::string::npos);
+}
+
+TEST_CASE("calibration retraction: recovery matches its retract across band boundary", "[calibration]")
+{
+    // The previous level's retract followed by the next level's recovery would
+    // drop a small plastic blob at the seam on every band boundary if the two
+    // values were looked up independently from current Z. Verify the recovery
+    // mirrors its matching retract, regardless of the Z change in between.
+    const std::string input =
+        ";Z:1.8\n"
+        "G1 E-1.7 F2700\n"          // retract at end of band-0 layer
+        "G1 X20 Y20 F21000\n"       // travel
+        "G1 Z2.0 F720\n"            // layer change INTO band 1
+        "G1 E1.7 F1500\n";          // recovery — must use band-0 value, NOT band-1
+
+    auto url  = make_calibration_retraction_url(0.7, {{2.0, 0.0}, {3.0, 0.1}});
+    auto path = write_tmp_gcode(input);
+    REQUIRE(run_calibration_retraction_post_processor(url, path));
+    auto out = slurp(path);
+    boost::filesystem::remove(path);
+
+    // Retract at z=1.8 uses band 0 = 0.0
+    CHECK(out.find("G1 E-0.0000 F2700 ; r z=1.80") != std::string::npos);
+    // Recovery at z=2.0 must match: 0.0 (NOT 0.1, which would be the band-1 lookup)
+    CHECK(out.find("G1 E0.0000 F1500 ; R z=2.00") != std::string::npos);
+    // No 0.1 anywhere — that would be the bug signature
+    CHECK(out.find("G1 E0.1000") == std::string::npos);
+    CHECK(out.find("G1 E-0.1000") == std::string::npos);
+}
+
+TEST_CASE("calibration retraction: refuses binary G-code input", "[calibration]")
+{
+    // A file starting with "GCDE" (bgcode magic) is binary G-code. The rewriter
+    // must refuse loudly instead of silently no-op'ing on a binary blob.
+    auto path = write_tmp_gcode(std::string("GCDE\x01\x00\x00\x00\x01\x00", 10));
+    auto url  = make_calibration_retraction_url(0.7, {{2.0, 0.0}});
+    CHECK_THROWS_WITH(run_calibration_retraction_post_processor(url, path),
+                      Catch::Matchers::ContainsSubstring("binary G-code"));
+    boost::filesystem::remove(path);
+}
+
+TEST_CASE("calibration retraction: malformed URL throws", "[calibration]")
+{
+    auto path = write_tmp_gcode("G1 E-1.6 F2700\n");
+    CHECK_THROWS(run_calibration_retraction_post_processor(
+        "::builtin::retraction_calibration?base=0.7", path));  // missing levels
+    CHECK_THROWS(run_calibration_retraction_post_processor(
+        "::builtin::retraction_calibration?levels=2.0:0.0", path));  // missing base
+    boost::filesystem::remove(path);
 }

--- a/tests/libslic3r/test_calibration.cpp
+++ b/tests/libslic3r/test_calibration.cpp
@@ -417,6 +417,39 @@ TEST_CASE("calibration retraction: no-op when calibration marker absent", "[cali
     CHECK(out == input);  // byte-identical — untouched
 }
 
+TEST_CASE("calibration retraction: rewrites only between the two markers", "[calibration]")
+{
+    // Retracts before the first marker (start G-code) and after the second
+    // (end G-code) are nozzle priming / cleanup — they must be left intact.
+    // Only the tower body between the two markers is rewritten.
+    const std::string mk = std::string("; ") + calibration_retraction_marker() + "\n";
+    const std::string input =
+        ";Z:0.5\n"
+        "G1 E-9 F2700\n"        // start G-code retract — before first marker
+        + mk +
+        ";Z:1.2\n"
+        "G1 E-9 F2700\n"        // body retract — rewritten to band 0 (0.0)
+        + mk +
+        ";Z:1.4\n"
+        "G1 E-9 F2700\n";       // end G-code retract — after second marker
+
+    auto url  = make_calibration_retraction_url(0.7, {{2.0, 0.0}});
+    auto path = write_tmp_gcode(input, /*with_marker=*/false);  // input carries its own markers
+    REQUIRE(run_calibration_retraction_post_processor(url, path));
+    auto out = slurp(path);
+    boost::filesystem::remove(path);
+
+    // Body retract rewritten to the band value...
+    CHECK(out.find("G1 E-0.0000 F2700 ; r z=1.20") != std::string::npos);
+    // ...start and end retracts left verbatim — exactly two unchanged moves.
+    size_t count = 0, pos = 0;
+    while ((pos = out.find("G1 E-9 F2700\n", pos)) != std::string::npos) {
+        ++count;
+        pos += 1;
+    }
+    CHECK(count == 2);
+}
+
 TEST_CASE("calibration retraction: refuses binary G-code input", "[calibration]")
 {
     // A file starting with "GCDE" (bgcode magic) is binary G-code. When it

--- a/tests/libslic3r/test_calibration.cpp
+++ b/tests/libslic3r/test_calibration.cpp
@@ -421,17 +421,22 @@ TEST_CASE("calibration retraction: rewrites only between the two markers", "[cal
 {
     // Retracts before the first marker (start G-code) and after the second
     // (end G-code) are nozzle priming / cleanup — they must be left intact.
-    // Only the tower body between the two markers is rewritten.
+    // The closing marker arrives mid-pair (between a layer-change retract and
+    // its recovery, as in real G-code), so the exit is deferred until that
+    // recovery is rewritten — otherwise the top band would have a retract
+    // rewritten but its recovery left at the sentinel value.
     const std::string mk = std::string("; ") + calibration_retraction_marker() + "\n";
     const std::string input =
         ";Z:0.5\n"
         "G1 E-9 F2700\n"        // start G-code retract — before first marker
-        + mk +
+        + mk +                  // opening marker
         ";Z:1.2\n"
-        "G1 E-9 F2700\n"        // body retract — rewritten to band 0 (0.0)
-        + mk +
+        "G1 E-9 F2700\n"        // body retract — rewritten, pair opens
+        "G1 X5 Y5 F21000\n"     // travel
+        + mk +                  // closing marker — arrives mid-pair, exit deferred
         ";Z:1.4\n"
-        "G1 E-9 F2700\n";       // end G-code retract — after second marker
+        "G1 E9 F1500\n"         // body recovery — still rewritten, pair closes
+        "G1 E-9 F2700\n";       // end G-code retract — body already exited, left verbatim
 
     auto url  = make_calibration_retraction_url(0.7, {{2.0, 0.0}});
     auto path = write_tmp_gcode(input, /*with_marker=*/false);  // input carries its own markers
@@ -439,9 +444,10 @@ TEST_CASE("calibration retraction: rewrites only between the two markers", "[cal
     auto out = slurp(path);
     boost::filesystem::remove(path);
 
-    // Body retract rewritten to the band value...
+    // Body retract and its (post-closing-marker) recovery are both rewritten.
     CHECK(out.find("G1 E-0.0000 F2700 ; r z=1.20") != std::string::npos);
-    // ...start and end retracts left verbatim — exactly two unchanged moves.
+    CHECK(out.find("G1 E0.0000 F1500 ; R z=1.40")  != std::string::npos);
+    // Start and end retracts left verbatim — exactly two unchanged moves.
     size_t count = 0, pos = 0;
     while ((pos = out.find("G1 E-9 F2700\n", pos)) != std::string::npos) {
         ++count;

--- a/tests/libslic3r/test_calibration.cpp
+++ b/tests/libslic3r/test_calibration.cpp
@@ -247,10 +247,16 @@ static std::string slurp(const std::string& path)
     return ss.str();
 }
 
-static std::string write_tmp_gcode(const std::string& content)
+// Writes a temp G-code file. By default it prepends the calibration marker
+// comment so the post-processor recognises the file as a calibration print;
+// pass with_marker=false to exercise the marker-absent (no-op) path or to
+// build a binary blob whose first bytes must stay intact.
+static std::string write_tmp_gcode(const std::string& content, bool with_marker = true)
 {
     auto p = boost::filesystem::temp_directory_path() / boost::filesystem::unique_path("retcal-%%%%-%%%%.gcode");
     std::ofstream f(p.string(), std::ios::binary);
+    if (with_marker)
+        f << "; " << calibration_retraction_marker() << "\n";
     f << content;
     f.close();
     return p.string();
@@ -391,11 +397,32 @@ TEST_CASE("calibration retraction: recovery matches its retract across band boun
     CHECK(out.find("G1 E-0.1000") == std::string::npos);
 }
 
+TEST_CASE("calibration retraction: no-op when calibration marker absent", "[calibration]")
+{
+    // The post_process hook persists in the print preset, so the post-processor
+    // runs for every slice. A normal print (no calibration marker) must be
+    // passed through completely untouched.
+    const std::string input =
+        ";Z:1.2\n"
+        "G1 E-1.6 F2700\n"
+        "G1 X10 Y10 F21000\n"
+        "G1 E1.6 F1500\n";
+    auto url  = make_calibration_retraction_url(0.7, {{2.0, 0.0}});
+    auto path = write_tmp_gcode(input, /*with_marker=*/false);
+    CHECK_FALSE(run_calibration_retraction_post_processor(url, path));  // no-op
+    auto out = slurp(path);
+    boost::filesystem::remove(path);
+    CHECK(out == input);  // byte-identical — untouched
+}
+
 TEST_CASE("calibration retraction: refuses binary G-code input", "[calibration]")
 {
-    // A file starting with "GCDE" (bgcode magic) is binary G-code. The rewriter
-    // must refuse loudly instead of silently no-op'ing on a binary blob.
-    auto path = write_tmp_gcode(std::string("GCDE\x01\x00\x00\x00\x01\x00", 10));
+    // A file starting with "GCDE" (bgcode magic) is binary G-code. When it
+    // carries the calibration marker the rewriter must refuse loudly instead
+    // of scribbling over a binarized payload.
+    std::string blob = std::string("GCDE\x01\x00\x00\x00\x01\x00", 10)
+                     + "\n; " + calibration_retraction_marker() + "\n";
+    auto path = write_tmp_gcode(blob, /*with_marker=*/false);
     auto url  = make_calibration_retraction_url(0.7, {{2.0, 0.0}});
     CHECK_THROWS_WITH(run_calibration_retraction_post_processor(url, path),
                       Catch::Matchers::ContainsSubstring("binary G-code"));

--- a/tests/libslic3r/test_calibration.cpp
+++ b/tests/libslic3r/test_calibration.cpp
@@ -402,6 +402,33 @@ TEST_CASE("calibration retraction: refuses binary G-code input", "[calibration]"
     boost::filesystem::remove(path);
 }
 
+TEST_CASE("calibration retraction: leaves unpaired positive-E moves untouched", "[calibration]")
+{
+    // Standalone prime/unload commands (default profiles emit `G1 E2` /
+    // `G1 E10` in start/end G-code) have no preceding retract — they must be
+    // passed through verbatim, not rewritten into tiny deretracts.
+    const std::string input =
+        ";Z:1.2\n"
+        "G1 E2 F2400\n"          // prime — no preceding retract
+        "G1 E-1.6 F2700\n"       // retract -> pending
+        "G1 X10 Y10 F21000\n"    // travel
+        "G1 E1.6 F1500\n"        // recovery — paired, rewritten
+        "G1 E10 F2400\n";        // unload — pending already cleared
+
+    auto url  = make_calibration_retraction_url(0.7, {{2.0, 0.0}});
+    auto path = write_tmp_gcode(input);
+    REQUIRE(run_calibration_retraction_post_processor(url, path));
+    auto out = slurp(path);
+    boost::filesystem::remove(path);
+
+    // Unpaired prime/unload moves preserved byte-for-byte
+    CHECK(out.find("G1 E2 F2400\n") != std::string::npos);
+    CHECK(out.find("G1 E10 F2400\n") != std::string::npos);
+    // The retract (z=1.2 -> band 0 = 0.0) and its paired recovery are rewritten
+    CHECK(out.find("G1 E-0.0000 F2700 ; r z=1.20") != std::string::npos);
+    CHECK(out.find("G1 E0.0000 F1500 ; R z=1.20") != std::string::npos);
+}
+
 TEST_CASE("calibration retraction: refuses absolute-E (M82) input", "[calibration]")
 {
     // In absolute-E mode the sign-based retract/recovery classifier is invalid.

--- a/tests/libslic3r/test_calibration.cpp
+++ b/tests/libslic3r/test_calibration.cpp
@@ -12,6 +12,8 @@
 
 #include <boost/filesystem.hpp>
 
+#include <clocale>
+#include <cstdio>
 #include <fstream>
 #include <sstream>
 #include <string>
@@ -486,6 +488,45 @@ TEST_CASE("calibration retraction: M83 after M82 re-enables rewriting", "[calibr
     boost::filesystem::remove(path);
     // z=1.2 → band 0 = 0.0
     CHECK(out.find("G1 E-0.0000") != std::string::npos);
+}
+
+TEST_CASE("calibration retraction: URL uses locale-invariant decimals", "[calibration]")
+{
+    // The URL is comma-delimited; a comma decimal separator (de_DE etc.) would
+    // make it ambiguous. make_calibration_retraction_url() and the rewrite path
+    // must always emit '.' decimals regardless of the process locale.
+    const std::string saved = std::setlocale(LC_NUMERIC, nullptr);
+    struct Restore {
+        std::string s;
+        ~Restore() { std::setlocale(LC_NUMERIC, s.c_str()); }
+    } restore{saved};
+
+    bool comma_locale = false;
+    for (const char* loc : {"de_DE.UTF-8", "de_DE", "fr_FR.UTF-8", "nl_NL.UTF-8"}) {
+        if (std::setlocale(LC_NUMERIC, loc)) {
+            char probe[8];
+            std::snprintf(probe, sizeof(probe), "%.1f", 1.5);
+            if (std::string(probe) == "1,5") { comma_locale = true; break; }
+        }
+    }
+
+    auto url = make_calibration_retraction_url(0.7, {{2.0, 0.1}, {3.0, 0.2}});
+    CHECK(url.find("base=0.7000") != std::string::npos);
+    CHECK(url.find("2.0000:0.1000") != std::string::npos);
+    CHECK(url.find("0,7000") == std::string::npos);  // never a comma decimal
+
+    if (comma_locale) {
+        // The rewrite path formats E values with snprintf too — verify those
+        // also stay '.' under a comma locale, or the G-code would be invalid.
+        const std::string input =
+            ";Z:1.2\nG1 E-9 F2700\nG1 X1 Y1 F900\nG1 E9 F900\n";
+        auto path = write_tmp_gcode(input);
+        REQUIRE(run_calibration_retraction_post_processor(url, path));
+        auto out = slurp(path);
+        boost::filesystem::remove(path);
+        CHECK(out.find("G1 E-0.1000") != std::string::npos);
+        CHECK(out.find("0,1000") == std::string::npos);
+    }
 }
 
 TEST_CASE("calibration retraction: malformed URL throws", "[calibration]")


### PR DESCRIPTION
## Summary

The Retraction Calibration tool relied on **firmware retraction + per-layer `M207`**. Buddy firmware (Core One / MK4 / MK4S / MK3.5 / MINI / iX / XL) does **not** implement `M207`, `G10` or `G11` — verified against the Buddy source: the G-code dispatcher jumps straight from `M206` to `M211` and from `G1` to `G28`, and there is no `feature/fwretract`. The whole chain was a silent no-op, so every tower band printed with identical (zero) retraction and the test showed no usable variation.

This reworks it to use slicer-side retraction the firmware actually honors.

## What changed

- **`use_firmware_retraction` disabled**, `retract_length` set to the run's maximum value so PrusaSlicer emits real `G1 E-x` retracts at every travel.
- **`binary_gcode` forced off** for calibration prints — PrusaSlicer binarizes *before* the post-process stage runs, so a `.bgcode` would reach the rewriter already sealed.
- **New in-process post-processor** `CalibrationRetractionPostProcessor`, dispatched from `run_post_process_scripts()` via a `::builtin::retraction_calibration?...` URL. It tracks Z and rewrites every retract/recovery move to the per-Z-band retraction length. No external interpreter, no temp script, identical on every platform.
- **Recovery mirrors the matching retract's amount** instead of a fresh Z lookup, keeping retract/recovery balanced across band boundaries.
- **Binary G-code input is refused loudly** (`GCDE` magic check) rather than silently rewriting nothing.
- **Seam stays on the inward face** (`spNearest`) — the seam is the perimeter start/end and the inter-tower travel runs seam-to-seam, so inward seams are what route the travel across the observed gap. Documented inline so it isn't "fixed" away.

## Verification

Printed on a Core One in PLA: the sliced G-code now shows retraction stepping cleanly per 1 mm Z band (`0.0` to `1.7` mm), and the printed towers show the expected stringing gradient — heavy at low-retract bands, clean at high-retract bands.

## Test plan

- [x] 6 new Catch2 cases in `tests/libslic3r/test_calibration.cpp`: URL round-trip, Z-band rewrite, combined-axis-move safety, Z tracking via `G1 Z`, band-boundary retract/recovery pairing, binary-gcode refusal
- [x] `libslic3r_tests [calibration]` — 26 cases pass
- [x] Full `PrusaSlicer` target builds clean (macOS, no-occt preset)
- [x] End-to-end: sliced + printed a calibration tower, confirmed per-band retraction in the output G-code

🤖 Generated with [Claude Code](https://claude.com/claude-code)