### PR TITLE
Fix retraction tower bands all retracting equally (#18)

### DIFF
--- a/src/slic3r/GUI/CalibrationRetractionDialog.cpp
+++ b/src/slic3r/GUI/CalibrationRetractionDialog.cpp
@@ -278,14 +278,17 @@ bool CalibrationRetractionDialog::generate_and_load()
     // tower section. Use the maximum test value as a slicer-side sentinel:
     // PrusaSlicer will emit explicit `G1 E-<end>` retracts at every travel,
     // and our post-process script rewrites each one based on Z.
-    double base_retract = 0.7;
+    double base_retract  = 0.7;
+    size_t num_extruders = 1;
     wxGetApp().preset_bundle->printers.discard_current_changes();
     {
         DynamicPrintConfig& printer_config =
             wxGetApp().preset_bundle->printers.get_edited_preset().config;
         const auto* opt_rl = printer_config.option<ConfigOptionFloats>("retract_length");
-        if (opt_rl && !opt_rl->empty())
-            base_retract = opt_rl->get_at(0);
+        if (opt_rl && !opt_rl->empty()) {
+            base_retract  = opt_rl->get_at(0);
+            num_extruders = std::max<size_t>(opt_rl->size(), 1);
+        }
 
         // Buddy firmware (Core One / MK4 / MK4S / MK3.5 / MINI / iX / XL)
         // does NOT implement M207/G10/G11. Force slicer-side retraction so
@@ -317,7 +320,6 @@ bool CalibrationRetractionDialog::generate_and_load()
         // Set retract_length to the maximum test value across every extruder
         // entry. Every travel will retract by `end` until the post-process
         // pass rewrites it.
-        size_t num_extruders = opt_rl ? std::max<size_t>(opt_rl->size(), 1) : 1;
         std::vector<double> rl_values(num_extruders, end);
         printer_config.set_key_value("retract_length", new ConfigOptionFloats(rl_values));
 
@@ -334,6 +336,28 @@ bool CalibrationRetractionDialog::generate_and_load()
         printer_config.set_key_value("wipe", new ConfigOptionBools(wipe_off));
 
         wxGetApp().get_tab(Preset::TYPE_PRINTER)->reload_config();
+    }
+
+    // Neutralize filament-level retraction overrides. `filament_wipe`,
+    // `filament_retract_length`, etc. are per-filament settings that take
+    // precedence over the printer config pinned above. Prusament PETG, for
+    // example, ships `filament_wipe = 1` — that re-enables wipe-while-
+    // retracting, which spreads retraction across combined X/Y+E moves the
+    // post-processor cannot rewrite (and the wipe move itself scrubs the
+    // nozzle), so every band ends up with the same effective retraction and
+    // the towers show no stringing gradient at all. Pin the filament
+    // overrides to match the printer config so the printer values win.
+    wxGetApp().preset_bundle->filaments.discard_current_changes();
+    {
+        DynamicPrintConfig& fil_config =
+            wxGetApp().preset_bundle->filaments.get_edited_preset().config;
+        fil_config.set_key_value("filament_wipe",
+            new ConfigOptionBoolsNullable(num_extruders, false));
+        fil_config.set_key_value("filament_retract_length",
+            new ConfigOptionFloatsNullable(num_extruders, end));
+        fil_config.set_key_value("filament_retract_restart_extra",
+            new ConfigOptionFloatsNullable(num_extruders, 0.0));
+        wxGetApp().get_tab(Preset::TYPE_FILAMENT)->reload_config();
     }
 
     // --- Wire up the in-process post-processor ---


### PR DESCRIPTION
## Summary

Fixes #18. The retraction calibration tower printed with uniform retraction across every band — no stringing gradient regardless of the per-band test values.

## Root cause

The dialog pinned `wipe = false` at the printer level, but **per-filament settings take precedence** in PrusaSlicer. Many shipped filament presets (Prusament PETG, etc.) set `filament_wipe = 1`, which silently re-enabled wipe-while-retracting.

With wipe on, the bulk of each retraction is spread across a combined `G1 X.. Y.. E-x` wipe move. The post-processor's `is_retract_only_g1()` correctly skips those (they have X/Y), so only the small pre-wipe and supplemental retracts got rewritten to the per-band value. Most of the E pull stayed at the sentinel `retract_length` for every band.

Visible in the issue's gcode at z=1.0 band where the test value is 0 mm:

```gcode
G1 E-0.0000 F2700 ; r z=1.00          ← pre-wipe (rewritten to 0)
;WIPE_START
G1 X149.775 Y119.775 E-.00916         ← wipe combined move
G1 X143.547 Y119.775 E-.95084         ← total -0.96 mm during wipe — at sentinel value!
;WIPE_END
G1 E0.0000 F1500 ; R z=1.00           ← recovery (rewritten)
```

Every band ended up with effectively the same retraction → no gradient.

## Fix

Pin the filament-level overrides alongside the printer pins:

- `filament_wipe` → false
- `filament_retract_length` → `end` (matches printer sentinel)
- `filament_retract_restart_extra` → 0

Hoists `num_extruders` out of the printer-config block so the new filament-config block can reuse it. Filament options are nullable, hence `ConfigOptionBoolsNullable` / `ConfigOptionFloatsNullable`.

## Test plan

- [x] Build with `cmake --build build-no-occt` — compiles clean
- [ ] Slice a retraction tower with Prusament PETG (or any filament with `filament_wipe = 1`)
- [ ] Verify exported gcode has wipe disabled: `;WIPE_START` markers absent
- [ ] Verify per-band `G1 E-x` retract values reflect the test values (no -0.96 mm sentinel leaks)
- [ ] Print the tower — bands should now show a visible stringing gradient

🤖 Generated with [Claude Code](https://claude.com/claude-code)