### PR TITLE
Fix FilamentDB spool-check warning truncated at embedded quote

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ deps/build-linux/*
 **/.idea/
 .pkg_cache
 CMakeUserPresets.json
+tutorial-preview.html
+.claude/

--- a/src/slic3r/Utils/FilamentDB.cpp
+++ b/src/slic3r/Utils/FilamentDB.cpp
@@ -494,6 +494,38 @@ SpoolCheckResult check_filament_spool(
     // so the user-facing string renders cleanly.
     auto pos_warn = response_body.find("\"warning\":\"");
     if (pos_warn != std::string::npos) {
+        auto parse_hex4 = [](const std::string &s, std::size_t at, std::uint32_t &out) {
+            if (at + 4 > s.size()) return false;
+            std::uint32_t v = 0;
+            for (int k = 0; k < 4; ++k) {
+                char ch = s[at + k];
+                int d;
+                if (ch >= '0' && ch <= '9') d = ch - '0';
+                else if (ch >= 'a' && ch <= 'f') d = 10 + (ch - 'a');
+                else if (ch >= 'A' && ch <= 'F') d = 10 + (ch - 'A');
+                else return false;
+                v = (v << 4) | static_cast<std::uint32_t>(d);
+            }
+            out = v;
+            return true;
+        };
+        auto append_utf8 = [](std::string &dst, std::uint32_t cp) {
+            if (cp < 0x80) {
+                dst += static_cast<char>(cp);
+            } else if (cp < 0x800) {
+                dst += static_cast<char>(0xC0 |  (cp >> 6));
+                dst += static_cast<char>(0x80 |  (cp        & 0x3F));
+            } else if (cp < 0x10000) {
+                dst += static_cast<char>(0xE0 |  (cp >> 12));
+                dst += static_cast<char>(0x80 | ((cp >> 6)  & 0x3F));
+                dst += static_cast<char>(0x80 |  (cp        & 0x3F));
+            } else {
+                dst += static_cast<char>(0xF0 |  (cp >> 18));
+                dst += static_cast<char>(0x80 | ((cp >> 12) & 0x3F));
+                dst += static_cast<char>(0x80 | ((cp >> 6)  & 0x3F));
+                dst += static_cast<char>(0x80 |  (cp        & 0x3F));
+            }
+        };
         std::size_t i = pos_warn + 11;
         std::string decoded;
         decoded.reserve(64);
@@ -504,18 +536,52 @@ SpoolCheckResult check_filament_spool(
             if (c == '\\' && i + 1 < response_body.size()) {
                 char esc = response_body[i + 1];
                 switch (esc) {
-                    case '"':  decoded += '"';  break;
-                    case '\\': decoded += '\\'; break;
-                    case '/':  decoded += '/';  break;
-                    case 'n':  decoded += '\n'; break;
-                    case 't':  decoded += '\t'; break;
-                    case 'r':  decoded += '\r'; break;
-                    case 'b':  decoded += '\b'; break;
-                    case 'f':  decoded += '\f'; break;
-                    default:   decoded += esc;  break; // \uXXXX etc. — drop the backslash
+                    case '"':  decoded += '"';  i += 2; continue;
+                    case '\\': decoded += '\\'; i += 2; continue;
+                    case '/':  decoded += '/';  i += 2; continue;
+                    case 'n':  decoded += '\n'; i += 2; continue;
+                    case 't':  decoded += '\t'; i += 2; continue;
+                    case 'r':  decoded += '\r'; i += 2; continue;
+                    case 'b':  decoded += '\b'; i += 2; continue;
+                    case 'f':  decoded += '\f'; i += 2; continue;
+                    case 'u': {
+                        // \uXXXX — decode to UTF-8. Recognize a UTF-16
+                        // surrogate pair (\uD8xx\uDCxx) so non-BMP code
+                        // points (emoji, etc.) round-trip correctly.
+                        std::uint32_t cp = 0;
+                        if (!parse_hex4(response_body, i + 2, cp)) {
+                            // Malformed — preserve the literal escape so
+                            // information isn't silently lost.
+                            decoded += c;
+                            ++i;
+                            continue;
+                        }
+                        std::size_t consumed = 6;
+                        if (cp >= 0xD800 && cp <= 0xDBFF
+                            && i + 12 <= response_body.size()
+                            && response_body[i + 6] == '\\'
+                            && response_body[i + 7] == 'u') {
+                            std::uint32_t low = 0;
+                            if (parse_hex4(response_body, i + 8, low)
+                                && low >= 0xDC00 && low <= 0xDFFF) {
+                                cp = 0x10000
+                                    + ((cp - 0xD800) << 10)
+                                    +  (low - 0xDC00);
+                                consumed = 12;
+                            }
+                        }
+                        append_utf8(decoded, cp);
+                        i += consumed;
+                        continue;
+                    }
+                    default:
+                        // Unknown / non-JSON escape — preserve verbatim
+                        // (both the backslash and the following char) so
+                        // we don't silently corrupt the message.
+                        decoded += c;
+                        ++i;
+                        continue;
                 }
-                i += 2;
-                continue;
             }
             decoded += c;
             ++i;

--- a/src/slic3r/Utils/FilamentDB.cpp
+++ b/src/slic3r/Utils/FilamentDB.cpp
@@ -547,7 +547,9 @@ SpoolCheckResult check_filament_spool(
                     case 'u': {
                         // \uXXXX — decode to UTF-8. Recognize a UTF-16
                         // surrogate pair (\uD8xx\uDCxx) so non-BMP code
-                        // points (emoji, etc.) round-trip correctly.
+                        // points (emoji, etc.) round-trip correctly. An
+                        // unpaired surrogate (lone high or low) would
+                        // produce invalid UTF-8, so substitute U+FFFD.
                         std::uint32_t cp = 0;
                         if (!parse_hex4(response_body, i + 2, cp)) {
                             // Malformed — preserve the literal escape so
@@ -570,6 +572,8 @@ SpoolCheckResult check_filament_spool(
                                 consumed = 12;
                             }
                         }
+                        if (cp >= 0xD800 && cp <= 0xDFFF)
+                            cp = 0xFFFD;
                         append_utf8(decoded, cp);
                         i += consumed;
                         continue;

--- a/src/slic3r/Utils/FilamentDB.cpp
+++ b/src/slic3r/Utils/FilamentDB.cpp
@@ -488,13 +488,40 @@ SpoolCheckResult check_filament_spool(
         result.has_data = true;
     }
 
-    // Extract "warning":"..."
+    // Extract "warning":"..." — scan for the closing quote while honoring
+    // JSON escapes so an embedded \" (e.g. a quoted spool label inside the
+    // message) doesn't truncate the text. Decode the common escapes inline
+    // so the user-facing string renders cleanly.
     auto pos_warn = response_body.find("\"warning\":\"");
     if (pos_warn != std::string::npos) {
-        auto val_start = pos_warn + 11;
-        auto val_end = response_body.find('"', val_start);
-        if (val_end != std::string::npos)
-            result.warning = response_body.substr(val_start, val_end - val_start);
+        std::size_t i = pos_warn + 11;
+        std::string decoded;
+        decoded.reserve(64);
+        bool terminated = false;
+        while (i < response_body.size()) {
+            char c = response_body[i];
+            if (c == '"') { terminated = true; break; }
+            if (c == '\\' && i + 1 < response_body.size()) {
+                char esc = response_body[i + 1];
+                switch (esc) {
+                    case '"':  decoded += '"';  break;
+                    case '\\': decoded += '\\'; break;
+                    case '/':  decoded += '/';  break;
+                    case 'n':  decoded += '\n'; break;
+                    case 't':  decoded += '\t'; break;
+                    case 'r':  decoded += '\r'; break;
+                    case 'b':  decoded += '\b'; break;
+                    case 'f':  decoded += '\f'; break;
+                    default:   decoded += esc;  break; // \uXXXX etc. — drop the backslash
+                }
+                i += 2;
+                continue;
+            }
+            decoded += c;
+            ++i;
+        }
+        if (terminated)
+            result.warning = std::move(decoded);
     }
 
     // If no spools array or "message" about no data, treat as no data


### PR DESCRIPTION
## Summary
- The FilamentDB spool-check warning notification was clipping mid-message (e.g. `Insufficient filament: need 518.5g but best spool \`) because `check_filament_spool` in `src/slic3r/Utils/FilamentDB.cpp` used a single `find('"', ...)` to locate the closing quote of the JSON `warning` field. Any `\"` embedded in the warning (such as a quoted spool label returned by the server) ended the extraction early, leaving a dangling backslash visible in the UI.
- Replaced the naive scan with an escape-aware decoder that walks the string character-by-character, honors `\"`, `\\`, `\/`, `\n`, `\t`, `\r`, `\b`, `\f`, and only accepts the result when a real closing quote is reached.
- Drive-by: add `tutorial-preview.html` and `.claude/` to `.gitignore`.

## Test plan
- [ ] Configure `Preferences → filamentdb_url`, scan an RFID tag, set spool remaining low (e.g. 10g)
- [ ] Slice a print that exceeds the remaining weight
- [ ] Confirm the warning notification renders the full message including any quoted spool label, with no trailing `\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)