### PR TITLE
Fix YOLO flow rate pads all printing at identical flow (#20)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,7 +270,7 @@ This fork adds a **Calibration** menu with built-in calibration tools:
 | Tool | Geometry | G-code |
 |------|----------|--------|
 | Temperature Tower | Multi-tier tower with overhangs, holes, cones, text labels | Per-layer `M104` |
-| Flow Rate (YOLO) | 11 rounded-rect pads with label tabs, Archimedean Chords spiral | Per-object extrusion multiplier |
+| Flow Rate (YOLO) | 11 rounded-rect pads with label tabs, Archimedean Chords spiral | Per-pad flow via in-process post-processor (scales each pad's deposition E, keyed on M486/EXCLUDE_OBJECT name) |
 | Pressure Advance | Chevron pattern tower | Per-layer `M572 S` / `M900 K` / `SET_PRESSURE_ADVANCE` |
 | Retraction | Two cylindrical towers on base plate (seam=nearest/inward) | Per-Z-band slicer-side retraction rewrite via in-process post-processor |
 | Max FlowRate | Serpentine E-shape specimen | Per-layer `M220 S` speed override |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,7 +270,7 @@ This fork adds a **Calibration** menu with built-in calibration tools:
 | Tool | Geometry | G-code |
 |------|----------|--------|
 | Temperature Tower | Multi-tier tower with overhangs, holes, cones, text labels | Per-layer `M104` |
-| Flow Rate (YOLO) | 11 rounded-rect pads with label tabs, Archimedean Chords spiral | Per-pad flow via in-process post-processor (scales each pad's deposition E, keyed on M486/EXCLUDE_OBJECT name) |
+| Flow Rate (YOLO) | 11 rounded-rect pads with label tabs, Archimedean Chords spiral | Per-pad flow via in-process post-processor (scales each pad's deposition E, keyed on object-label name; dialog forces OctoPrint labeling so boundaries emit on every gcode flavor) |
 | Pressure Advance | Chevron pattern tower | Per-layer `M572 S` / `M900 K` / `SET_PRESSURE_ADVANCE` |
 | Retraction | Two cylindrical towers on base plate (seam=nearest/inward) | Per-Z-band slicer-side retraction rewrite via in-process post-processor |
 | Max FlowRate | Serpentine E-shape specimen | Per-layer `M220 S` speed override |

--- a/src/libslic3r/CMakeLists.txt
+++ b/src/libslic3r/CMakeLists.txt
@@ -173,6 +173,8 @@ set(SLIC3R_SOURCES
     GCode/ConflictChecker.hpp
     GCode/CalibrationRetractionPostProcessor.cpp
     GCode/CalibrationRetractionPostProcessor.hpp
+    GCode/CalibrationFlowPostProcessor.cpp
+    GCode/CalibrationFlowPostProcessor.hpp
     GCode/CoolingBuffer.cpp
     GCode/CoolingBuffer.hpp
     GCode/ExtrusionProcessor.cpp

--- a/src/libslic3r/GCode/CalibrationFlowPostProcessor.cpp
+++ b/src/libslic3r/GCode/CalibrationFlowPostProcessor.cpp
@@ -57,6 +57,20 @@ namespace {
 // name -> E scale factor.
 using FactorMap = std::map<std::string, double>;
 
+// For Klipper flavor, LabelObjects::init rewrites object-label names before
+// emitting EXCLUDE_OBJECT markers (it replaces a set of special characters
+// with '_'), so a pad named "-.05" reaches the G-code as "__05". Mirror that
+// substitution here so the factor table can be matched against the rewritten
+// names too. Keep this banned set in sync with LabelObjects.cpp.
+std::string klipper_sanitize(const std::string &name)
+{
+    static const std::string banned = "\b\t\n\v\f\r \"#%&\'*-./:;<>\\";
+    std::string out = name;
+    std::replace_if(out.begin(), out.end(),
+                    [](char c) { return banned.find(c) != std::string::npos; }, '_');
+    return out;
+}
+
 // Throws on malformed URL.
 FactorMap parse_url(const std::string &url)
 {
@@ -93,6 +107,9 @@ FactorMap parse_url(const std::string &url)
                 std::string name   = pair.substr(0, colon);
                 double      factor = std::stod(pair.substr(colon + 1));
                 factors[name]      = factor;
+                // Also key on the Klipper-rewritten form (e.g. "-.05" -> "__05")
+                // so EXCLUDE_OBJECT names match. Never overwrite a raw name.
+                factors.emplace(klipper_sanitize(name), factor);
             }
             have_objects = true;
         }
@@ -186,9 +203,15 @@ int extrusion_mode_command(const std::string &line)
     return line[2] == '2' ? 82 : 83;
 }
 
-// Parse "M486 S<id>" -> id (>=0, or -1 for stop). Returns false if not such a line.
-bool parse_m486_s(const std::string &line, int &id_out)
+// Parse "M486 S<id>" -> id (>=0, or -1 for stop). Returns false if not such a
+// line. RepRapFirmware emits the header definition on a single line as
+// `M486 S<id> A"<name>"`; if such an inline name is present it is returned via
+// inline_name_out / has_inline_name_out (quotes stripped). Marlin uses two
+// lines (`M486 S<id>` then `M486 A<name>`), in which case no inline name.
+bool parse_m486_s(const std::string &line, int &id_out,
+                  std::string &inline_name_out, bool &has_inline_name_out)
 {
+    has_inline_name_out = false;
     if (!boost::starts_with(line, "M486"))
         return false;
     size_t i = 4;
@@ -203,6 +226,20 @@ bool parse_m486_s(const std::string &line, int &id_out)
     if (!any)
         return false;
     id_out = std::stoi(line.substr(start, i - start));
+
+    // Look for an inline `A<name>` token after the S<id> (RepRapFirmware form).
+    while (i < line.size()) {
+        if ((line[i] == 'A' || line[i] == 'a') && std::isspace(static_cast<unsigned char>(line[i - 1]))) {
+            std::string name = line.substr(i + 1);
+            boost::trim(name);
+            if (name.size() >= 2 && name.front() == '"' && name.back() == '"')
+                name = name.substr(1, name.size() - 2);
+            inline_name_out     = std::move(name);
+            has_inline_name_out = true;
+            break;
+        }
+        ++i;
+    }
     return true;
 }
 
@@ -341,11 +378,16 @@ bool run_calibration_flow_post_processor(const std::string &url, const std::stri
 
         int         m486_id;
         std::string obj_name;
-        if (parse_m486_s(line, m486_id)) {
+        std::string inline_name;
+        bool        has_inline_name = false;
+        if (parse_m486_s(line, m486_id, inline_name, has_inline_name)) {
             if (m486_id < 0) {
                 current_factor = 1.0;            // M486 S-1: stop object
             } else {
-                def_id_pending = m486_id;        // may be a header definition (A follows)
+                if (has_inline_name)             // RRF single-line definition: M486 S<id> A"<name>"
+                    id_to_factor[m486_id] = factor_for_name(inline_name);
+                else
+                    def_id_pending = m486_id;    // Marlin: M486 A<name> follows on the next line
                 auto it        = id_to_factor.find(m486_id);
                 current_factor = it == id_to_factor.end() ? 1.0 : it->second;
             }

--- a/src/libslic3r/GCode/CalibrationFlowPostProcessor.cpp
+++ b/src/libslic3r/GCode/CalibrationFlowPostProcessor.cpp
@@ -263,6 +263,19 @@ bool parse_m486_a(const std::string &line, std::string &name_out)
     return true;
 }
 
+// OctoPrint object-label comments carry the name plus an " id:<n> copy <m>"
+// suffix (LabelObjects::init appends it). Recover the bare object name by
+// stripping that trailing suffix.
+std::string octoprint_object_name(const std::string &after_prefix)
+{
+    std::string name = after_prefix;
+    boost::trim(name);
+    size_t id = name.rfind(" id:");
+    if (id != std::string::npos && name.find(" copy ", id) != std::string::npos)
+        name = name.substr(0, id);
+    return name;
+}
+
 // Parse a Klipper EXCLUDE_OBJECT_START NAME='...' / NAME=... line.
 bool parse_exclude_object_start(const std::string &line, std::string &name_out)
 {
@@ -411,7 +424,8 @@ bool run_calibration_flow_post_processor(const std::string &url, const std::stri
             continue;
         }
         if (boost::starts_with(line, "; printing object ")) {
-            current_factor = factor_for_name(line.substr(std::string("; printing object ").size()));
+            current_factor = factor_for_name(
+                octoprint_object_name(line.substr(std::string("; printing object ").size())));
             out << line << '\n';
             continue;
         }

--- a/src/libslic3r/GCode/CalibrationFlowPostProcessor.cpp
+++ b/src/libslic3r/GCode/CalibrationFlowPostProcessor.cpp
@@ -1,0 +1,429 @@
+///|/ Copyright (c) 2025
+///|/
+///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
+///|/
+#include "CalibrationFlowPostProcessor.hpp"
+
+#include "libslic3r/Exception.hpp"
+#include "libslic3r/format.hpp"
+
+#include <LocalesUtils.hpp>
+
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/log/trivial.hpp>
+#include <boost/nowide/fstream.hpp>
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <cstdio>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace Slic3r {
+
+static constexpr const char *BUILTIN_PREFIX = "::builtin::flow_calibration";
+
+bool is_calibration_flow_url(const std::string &script)
+{
+    return boost::starts_with(script, BUILTIN_PREFIX);
+}
+
+std::string make_calibration_flow_url(const std::vector<std::pair<std::string, double>> &objects)
+{
+    // Force the C numeric locale so the URL always uses '.' decimals.
+    // PrusaSlicer does not pin LC_NUMERIC globally, and the URL is
+    // comma-delimited — a comma decimal separator would make it ambiguous.
+    CNumericLocalesSetter locales_setter;
+
+    std::ostringstream out;
+    out << BUILTIN_PREFIX << "?objects=";
+    char buf[32];
+    for (size_t i = 0; i < objects.size(); ++i) {
+        if (i != 0) out << ',';
+        out << objects[i].first << ':';
+        std::snprintf(buf, sizeof(buf), "%.5f", objects[i].second);
+        out << buf;
+    }
+    return out.str();
+}
+
+namespace {
+
+// name -> E scale factor.
+using FactorMap = std::map<std::string, double>;
+
+// Throws on malformed URL.
+FactorMap parse_url(const std::string &url)
+{
+    auto qpos = url.find('?');
+    if (qpos == std::string::npos)
+        throw Slic3r::RuntimeError(format("flow_calibration URL has no query string: %1%", url));
+
+    FactorMap factors;
+    bool      have_objects = false;
+
+    std::string query = url.substr(qpos + 1);
+    size_t      pos   = 0;
+    while (pos < query.size()) {
+        size_t      amp = query.find('&', pos);
+        std::string kv  = query.substr(pos, amp == std::string::npos ? std::string::npos : amp - pos);
+        pos             = amp == std::string::npos ? query.size() : amp + 1;
+
+        size_t eq = kv.find('=');
+        if (eq == std::string::npos)
+            continue;
+        std::string key = kv.substr(0, eq);
+        std::string val = kv.substr(eq + 1);
+
+        if (key == "objects") {
+            size_t lp = 0;
+            while (lp < val.size()) {
+                size_t      comma = val.find(',', lp);
+                std::string pair  = val.substr(lp, comma == std::string::npos ? std::string::npos : comma - lp);
+                lp                = comma == std::string::npos ? val.size() : comma + 1;
+                // Split at the LAST ':' so an object name may itself contain ':'.
+                size_t colon = pair.rfind(':');
+                if (colon == std::string::npos)
+                    throw Slic3r::RuntimeError(format("flow_calibration object missing ':': %1%", pair));
+                std::string name   = pair.substr(0, colon);
+                double      factor = std::stod(pair.substr(colon + 1));
+                factors[name]      = factor;
+            }
+            have_objects = true;
+        }
+    }
+
+    if (!have_objects || factors.empty())
+        throw Slic3r::RuntimeError(format("flow_calibration URL missing objects: %1%", url));
+    return factors;
+}
+
+// Locate an axis term in a G-code line: the axis letter must start the token
+// (preceded by whitespace or be at the start) and be followed by a number.
+// Searches the part before any ';' comment. On a hit, returns true and writes
+// the [begin, end) span of the numeric substring (excluding the axis letter)
+// plus its parsed value.
+bool find_axis_span(const std::string &line, char axis, size_t &num_begin, size_t &num_end, double &value)
+{
+    size_t       comment = line.find(';');
+    const size_t bound   = comment == std::string::npos ? line.size() : comment;
+    size_t       i       = 0;
+    while (i < bound) {
+        if ((line[i] == axis || line[i] == char(std::tolower(axis))) &&
+            (i == 0 || std::isspace(static_cast<unsigned char>(line[i - 1])))) {
+            size_t j         = i + 1;
+            size_t start_num = j;
+            if (j < bound && (line[j] == '+' || line[j] == '-'))
+                ++j;
+            bool any = false;
+            while (j < bound && (std::isdigit(static_cast<unsigned char>(line[j])) || line[j] == '.')) {
+                any = true;
+                ++j;
+            }
+            if (any) {
+                num_begin = start_num;
+                num_end   = j;
+                value     = std::stod(line.substr(start_num, j - start_num));
+                return true;
+            }
+        }
+        ++i;
+    }
+    return false;
+}
+
+bool has_axis(const std::string &line, char axis)
+{
+    size_t b, e;
+    double v;
+    return find_axis_span(line, axis, b, e, v);
+}
+
+// A move that deposits material: G0/G1/G2/G3 with positive E and some XY
+// motion. Pure-E moves (retract/deretract/prime) have no X/Y and are skipped,
+// so retraction lengths are never touched. Travels have no E. Arc moves
+// (G2/G3) always carry X/Y in PrusaSlicer output, so the XY test covers them.
+bool is_deposition_move(const std::string &line, double &e_begin_out, double &e_end_out, double &e_value_out)
+{
+    if (line.size() < 3 || line[0] != 'G')
+        return false;
+    char c = line[1];
+    if (c != '0' && c != '1' && c != '2' && c != '3')
+        return false;
+    // Reject G10/G11/G17/... where a digit follows (e.g. "G17").
+    if (std::isdigit(static_cast<unsigned char>(line[2])))
+        return false;
+
+    size_t b, e;
+    double v;
+    if (!find_axis_span(line, 'E', b, e, v) || v <= 0.0)
+        return false;
+    if (!has_axis(line, 'X') && !has_axis(line, 'Y'))
+        return false;
+    e_begin_out = double(b);
+    e_end_out   = double(e);
+    e_value_out = v;
+    return true;
+}
+
+// Returns 83 for an M83 line (relative E), 82 for M82 (absolute E), 0 otherwise.
+int extrusion_mode_command(const std::string &line)
+{
+    if (line.size() < 3 || line[0] != 'M' || line[1] != '8')
+        return 0;
+    if (line[2] != '2' && line[2] != '3')
+        return 0;
+    if (line.size() > 3) {
+        char c = line[3];
+        if (!std::isspace(static_cast<unsigned char>(c)) && c != ';')
+            return 0;
+    }
+    return line[2] == '2' ? 82 : 83;
+}
+
+// Parse "M486 S<id>" -> id (>=0, or -1 for stop). Returns false if not such a line.
+bool parse_m486_s(const std::string &line, int &id_out)
+{
+    if (!boost::starts_with(line, "M486"))
+        return false;
+    size_t i = 4;
+    while (i < line.size() && std::isspace(static_cast<unsigned char>(line[i]))) ++i;
+    if (i >= line.size() || (line[i] != 'S' && line[i] != 's'))
+        return false;
+    ++i;
+    size_t start = i;
+    if (i < line.size() && line[i] == '-') ++i;
+    bool any = false;
+    while (i < line.size() && std::isdigit(static_cast<unsigned char>(line[i]))) { any = true; ++i; }
+    if (!any)
+        return false;
+    id_out = std::stoi(line.substr(start, i - start));
+    return true;
+}
+
+// Parse "M486 A<name>" -> name (the rest of the line, trimmed; surrounding
+// quotes stripped for the RepRapFirmware `A"name"` form). Returns false if not
+// such a line.
+bool parse_m486_a(const std::string &line, std::string &name_out)
+{
+    if (!boost::starts_with(line, "M486"))
+        return false;
+    size_t i = 4;
+    while (i < line.size() && std::isspace(static_cast<unsigned char>(line[i]))) ++i;
+    if (i >= line.size() || (line[i] != 'A' && line[i] != 'a'))
+        return false;
+    ++i;
+    std::string name = line.substr(i);
+    boost::trim(name);
+    if (name.size() >= 2 && name.front() == '"' && name.back() == '"')
+        name = name.substr(1, name.size() - 2);
+    name_out = std::move(name);
+    return true;
+}
+
+// Parse a Klipper EXCLUDE_OBJECT_START NAME='...' / NAME=... line.
+bool parse_exclude_object_start(const std::string &line, std::string &name_out)
+{
+    if (!boost::starts_with(line, "EXCLUDE_OBJECT_START"))
+        return false;
+    size_t n = line.find("NAME=");
+    if (n == std::string::npos)
+        return false;
+    std::string name = line.substr(n + 5);
+    boost::trim(name);
+    if (!name.empty() && (name.front() == '\'' || name.front() == '"')) {
+        char q   = name.front();
+        size_t e = name.find(q, 1);
+        name     = name.substr(1, e == std::string::npos ? std::string::npos : e - 1);
+    }
+    name_out = std::move(name);
+    return true;
+}
+
+} // namespace
+
+bool run_calibration_flow_post_processor(const std::string &url, const std::string &gcode_path)
+{
+    BOOST_LOG_TRIVIAL(info) << "flow_calibration: starting in-process post-process on " << gcode_path;
+
+    // Force the C numeric locale for the whole pass: parse_url() uses stod(),
+    // axis parsing uses stod(), and the rewritten E values are formatted with
+    // snprintf() — all of which must use '.' decimals regardless of the user's
+    // system locale (PrusaSlicer does not pin LC_NUMERIC globally).
+    CNumericLocalesSetter locales_setter;
+
+    FactorMap factors = parse_url(url);
+
+    boost::filesystem::path src(gcode_path);
+
+    // Pass 1 — confirm this G-code is actually a flow calibration print. The
+    // `post_process` hook persists in the print preset, so this runs for EVERY
+    // slice made with that preset. Only a G-code carrying the job-scoped
+    // calibration marker should be rewritten; anything else is passed through
+    // untouched.
+    {
+        boost::nowide::ifstream scan(gcode_path);
+        if (!scan.is_open())
+            throw Slic3r::RuntimeError(format("flow_calibration: cannot open %1%", gcode_path));
+        const std::string marker = calibration_flow_marker();
+        bool              found  = false;
+        std::string       l;
+        while (std::getline(scan, l)) {
+            if (l.find(marker) != std::string::npos) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            BOOST_LOG_TRIVIAL(info) << "flow_calibration: marker absent, leaving "
+                                    << gcode_path << " unchanged";
+            return false;
+        }
+    }
+
+    // Defensive: a marker-carrying file should always be ASCII (the dialog
+    // forces binary_gcode=false). Detect binary G-code anyway and refuse
+    // loudly rather than scribbling over a binarized payload.
+    {
+        boost::nowide::ifstream sniff(gcode_path, std::ios::binary);
+        char magic[4] = {};
+        sniff.read(magic, 4);
+        if (sniff.gcount() == 4 && std::string(magic, 4) == "GCDE")
+            throw Slic3r::RuntimeError(format(
+                "flow_calibration: input %1% is binary G-code (.bgcode); "
+                "the in-process rewriter only operates on ASCII. Set binary_gcode=false "
+                "on the printer config for calibration prints.",
+                gcode_path));
+    }
+
+    boost::filesystem::path tmp = src;
+    tmp += ".flowcal.tmp";
+
+    boost::nowide::ifstream in(gcode_path);
+    if (!in.is_open())
+        throw Slic3r::RuntimeError(format("flow_calibration: cannot open %1%", gcode_path));
+    boost::nowide::ofstream out(tmp.string(), std::ios::binary | std::ios::trunc);
+    if (!out.is_open())
+        throw Slic3r::RuntimeError(format("flow_calibration: cannot write %1%", tmp.string()));
+
+    // M486 emits its object table up front: "M486 S<id>\nM486 A<name>\nM486 S-1"
+    // per object (see LabelObjects::all_objects_header). We learn id->factor
+    // from that header, then apply by id in the body. EXCLUDE_OBJECT_START /
+    // "; printing object" carry the name directly. Object ids are assigned in
+    // pointer order, so we never key off the numeric id alone — always name.
+    std::map<int, double> id_to_factor;
+    double                current_factor   = 1.0;  // 1.0 == outside any pad, or unknown pad
+    bool                  relative_e       = true; // dialog forces relative E; track M82/M83 anyway
+    int                   def_id_pending   = -2;   // M486 S<id> awaiting its M486 A<name> on the next line
+    size_t                rewrites         = 0;
+    std::string           line;
+    line.reserve(256);
+
+    auto factor_for_name = [&](const std::string &name) -> double {
+        auto it = factors.find(name);
+        return it == factors.end() ? 1.0 : it->second;
+    };
+
+    while (std::getline(in, line)) {
+        // Strip trailing CR if present (Windows line endings).
+        if (!line.empty() && line.back() == '\r')
+            line.pop_back();
+
+        // An "M486 A<name>" immediately following an "M486 S<id>" defines that
+        // object's name (header block). Consume the pending id for this line only.
+        const int await_def = def_id_pending;
+        def_id_pending       = -2;
+
+        int         m486_id;
+        std::string obj_name;
+        if (parse_m486_s(line, m486_id)) {
+            if (m486_id < 0) {
+                current_factor = 1.0;            // M486 S-1: stop object
+            } else {
+                def_id_pending = m486_id;        // may be a header definition (A follows)
+                auto it        = id_to_factor.find(m486_id);
+                current_factor = it == id_to_factor.end() ? 1.0 : it->second;
+            }
+            out << line << '\n';
+            continue;
+        }
+        if (parse_m486_a(line, obj_name)) {
+            if (await_def >= 0)
+                id_to_factor[await_def] = factor_for_name(obj_name);
+            out << line << '\n';
+            continue;
+        }
+        if (parse_exclude_object_start(line, obj_name)) {
+            current_factor = factor_for_name(obj_name);
+            out << line << '\n';
+            continue;
+        }
+        if (boost::starts_with(line, "EXCLUDE_OBJECT_END")) {
+            current_factor = 1.0;
+            out << line << '\n';
+            continue;
+        }
+        if (boost::starts_with(line, "; printing object ")) {
+            current_factor = factor_for_name(line.substr(std::string("; printing object ").size()));
+            out << line << '\n';
+            continue;
+        }
+        if (boost::starts_with(line, "; stop printing object")) {
+            current_factor = 1.0;
+            out << line << '\n';
+            continue;
+        }
+
+        // Extrusion-distance mode tracking.
+        if (int mode = extrusion_mode_command(line); mode != 0)
+            relative_e = (mode == 83);
+
+        // Scale the deposited E inside a pad with a non-unity factor. The
+        // center pad (factor 1.0) and all non-pad moves stay byte-identical.
+        if (std::abs(current_factor - 1.0) > 1e-9) {
+            double e_begin, e_end, e_val;
+            if (is_deposition_move(line, e_begin, e_end, e_val)) {
+                // Scaling a single relative-E delta scales that move's
+                // deposition exactly. In absolute-E mode E is cumulative, so a
+                // per-move scale would corrupt the running position — refuse.
+                if (!relative_e)
+                    throw Slic3r::RuntimeError(format(
+                        "flow_calibration: %1% uses absolute E distances (M82); "
+                        "the rewriter requires relative E (M83). Set "
+                        "use_relative_e_distances=true on the printer config.",
+                        gcode_path));
+                char buf[32];
+                std::snprintf(buf, sizeof(buf), "%.5f", e_val * current_factor);
+                line = line.substr(0, size_t(e_begin)) + buf + line.substr(size_t(e_end));
+                ++rewrites;
+            }
+        }
+
+        out << line << '\n';
+    }
+
+    in.close();
+    out.close();
+
+    boost::system::error_code ec;
+    boost::filesystem::rename(tmp, src, ec);
+    if (ec) {
+        // Fallback: copy + remove. rename can fail across filesystems.
+        boost::filesystem::copy_file(tmp, src, boost::filesystem::copy_options::overwrite_existing, ec);
+        if (ec)
+            throw Slic3r::RuntimeError(format("flow_calibration: failed replacing %1%: %2%",
+                                              src.string(), ec.message()));
+        boost::filesystem::remove(tmp, ec);
+    }
+
+    BOOST_LOG_TRIVIAL(info) << "flow_calibration: scaled " << rewrites << " deposition moves across "
+                            << id_to_factor.size() << " objects";
+    return true;
+}
+
+} // namespace Slic3r

--- a/src/libslic3r/GCode/CalibrationFlowPostProcessor.hpp
+++ b/src/libslic3r/GCode/CalibrationFlowPostProcessor.hpp
@@ -1,0 +1,71 @@
+///|/ Copyright (c) 2025
+///|/
+///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
+///|/
+#ifndef slic3r_CalibrationFlowPostProcessor_hpp_
+#define slic3r_CalibrationFlowPostProcessor_hpp_
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace Slic3r {
+
+// In-process post-processor for the Filament-Edition YOLO Flow Rate Calibration.
+//
+// Why this exists: the flow rate test prints one pad per flow value and the
+// user picks the best-looking top surface. The natural way to vary flow is a
+// per-object `extrusion_multiplier`, but that option lives in GCodeConfig (it
+// is resolved per-extruder, baked once into Extruder::m_e_per_mm3) — it is NOT
+// a PrintObjectConfig/PrintRegionConfig key, so a per-object override is
+// silently dropped during slicing and every pad ends up at the *same* flow.
+// (That is GitHub issue #20: the pads are indistinguishable.)
+//
+// This post-processor restores the per-pad variation by scaling the extruded
+// E of each pad's deposition moves. Each pad is a separate object, so the
+// object boundaries the slicer already emits (M486 / EXCLUDE_OBJECT) delimit
+// exactly the moves to scale. The scale factor is applied *on top of* whatever
+// flow the slicer baked in, so the center pad (factor 1.0) prints at the
+// filament's current flow and the others bracket it.
+//
+// Triggered via the standard `post_process` config when one of its entries
+// starts with the `::builtin::flow_calibration?...` prefix (see
+// is_calibration_flow_url). It only rewrites a G-code carrying the
+// calibration marker (see below) and is a pass-through no-op otherwise.
+//
+// URL format:
+//     ::builtin::flow_calibration?objects=<name>:<factor>,<name>:<factor>,...
+// where <name> is the object name as it appears in the object-label markers
+// (the pad's flow-offset label, e.g. "-.05", "0", ".05") and <factor> is the
+// E scale factor for that object (e.g. 0.95 .. 1.05). The name is matched
+// verbatim, so it must not contain ',' (the pair separator). Object identity
+// is keyed by name, never by the M486 numeric id — those ids are assigned in
+// pointer order and do not match the dialog's pad order.
+
+bool is_calibration_flow_url(const std::string &script);
+
+// Comment the calibration dialog injects into the sliced G-code (job-scoped,
+// via the model's custom per-Z G-code). The `post_process` hook lives in the
+// print *preset* and therefore runs for every subsequent slice; the
+// post-processor rewrites ONLY a G-code that carries this marker and is a
+// pass-through no-op for any normal print. The marker is wiped automatically
+// when a different model is loaded, so it cannot leak across jobs.
+inline constexpr const char *calibration_flow_marker()
+{
+    return "PRUSASLICER_FLOWRATE_CALIBRATION";
+}
+
+// Run the in-process post-processor against `gcode_path` using the parameters
+// embedded in `url`. Returns true if the G-code was rewritten, false if it was
+// left untouched (no calibration marker present — i.e. not a calibration
+// print). Throws Slic3r::RuntimeError on a malformed URL, an unreadable file,
+// or a marker-carrying G-code that is binary or absolute-E.
+bool run_calibration_flow_post_processor(const std::string &url, const std::string &gcode_path);
+
+// Build a `::builtin::flow_calibration?...` URL from an (object-name, factor)
+// table. Factors are formatted locale-invariantly ('.' decimals).
+std::string make_calibration_flow_url(const std::vector<std::pair<std::string, double>> &objects);
+
+} // namespace Slic3r
+
+#endif // slic3r_CalibrationFlowPostProcessor_hpp_

--- a/src/libslic3r/GCode/PostProcessor.cpp
+++ b/src/libslic3r/GCode/PostProcessor.cpp
@@ -5,6 +5,7 @@
 ///|/
 #include "PostProcessor.hpp"
 #include "CalibrationRetractionPostProcessor.hpp"
+#include "CalibrationFlowPostProcessor.hpp"
 
 #include "libslic3r/Utils.hpp"
 #include "libslic3r/format.hpp"
@@ -283,6 +284,18 @@ bool run_post_process_scripts(std::string &src_path, bool make_copy, const std::
                     BOOST_LOG_TRIVIAL(info) << "Running built-in post-processor: " << script;
                     try {
                         run_calibration_retraction_post_processor(script, gcode_file.string());
+                    } catch (const std::exception &err) {
+                        delete_copy();
+                        throw Slic3r::RuntimeError(
+                            (boost::format("Built-in post-processor %1% on file %2% failed:\n%3%")
+                                 % script % path % err.what()).str());
+                    }
+                    continue;
+                }
+                if (is_calibration_flow_url(script)) {
+                    BOOST_LOG_TRIVIAL(info) << "Running built-in post-processor: " << script;
+                    try {
+                        run_calibration_flow_post_processor(script, gcode_file.string());
                     } catch (const std::exception &err) {
                         delete_copy();
                         throw Slic3r::RuntimeError(

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -135,6 +135,8 @@ set(SLIC3R_GUI_SOURCES
     GUI/IconManager.hpp
     GUI/MainFrame.cpp
     GUI/MainFrame.hpp
+    GUI/CalibrationCommon.cpp
+    GUI/CalibrationCommon.hpp
     GUI/CalibrationTempDialog.cpp
     GUI/CalibrationTempDialog.hpp
     GUI/CalibrationExtrusionDialog.cpp

--- a/src/slic3r/GUI/CalibrationCommon.cpp
+++ b/src/slic3r/GUI/CalibrationCommon.cpp
@@ -1,0 +1,38 @@
+///|/ Copyright (c) 2025
+///|/
+///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
+///|/
+#include "CalibrationCommon.hpp"
+
+#include "GUI_App.hpp"
+#include "Tab.hpp"
+
+#include "libslic3r/PresetBundle.hpp"
+#include "libslic3r/PrintConfig.hpp"
+
+namespace Slic3r { namespace GUI {
+
+void apply_calibration_filename_prefix(const std::string& test_name)
+{
+    if (test_name.empty())
+        return;
+
+    DynamicPrintConfig& config =
+        wxGetApp().preset_bundle->prints.get_edited_preset().config;
+
+    const std::string token = "{input_filename_base}";
+    std::string fmt = config.opt_string("output_filename_format");
+    size_t pos = fmt.find(token);
+    if (pos != std::string::npos)
+        fmt.replace(pos, token.size(), test_name);
+    else if (!fmt.empty())
+        fmt = test_name + "_" + fmt;
+    else
+        fmt = test_name + "_{print_time}.gcode";
+
+    config.set_key_value("output_filename_format", new ConfigOptionString(fmt));
+    if (Tab* tab = wxGetApp().get_tab(Preset::TYPE_PRINT))
+        tab->reload_config();
+}
+
+}} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/CalibrationCommon.hpp
+++ b/src/slic3r/GUI/CalibrationCommon.hpp
@@ -1,0 +1,29 @@
+///|/ Copyright (c) 2025
+///|/
+///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
+///|/
+#ifndef slic3r_CalibrationCommon_hpp_
+#define slic3r_CalibrationCommon_hpp_
+
+#include <string>
+
+namespace Slic3r { namespace GUI {
+
+// Give a generated calibration model a meaningful export filename.
+//
+// output_filename_format defaults to a "{input_filename_base}_..." template,
+// and input_filename_base is derived from the first object's name (or its
+// source file). For generated calibration models that name is either a temp
+// STL stem (e.g. "temp_tower") or, worse, an object label containing a '.'
+// (the Flow Rate pads are named "-.05" etc.), which PrintBase truncates at the
+// dot down to a bare "-", producing files like "-_0.4n_...". Substitute a
+// fixed, human-readable test name for that token so every calibration export
+// gets a clean, self-describing prefix (e.g. "FlowRate_0.4n_0.2mm_PLA_...").
+//
+// Edits the active (edited) print preset and reloads the Print tab, so call it
+// after any prints.discard_current_changes() the dialog performs.
+void apply_calibration_filename_prefix(const std::string& test_name);
+
+}} // namespace Slic3r::GUI
+
+#endif // slic3r_CalibrationCommon_hpp_

--- a/src/slic3r/GUI/CalibrationExtrusionDialog.cpp
+++ b/src/slic3r/GUI/CalibrationExtrusionDialog.cpp
@@ -3,6 +3,7 @@
 ///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
 ///|/
 #include "CalibrationExtrusionDialog.hpp"
+#include "CalibrationCommon.hpp"
 #include "GUI_App.hpp"
 #include "Plater.hpp"
 #include "Tab.hpp"
@@ -121,6 +122,8 @@ bool CalibrationExtrusionDialog::generate_and_load()
             config.set_key_value("brim_width", new ConfigOptionFloat(0.0));
         wxGetApp().get_tab(Preset::TYPE_PRINT)->reload_config();
     }
+
+    apply_calibration_filename_prefix("ExtrusionMultiplier");
 
     // Clean up temp file
     boost::filesystem::remove(stl_path);

--- a/src/slic3r/GUI/CalibrationFanDialog.cpp
+++ b/src/slic3r/GUI/CalibrationFanDialog.cpp
@@ -3,6 +3,7 @@
 ///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
 ///|/
 #include "CalibrationFanDialog.hpp"
+#include "CalibrationCommon.hpp"
 #include "GUI_App.hpp"
 #include "Plater.hpp"
 #include "Tab.hpp"
@@ -207,6 +208,8 @@ bool CalibrationFanDialog::generate_and_load()
 
     BOOST_LOG_TRIVIAL(info) << "Fan tower: inserted " << info.gcodes.size()
                             << " custom gcode entries";
+
+    apply_calibration_filename_prefix("FanSpeed");
 
     // Clean up temp file
     boost::filesystem::remove(stl_path);

--- a/src/slic3r/GUI/CalibrationFlowDialog.cpp
+++ b/src/slic3r/GUI/CalibrationFlowDialog.cpp
@@ -3,6 +3,7 @@
 ///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
 ///|/
 #include "CalibrationFlowDialog.hpp"
+#include "CalibrationCommon.hpp"
 #include "GUI_App.hpp"
 #include "Plater.hpp"
 #include "Tab.hpp"
@@ -267,6 +268,8 @@ bool CalibrationFlowDialog::generate_and_load()
         info.gcodes.push_back(item);
     }
     std::sort(info.gcodes.begin(), info.gcodes.end());
+
+    apply_calibration_filename_prefix("MaxFlow");
 
     // Clean up temp file
     boost::filesystem::remove(stl_path);

--- a/src/slic3r/GUI/CalibrationFlowRateDialog.cpp
+++ b/src/slic3r/GUI/CalibrationFlowRateDialog.cpp
@@ -300,15 +300,23 @@ bool CalibrationFlowRateDialog::generate_and_load()
     // belongs to the model, so loading any other model clears the marker.
     {
         CustomGCode::Info& cg = model.custom_gcode_per_print_z();
-        cg.mode = CustomGCode::SingleExtruder;
-        cg.gcodes.clear();
+        const std::string marker_extra = std::string("; ") + calibration_flow_marker() + "\n";
+        // Drop only a stale marker from a previous calibration run (idempotent);
+        // preserve any unrelated custom per-Z entries the user already has on the
+        // bed (pauses, color changes, ...) rather than clearing the whole list.
+        cg.gcodes.erase(std::remove_if(cg.gcodes.begin(), cg.gcodes.end(),
+                            [&](const CustomGCode::Item& it) { return it.extra == marker_extra; }),
+                        cg.gcodes.end());
+        if (cg.gcodes.empty())
+            cg.mode = CustomGCode::SingleExtruder;
         CustomGCode::Item marker;
         marker.print_z  = layer_height / 2.0;   // first layer
         marker.type     = CustomGCode::Custom;
         marker.extruder = 1;
         marker.color    = "";
-        marker.extra    = std::string("; ") + calibration_flow_marker() + "\n";
+        marker.extra    = marker_extra;
         cg.gcodes.push_back(marker);
+        std::sort(cg.gcodes.begin(), cg.gcodes.end());
     }
 
     // --- Pin the printer output options the post-processor relies on ---
@@ -358,33 +366,52 @@ bool CalibrationFlowRateDialog::generate_and_load()
 
     BOOST_LOG_TRIVIAL(info) << "YOLO Flow calibration: post-process URL " << builtin_url;
 
-    // --- Lay the pads out in a fixed grid, ordered by flow offset ---
+    // --- Lay the pads out in a grid, ordered by flow offset ---
     //
     // load order == ascending flow offset (most negative .. most positive), so
-    // a row-major fill (kGridColumns per row, left to right, back to front)
-    // reads naturally, e.g. for the ±5%/1% default:
+    // a row-major fill (cols per row, left to right, back to front) reads
+    // naturally, e.g. for the ±5%/1% default at 4 columns:
     //     -.05  -.04  -.03  -.02
     //     -.01    0    .01   .02
     //      .03   .04   .05
     // This replaces the auto-nester (plater->arrange), which packed the pads in
-    // an arbitrary order so the labels read randomly on the bed.
+    // an arbitrary order so the labels read randomly on the bed. The column
+    // count prefers 4 (the layout above) but is reduced to fit the bed width and
+    // increased to fit the bed depth, so larger step counts / pad sizes still
+    // land on small beds (e.g. a 180 mm MINI) instead of off the plate.
     {
-        constexpr int kGridColumns = 4;
         // Footprint of one pad (all identical), including the back label tab.
         const BoundingBoxf3 fp = model.objects[loaded_object_idxs[0]]->instance_bounding_box(0);
         const double cell_w = (fp.max.x() - fp.min.x()) + 5.0;  // + inter-pad gap
         const double cell_h = (fp.max.y() - fp.min.y()) + 5.0;
-        const int    rows   = (total_pads + kGridColumns - 1) / kGridColumns;
-        const Vec2d  bed_c  = plater->build_volume().bed_center();
-        const double grid_left = bed_c.x() - kGridColumns * cell_w / 2.0;
+
+        const BoundingBoxf bed2d   = plater->build_volume().bounding_volume2d();
+        const Vec2d        bed_c   = bed2d.center();
+        const double       usable_w = bed2d.size().x() - 10.0;  // keep off the edges
+        const double       usable_h = bed2d.size().y() - 10.0;
+
+        const int max_cols = std::max(1, int(std::floor(usable_w / cell_w)));
+        int       cols     = std::min(4, max_cols);            // prefer 4 columns
+        // Add columns (fewer rows) until the grid is short enough for the bed.
+        while (cols < max_cols &&
+               double((total_pads + cols - 1) / cols) * cell_h > usable_h)
+            ++cols;
+        const int rows = (total_pads + cols - 1) / cols;
+        if (rows * cell_h > usable_h || cols * cell_w > usable_w)
+            BOOST_LOG_TRIVIAL(warning)
+                << "YOLO Flow calibration: " << total_pads << " pads (" << cols << "x" << rows
+                << ") exceed the usable bed; some pads may sit off the plate. "
+                   "Reduce the step count or pad size.";
+
+        const double grid_left = bed_c.x() - cols * cell_w / 2.0;
         const double grid_top  = bed_c.y() + rows * cell_h / 2.0;
 
         for (int i = 0; i < total_pads && i < (int)loaded_object_idxs.size(); ++i) {
             ModelObject* obj = model.objects[loaded_object_idxs[i]];
             if (obj->instances.empty())
                 continue;
-            const int col = i % kGridColumns;
-            const int row = i / kGridColumns;
+            const int col = i % cols;
+            const int row = i / cols;
             // Cell center; row 0 sits at the back (max Y) so the grid reads
             // top-to-bottom the way the labels are listed above.
             const Vec2d target(grid_left + cell_w * (col + 0.5),

--- a/src/slic3r/GUI/CalibrationFlowRateDialog.cpp
+++ b/src/slic3r/GUI/CalibrationFlowRateDialog.cpp
@@ -10,10 +10,12 @@
 #include "libslic3r/PresetBundle.hpp"
 #include "libslic3r/PrintConfig.hpp"
 #include "libslic3r/Model.hpp"
+#include "libslic3r/BuildVolume.hpp"
 #include "libslic3r/CustomGCode.hpp"
 #include "libslic3r/TriangleMesh.hpp"
 #include "libslic3r/CalibrationModels.hpp"
 #include "libslic3r/GCode/CalibrationFlowPostProcessor.hpp"
+#include "CalibrationCommon.hpp"
 
 #include <wx/sizer.h>
 #include <wx/stattext.h>
@@ -163,6 +165,10 @@ bool CalibrationFlowRateDialog::generate_and_load()
         wxGetApp().get_tab(Preset::TYPE_PRINT)->reload_config();
         wxGetApp().plater()->on_config_change(wxGetApp().preset_bundle->full_config());
     }
+
+    // Clean, self-describing export filename ("FlowRate_..." instead of "-_...";
+    // see apply_calibration_filename_prefix for why the default collapses to "-").
+    apply_calibration_filename_prefix("FlowRate");
 
     // --- Generate geometry ---
     boost::filesystem::path tmp_dir = boost::filesystem::temp_directory_path();
@@ -352,10 +358,51 @@ bool CalibrationFlowRateDialog::generate_and_load()
 
     BOOST_LOG_TRIVIAL(info) << "YOLO Flow calibration: post-process URL " << builtin_url;
 
+    // --- Lay the pads out in a fixed grid, ordered by flow offset ---
+    //
+    // load order == ascending flow offset (most negative .. most positive), so
+    // a row-major fill (kGridColumns per row, left to right, back to front)
+    // reads naturally, e.g. for the ±5%/1% default:
+    //     -.05  -.04  -.03  -.02
+    //     -.01    0    .01   .02
+    //      .03   .04   .05
+    // This replaces the auto-nester (plater->arrange), which packed the pads in
+    // an arbitrary order so the labels read randomly on the bed.
+    {
+        constexpr int kGridColumns = 4;
+        // Footprint of one pad (all identical), including the back label tab.
+        const BoundingBoxf3 fp = model.objects[loaded_object_idxs[0]]->instance_bounding_box(0);
+        const double cell_w = (fp.max.x() - fp.min.x()) + 5.0;  // + inter-pad gap
+        const double cell_h = (fp.max.y() - fp.min.y()) + 5.0;
+        const int    rows   = (total_pads + kGridColumns - 1) / kGridColumns;
+        const Vec2d  bed_c  = plater->build_volume().bed_center();
+        const double grid_left = bed_c.x() - kGridColumns * cell_w / 2.0;
+        const double grid_top  = bed_c.y() + rows * cell_h / 2.0;
+
+        for (int i = 0; i < total_pads && i < (int)loaded_object_idxs.size(); ++i) {
+            ModelObject* obj = model.objects[loaded_object_idxs[i]];
+            if (obj->instances.empty())
+                continue;
+            const int col = i % kGridColumns;
+            const int row = i / kGridColumns;
+            // Cell center; row 0 sits at the back (max Y) so the grid reads
+            // top-to-bottom the way the labels are listed above.
+            const Vec2d target(grid_left + cell_w * (col + 0.5),
+                               grid_top  - cell_h * (row + 0.5));
+            const BoundingBoxf3 bb = obj->instance_bounding_box(0);
+            const Vec2d cur(0.5 * (bb.min.x() + bb.max.x()),
+                            0.5 * (bb.min.y() + bb.max.y()));
+            const Vec2d delta = target - cur;
+            ModelInstance* inst = obj->instances.front();
+            inst->set_offset(inst->get_offset() + Vec3d(delta.x(), delta.y(), 0.0));
+            obj->invalidate_bounding_box();
+        }
+    }
+
     // load_files() schedules a slice using the just-imported defaults, so the
-    // per-object overrides need an explicit invalidation pass.
+    // per-object overrides need an explicit invalidation pass. This also
+    // reloads the 3D scene so the grid placement above is reflected.
     plater->changed_objects(loaded_object_idxs);
-    plater->arrange(true);
 
     // Clean up temp files
     for (const auto& p : stl_paths)

--- a/src/slic3r/GUI/CalibrationFlowRateDialog.cpp
+++ b/src/slic3r/GUI/CalibrationFlowRateDialog.cpp
@@ -138,6 +138,11 @@ bool CalibrationFlowRateDialog::generate_and_load()
 
         config.set_key_value("layer_height", new ConfigOptionFloat(layer_height));
         config.set_key_value("variable_layer_height", new ConfigOptionBool(false));
+        // Print the pads interleaved (all at the same Z), never sequentially:
+        // they must reach the same height for a fair comparison, and sequential
+        // printing (complete_objects) suppresses custom_gcode_per_print_z, so
+        // the calibration marker the post-processor keys on would never emit.
+        config.set_key_value("complete_objects", new ConfigOptionBool(false));
 
         if (m_brim && m_brim->GetValue())
             config.set_key_value("brim_width", new ConfigOptionFloat(5.0));

--- a/src/slic3r/GUI/CalibrationFlowRateDialog.cpp
+++ b/src/slic3r/GUI/CalibrationFlowRateDialog.cpp
@@ -379,7 +379,14 @@ bool CalibrationFlowRateDialog::generate_and_load()
     // count prefers 4 (the layout above) but is reduced to fit the bed width and
     // increased to fit the bed depth, so larger step counts / pad sizes still
     // land on small beds (e.g. a 180 mm MINI) instead of off the plate.
-    {
+    //
+    // The grid only applies to rectangular beds. For circular (delta) or custom
+    // beds the bounding rectangle includes unprintable corners, so a grid that
+    // "fits" could still drop pads off the plate; and if the pads don't fit even
+    // an adapted rectangular grid, packing them is better than placing them off
+    // the bed. In both cases fall back to the shape-aware arranger.
+    bool placed_in_grid = false;
+    if (plater->build_volume().type() == BuildVolume::Type::Rectangle) {
         // Footprint of one pad (all identical), including the back label tab.
         const BoundingBoxf3 fp = model.objects[loaded_object_idxs[0]]->instance_bounding_box(0);
         const double cell_w = (fp.max.x() - fp.min.x()) + 5.0;  // + inter-pad gap
@@ -397,33 +404,37 @@ bool CalibrationFlowRateDialog::generate_and_load()
                double((total_pads + cols - 1) / cols) * cell_h > usable_h)
             ++cols;
         const int rows = (total_pads + cols - 1) / cols;
-        if (rows * cell_h > usable_h || cols * cell_w > usable_w)
-            BOOST_LOG_TRIVIAL(warning)
-                << "YOLO Flow calibration: " << total_pads << " pads (" << cols << "x" << rows
-                << ") exceed the usable bed; some pads may sit off the plate. "
-                   "Reduce the step count or pad size.";
 
-        const double grid_left = bed_c.x() - cols * cell_w / 2.0;
-        const double grid_top  = bed_c.y() + rows * cell_h / 2.0;
+        if (rows * cell_h <= usable_h && cols * cell_w <= usable_w) {
+            const double grid_left = bed_c.x() - cols * cell_w / 2.0;
+            const double grid_top  = bed_c.y() + rows * cell_h / 2.0;
 
-        for (int i = 0; i < total_pads && i < (int)loaded_object_idxs.size(); ++i) {
-            ModelObject* obj = model.objects[loaded_object_idxs[i]];
-            if (obj->instances.empty())
-                continue;
-            const int col = i % cols;
-            const int row = i / cols;
-            // Cell center; row 0 sits at the back (max Y) so the grid reads
-            // top-to-bottom the way the labels are listed above.
-            const Vec2d target(grid_left + cell_w * (col + 0.5),
-                               grid_top  - cell_h * (row + 0.5));
-            const BoundingBoxf3 bb = obj->instance_bounding_box(0);
-            const Vec2d cur(0.5 * (bb.min.x() + bb.max.x()),
-                            0.5 * (bb.min.y() + bb.max.y()));
-            const Vec2d delta = target - cur;
-            ModelInstance* inst = obj->instances.front();
-            inst->set_offset(inst->get_offset() + Vec3d(delta.x(), delta.y(), 0.0));
-            obj->invalidate_bounding_box();
+            for (int i = 0; i < total_pads && i < (int)loaded_object_idxs.size(); ++i) {
+                ModelObject* obj = model.objects[loaded_object_idxs[i]];
+                if (obj->instances.empty())
+                    continue;
+                const int col = i % cols;
+                const int row = i / cols;
+                // Cell center; row 0 sits at the back (max Y) so the grid reads
+                // top-to-bottom the way the labels are listed above.
+                const Vec2d target(grid_left + cell_w * (col + 0.5),
+                                   grid_top  - cell_h * (row + 0.5));
+                const BoundingBoxf3 bb = obj->instance_bounding_box(0);
+                const Vec2d cur(0.5 * (bb.min.x() + bb.max.x()),
+                                0.5 * (bb.min.y() + bb.max.y()));
+                const Vec2d delta = target - cur;
+                ModelInstance* inst = obj->instances.front();
+                inst->set_offset(inst->get_offset() + Vec3d(delta.x(), delta.y(), 0.0));
+                obj->invalidate_bounding_box();
+            }
+            placed_in_grid = true;
         }
+    }
+    if (!placed_in_grid) {
+        BOOST_LOG_TRIVIAL(info)
+            << "YOLO Flow calibration: pads do not fit a flow-ordered grid on this bed "
+               "(non-rectangular or too small); using the arranger instead.";
+        plater->arrange(true);
     }
 
     // load_files() schedules a slice using the just-imported defaults, so the

--- a/src/slic3r/GUI/CalibrationFlowRateDialog.cpp
+++ b/src/slic3r/GUI/CalibrationFlowRateDialog.cpp
@@ -10,8 +10,10 @@
 #include "libslic3r/PresetBundle.hpp"
 #include "libslic3r/PrintConfig.hpp"
 #include "libslic3r/Model.hpp"
+#include "libslic3r/CustomGCode.hpp"
 #include "libslic3r/TriangleMesh.hpp"
 #include "libslic3r/CalibrationModels.hpp"
+#include "libslic3r/GCode/CalibrationFlowPostProcessor.hpp"
 
 #include <wx/sizer.h>
 #include <wx/stattext.h>
@@ -24,6 +26,7 @@
 #include <algorithm>
 #include <cmath>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace Slic3r { namespace GUI {
@@ -236,6 +239,10 @@ bool CalibrationFlowRateDialog::generate_and_load()
         return false;
     }
 
+    // (object name -> E scale factor) handed to the post-processor below.
+    std::vector<std::pair<std::string, double>> object_factors;
+    object_factors.reserve(total_pads);
+
     for (int i = 0; i < total_pads && i < (int)loaded_object_idxs.size(); ++i) {
         int flow_offset_pct = -num_steps * step_pct + i * step_pct;
         double multiplier = 1.0 + flow_offset_pct / 100.0;
@@ -247,7 +254,9 @@ bool CalibrationFlowRateDialog::generate_and_load()
         }
         ModelObject* obj = model.objects[obj_idx];
 
-        // Object name = flow modifier label
+        // Object name = flow modifier label. This same string identifies the
+        // object in the M486 / EXCLUDE_OBJECT markers the slicer emits, so the
+        // post-processor keys its per-pad scale factor on it.
         char name_buf[32];
         if (flow_offset_pct == 0)
             snprintf(name_buf, sizeof(name_buf), "0");
@@ -257,20 +266,86 @@ bool CalibrationFlowRateDialog::generate_and_load()
             snprintf(name_buf, sizeof(name_buf), "-.%02d", -flow_offset_pct);
         obj->name = name_buf;
 
-        // Per-object extrusion multiplier
-        auto* em_opt = new ConfigOptionFloats();
-        em_opt->values = { multiplier };
-        obj->config.set_key_value("extrusion_multiplier", em_opt);
+        // NOTE: extrusion_multiplier is a GCodeConfig (per-extruder) option, not
+        // a PrintObjectConfig/PrintRegionConfig one, so setting it on the object
+        // config is silently dropped at slice time and every pad would print at
+        // the same flow (issue #20). The per-pad flow is instead applied by the
+        // in-process post-processor wired up below, which scales each pad's
+        // deposition E by `multiplier` relative to the filament's current flow.
+        object_factors.emplace_back(obj->name, multiplier);
 
         // Enable special Archimedean Chords ordering (ported from OrcaSlicer)
         obj->config.set_key_value("calib_flowrate_topinfill_special_order",
             new ConfigOptionBool(true));
         BOOST_LOG_TRIVIAL(info) << "Flow pad " << obj->name
-                                << ": extrusion_multiplier=" << multiplier;
+                                << ": E scale factor=" << multiplier;
     }
 
+    // --- Inject the job-scoped calibration marker ---
+    //
+    // The post_process hook below lives in the print *preset* and runs for every
+    // later slice; the post-processor only rewrites a G-code that carries this
+    // marker, so a normal print is passed through untouched. custom_gcode_per_print_z
+    // belongs to the model, so loading any other model clears the marker.
+    {
+        CustomGCode::Info& cg = model.custom_gcode_per_print_z();
+        cg.mode = CustomGCode::SingleExtruder;
+        cg.gcodes.clear();
+        CustomGCode::Item marker;
+        marker.print_z  = layer_height / 2.0;   // first layer
+        marker.type     = CustomGCode::Custom;
+        marker.extruder = 1;
+        marker.color    = "";
+        marker.extra    = std::string("; ") + calibration_flow_marker() + "\n";
+        cg.gcodes.push_back(marker);
+    }
+
+    // --- Pin the printer output options the post-processor relies on ---
+    wxGetApp().preset_bundle->printers.discard_current_changes();
+    {
+        DynamicPrintConfig& printer_config =
+            wxGetApp().preset_bundle->printers.get_edited_preset().config;
+        // Emit M486 object boundaries so the post-processor can tell the pads
+        // apart. (Some printer profiles default this off.)
+        printer_config.set_key_value("gcode_label_objects",
+            new ConfigOptionEnum<LabelObjectsStyle>(LabelObjectsStyle::Firmware));
+        // Relative, linear E: the post-processor scales each move's E delta, which
+        // is only valid for relative (M83) non-volumetric extrusion.
+        printer_config.set_key_value("use_relative_e_distances", new ConfigOptionBool(true));
+        printer_config.set_key_value("use_volumetric_e", new ConfigOptionBool(false));
+        // ASCII output. PrusaSlicer writes binary G-code before running
+        // post-process scripts, so a .bgcode would be sealed and unrewritable.
+        printer_config.set_key_value("binary_gcode", new ConfigOptionBool(false));
+        wxGetApp().get_tab(Preset::TYPE_PRINTER)->reload_config();
+    }
+
+    // --- Wire up the in-process post-processor ---
+    //
+    // A `::builtin::` URL that PostProcessor.cpp intercepts and dispatches to
+    // Slic3r::run_calibration_flow_post_processor() — no external interpreter.
+    std::string builtin_url = make_calibration_flow_url(object_factors);
+    {
+        DynamicPrintConfig& print_config =
+            wxGetApp().preset_bundle->prints.get_edited_preset().config;
+        // Merge into any user post-processing scripts rather than replacing the
+        // list; strip a stale flow hook from a previous run (idempotent), then
+        // insert ours at the FRONT so it runs before any user script that
+        // consumes/transforms the G-code.
+        std::vector<std::string> scripts;
+        if (const auto* pp = print_config.option<ConfigOptionStrings>("post_process"))
+            scripts = pp->values;
+        scripts.erase(std::remove_if(scripts.begin(), scripts.end(),
+                          [](const std::string& s) { return is_calibration_flow_url(s); }),
+                      scripts.end());
+        scripts.insert(scripts.begin(), builtin_url);
+        print_config.set_key_value("post_process", new ConfigOptionStrings(scripts));
+        wxGetApp().get_tab(Preset::TYPE_PRINT)->reload_config();
+    }
+
+    BOOST_LOG_TRIVIAL(info) << "YOLO Flow calibration: post-process URL " << builtin_url;
+
     // load_files() schedules a slice using the just-imported defaults, so the
-    // per-object flow-rate overrides need an explicit invalidation pass.
+    // per-object overrides need an explicit invalidation pass.
     plater->changed_objects(loaded_object_idxs);
     plater->arrange(true);
 

--- a/src/slic3r/GUI/CalibrationFlowRateDialog.cpp
+++ b/src/slic3r/GUI/CalibrationFlowRateDialog.cpp
@@ -305,10 +305,6 @@ bool CalibrationFlowRateDialog::generate_and_load()
     {
         DynamicPrintConfig& printer_config =
             wxGetApp().preset_bundle->printers.get_edited_preset().config;
-        // Emit M486 object boundaries so the post-processor can tell the pads
-        // apart. (Some printer profiles default this off.)
-        printer_config.set_key_value("gcode_label_objects",
-            new ConfigOptionEnum<LabelObjectsStyle>(LabelObjectsStyle::Firmware));
         // Relative, linear E: the post-processor scales each move's E delta, which
         // is only valid for relative (M83) non-volumetric extrusion.
         printer_config.set_key_value("use_relative_e_distances", new ConfigOptionBool(true));
@@ -327,6 +323,13 @@ bool CalibrationFlowRateDialog::generate_and_load()
     {
         DynamicPrintConfig& print_config =
             wxGetApp().preset_bundle->prints.get_edited_preset().config;
+        // Emit object boundaries so the post-processor can tell the pads apart.
+        // gcode_label_objects is a PRINT option. Use OctoPrint style ("; printing
+        // object <name>" comments): unlike Firmware (M486/EXCLUDE_OBJECT) it is
+        // emitted for EVERY gcode flavor and carries the raw, unsanitized name,
+        // so the calibration works on Marlin, RRF, Klipper and any other flavor.
+        print_config.set_key_value("gcode_label_objects",
+            new ConfigOptionEnum<LabelObjectsStyle>(LabelObjectsStyle::Octoprint));
         // Merge into any user post-processing scripts rather than replacing the
         // list; strip a stale flow hook from a previous run (idempotent), then
         // insert ours at the FRONT so it runs before any user script that

--- a/src/slic3r/GUI/CalibrationPADialog.cpp
+++ b/src/slic3r/GUI/CalibrationPADialog.cpp
@@ -3,6 +3,7 @@
 ///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
 ///|/
 #include "CalibrationPADialog.hpp"
+#include "CalibrationCommon.hpp"
 #include "GUI_App.hpp"
 #include "NotificationManager.hpp"
 #include "Plater.hpp"
@@ -339,6 +340,8 @@ bool CalibrationPADialog::generate_and_load()
             NotificationManager::NotificationLevel::WarningNotificationLevel,
             buf);
     }
+
+    apply_calibration_filename_prefix("PressureAdvance");
 
     return true;
 }

--- a/src/slic3r/GUI/CalibrationRetractionDialog.cpp
+++ b/src/slic3r/GUI/CalibrationRetractionDialog.cpp
@@ -3,6 +3,7 @@
 ///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
 ///|/
 #include "CalibrationRetractionDialog.hpp"
+#include "CalibrationCommon.hpp"
 #include "GUI_App.hpp"
 #include "Plater.hpp"
 #include "Tab.hpp"
@@ -403,6 +404,8 @@ bool CalibrationRetractionDialog::generate_and_load()
     BOOST_LOG_TRIVIAL(info) << "Retraction calibration: post-process URL " << builtin_url
                             << ", base_retract=" << base_retract
                             << ", levels=" << num_levels;
+
+    apply_calibration_filename_prefix("Retraction");
 
     // Clean up temp STL
     boost::filesystem::remove(stl_path);

--- a/src/slic3r/GUI/CalibrationShrinkageDialog.cpp
+++ b/src/slic3r/GUI/CalibrationShrinkageDialog.cpp
@@ -3,6 +3,7 @@
 ///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
 ///|/
 #include "CalibrationShrinkageDialog.hpp"
+#include "CalibrationCommon.hpp"
 #include "GUI_App.hpp"
 #include "Plater.hpp"
 #include "Tab.hpp"
@@ -130,6 +131,8 @@ bool CalibrationShrinkageDialog::generate_and_load()
     }
 
     // No custom G-code needed — just print and measure
+
+    apply_calibration_filename_prefix("DimAccuracy");
 
     // Clean up temp file
     boost::filesystem::remove(stl_path);

--- a/src/slic3r/GUI/CalibrationTempDialog.cpp
+++ b/src/slic3r/GUI/CalibrationTempDialog.cpp
@@ -3,6 +3,7 @@
 ///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
 ///|/
 #include "CalibrationTempDialog.hpp"
+#include "CalibrationCommon.hpp"
 #include "GUI_App.hpp"
 #include "Plater.hpp"
 #include "Tab.hpp"
@@ -233,6 +234,8 @@ bool CalibrationTempDialog::generate_and_load()
         info.gcodes.push_back(item);
     }
     std::sort(info.gcodes.begin(), info.gcodes.end());
+
+    apply_calibration_filename_prefix("TempTower");
 
     // Clean up temp file
     boost::filesystem::remove(stl_path);

--- a/tests/libslic3r/test_calibration.cpp
+++ b/tests/libslic3r/test_calibration.cpp
@@ -727,6 +727,31 @@ TEST_CASE("calibration flow: Klipper EXCLUDE_OBJECT markers with sanitized names
     CHECK(out.find("G1 X2 Y2 E1.05000 F1500") != std::string::npos);  // "_05"  -> 1.05
 }
 
+TEST_CASE("calibration flow: OctoPrint object comments with id/copy suffix", "[calibration]")
+{
+    // OctoPrint labeling (what the dialog forces — universal across flavors)
+    // emits "; printing object <name> id:<n> copy <m>". The post-processor must
+    // strip the " id:.. copy .." suffix to recover the pad name.
+    const std::string input =
+        "; printing object -.05 id:6 copy 0\n"
+        "G1 X1 Y1 E1 F1500\n"
+        "; stop printing object -.05 id:6 copy 0\n"
+        "; printing object 0 id:8 copy 0\n"
+        "G1 X2 Y2 E1 F1500\n"            // center pad -> unchanged
+        "; stop printing object 0 id:8 copy 0\n"
+        "; printing object .05 id:2 copy 0\n"
+        "G1 X3 Y3 E1 F1500\n"
+        "; stop printing object .05 id:2 copy 0\n";
+    auto url  = make_calibration_flow_url({{"-.05", 0.95}, {"0", 1.0}, {".05", 1.05}});
+    auto path = write_tmp_flow_gcode(input);
+    REQUIRE(run_calibration_flow_post_processor(url, path));
+    auto out = slurp(path);
+    boost::filesystem::remove(path);
+    CHECK(out.find("G1 X1 Y1 E0.95000 F1500") != std::string::npos);
+    CHECK(out.find("G1 X2 Y2 E1 F1500")       != std::string::npos);  // center untouched
+    CHECK(out.find("G1 X3 Y3 E1.05000 F1500") != std::string::npos);
+}
+
 TEST_CASE("calibration flow: RepRapFirmware single-line M486 header", "[calibration]")
 {
     // RRF emits the object definition on ONE line as `M486 S<id> A"<name>"`

--- a/tests/libslic3r/test_calibration.cpp
+++ b/tests/libslic3r/test_calibration.cpp
@@ -9,6 +9,7 @@
 #include "libslic3r/CalibrationModels.hpp"
 #include "libslic3r/TriangleMesh.hpp"
 #include "libslic3r/GCode/CalibrationRetractionPostProcessor.hpp"
+#include "libslic3r/GCode/CalibrationFlowPostProcessor.hpp"
 
 #include <boost/filesystem.hpp>
 
@@ -575,5 +576,237 @@ TEST_CASE("calibration retraction: malformed URL throws", "[calibration]")
         "::builtin::retraction_calibration?base=0.7", path));  // missing levels
     CHECK_THROWS(run_calibration_retraction_post_processor(
         "::builtin::retraction_calibration?levels=2.0:0.0", path));  // missing base
+    boost::filesystem::remove(path);
+}
+
+// ---------------------------------------------------------------------------
+// Flow Rate (YOLO) Calibration Post-Processor
+// ---------------------------------------------------------------------------
+
+// Writes a temp G-code file, prepending the flow calibration marker by default
+// so the post-processor recognises the file as a calibration print.
+static std::string write_tmp_flow_gcode(const std::string& content, bool with_marker = true)
+{
+    auto p = boost::filesystem::temp_directory_path() / boost::filesystem::unique_path("flowcal-%%%%-%%%%.gcode");
+    std::ofstream f(p.string(), std::ios::binary);
+    if (with_marker)
+        f << "; " << calibration_flow_marker() << "\n";
+    f << content;
+    f.close();
+    return p.string();
+}
+
+TEST_CASE("calibration flow: URL round-trip", "[calibration]")
+{
+    std::vector<std::pair<std::string, double>> objs = {
+        {"-.05", 0.95}, {"0", 1.0}, {".05", 1.05}};
+    auto url = make_calibration_flow_url(objs);
+    CHECK(is_calibration_flow_url(url));
+    CHECK(url.find("-.05:0.95000") != std::string::npos);
+    CHECK(url.find("0:1.00000") != std::string::npos);
+    CHECK(url.find(".05:1.05000") != std::string::npos);
+
+    CHECK_FALSE(is_calibration_flow_url("/usr/local/bin/my_script.py"));
+    CHECK_FALSE(is_calibration_flow_url("::builtin::retraction_calibration?base=0.7"));
+}
+
+TEST_CASE("calibration flow: scales deposition E per object via M486", "[calibration]")
+{
+    // Header maps S0->".05" and S1->"-.05" — deliberately NOT in offset order,
+    // to prove the post-processor keys on the object NAME, not the M486 id
+    // (ids are assigned in pointer order and need not match the pad order).
+    const std::string input =
+        "M486 S0\n"
+        "M486 A.05\n"
+        "M486 S-1\n"
+        "M486 S1\n"
+        "M486 A-.05\n"
+        "M486 S-1\n"
+        "G1 X235 E5 F500\n"          // purge, outside any object -> untouched
+        "M486 S1\n"                  // object "-.05" -> factor 0.95
+        "G1 X10 Y10 E1 F1500\n"      // deposition -> 0.95000
+        "G1 E-0.25 F1500\n"          // retract (pure E) -> untouched
+        "G1 X20 Y20 F21000\n"        // travel (no E) -> untouched
+        "M486 S-1\n"
+        "M486 S0\n"                  // object ".05" -> factor 1.05
+        "G1 X10 Y10 E1 F1500\n"      // deposition -> 1.05000
+        "G3 X12 Y12 I1 J1 E.5 F1800\n"; // arc deposition -> 0.52500
+
+    std::vector<std::pair<std::string, double>> objs = {{"-.05", 0.95}, {".05", 1.05}};
+    auto url  = make_calibration_flow_url(objs);
+    auto path = write_tmp_flow_gcode(input);
+    REQUIRE(run_calibration_flow_post_processor(url, path));
+    auto out = slurp(path);
+    boost::filesystem::remove(path);
+
+    // Pad "-.05": deposition scaled 0.95, retract & travel untouched.
+    CHECK(out.find("G1 X10 Y10 E0.95000 F1500") != std::string::npos);
+    CHECK(out.find("G1 E-0.25 F1500\n")          != std::string::npos);
+    CHECK(out.find("G1 X20 Y20 F21000\n")        != std::string::npos);
+    // Pad ".05": deposition + arc scaled 1.05.
+    CHECK(out.find("G1 X10 Y10 E1.05000 F1500")  != std::string::npos);
+    CHECK(out.find("G3 X12 Y12 I1 J1 E0.52500 F1800") != std::string::npos);
+    // Purge line outside any object is never scaled.
+    CHECK(out.find("G1 X235 E5 F500\n")          != std::string::npos);
+}
+
+TEST_CASE("calibration flow: center pad (factor 1.0) is byte-identical", "[calibration]")
+{
+    const std::string input =
+        "M486 S0\n"
+        "M486 A0\n"
+        "M486 S-1\n"
+        "M486 S0\n"
+        "G1 X10 Y10 E1 F1500\n"
+        "G1 X20 Y20 E.5 F1500\n"
+        "M486 S-1\n";
+    auto url  = make_calibration_flow_url({{"0", 1.0}});
+    auto path = write_tmp_flow_gcode(input);
+    REQUIRE(run_calibration_flow_post_processor(url, path));
+    auto out = slurp(path);
+    boost::filesystem::remove(path);
+    // Marker + unchanged body; the deposition lines are untouched.
+    CHECK(out.find("G1 X10 Y10 E1 F1500\n") != std::string::npos);
+    CHECK(out.find("G1 X20 Y20 E.5 F1500\n") != std::string::npos);
+}
+
+TEST_CASE("calibration flow: no-op when marker absent", "[calibration]")
+{
+    const std::string input =
+        "M486 S0\n"
+        "M486 A-.05\n"
+        "M486 S-1\n"
+        "M486 S0\n"
+        "G1 X10 Y10 E1 F1500\n"
+        "M486 S-1\n";
+    auto url  = make_calibration_flow_url({{"-.05", 0.95}});
+    auto path = write_tmp_flow_gcode(input, /*with_marker=*/false);
+    CHECK_FALSE(run_calibration_flow_post_processor(url, path));  // no-op
+    auto out = slurp(path);
+    boost::filesystem::remove(path);
+    CHECK(out == input);  // byte-identical — untouched
+}
+
+TEST_CASE("calibration flow: unknown object name passes through unscaled", "[calibration]")
+{
+    // A body object whose name isn't in the factor table must not be scaled.
+    const std::string input =
+        "M486 S0\n"
+        "M486 Asomething-else\n"
+        "M486 S-1\n"
+        "M486 S0\n"
+        "G1 X10 Y10 E1 F1500\n"
+        "M486 S-1\n";
+    auto url  = make_calibration_flow_url({{"-.05", 0.95}});
+    auto path = write_tmp_flow_gcode(input);
+    REQUIRE(run_calibration_flow_post_processor(url, path));
+    auto out = slurp(path);
+    boost::filesystem::remove(path);
+    CHECK(out.find("G1 X10 Y10 E1 F1500\n") != std::string::npos);  // unchanged
+}
+
+TEST_CASE("calibration flow: Klipper EXCLUDE_OBJECT markers", "[calibration]")
+{
+    const std::string input =
+        "EXCLUDE_OBJECT_START NAME='-.05'\n"
+        "G1 X1 Y1 E1 F1500\n"
+        "EXCLUDE_OBJECT_END NAME='-.05'\n"
+        "EXCLUDE_OBJECT_START NAME='.05'\n"
+        "G1 X2 Y2 E1 F1500\n"
+        "EXCLUDE_OBJECT_END NAME='.05'\n";
+    auto url  = make_calibration_flow_url({{"-.05", 0.95}, {".05", 1.05}});
+    auto path = write_tmp_flow_gcode(input);
+    REQUIRE(run_calibration_flow_post_processor(url, path));
+    auto out = slurp(path);
+    boost::filesystem::remove(path);
+    CHECK(out.find("G1 X1 Y1 E0.95000 F1500") != std::string::npos);
+    CHECK(out.find("G1 X2 Y2 E1.05000 F1500") != std::string::npos);
+}
+
+TEST_CASE("calibration flow: refuses binary G-code input", "[calibration]")
+{
+    std::string blob = std::string("GCDE\x01\x00\x00\x00\x01\x00", 10)
+                     + "\n; " + calibration_flow_marker() + "\n";
+    auto path = write_tmp_flow_gcode(blob, /*with_marker=*/false);
+    auto url  = make_calibration_flow_url({{"-.05", 0.95}});
+    CHECK_THROWS_WITH(run_calibration_flow_post_processor(url, path),
+                      Catch::Matchers::ContainsSubstring("binary G-code"));
+    boost::filesystem::remove(path);
+}
+
+TEST_CASE("calibration flow: refuses absolute-E (M82) input", "[calibration]")
+{
+    const std::string input =
+        "M82\n"
+        "M486 S0\n"
+        "M486 A-.05\n"
+        "M486 S-1\n"
+        "M486 S0\n"
+        "G1 X10 Y10 E1 F1500\n";
+    auto url  = make_calibration_flow_url({{"-.05", 0.95}});
+    auto path = write_tmp_flow_gcode(input);
+    CHECK_THROWS_WITH(run_calibration_flow_post_processor(url, path),
+                      Catch::Matchers::ContainsSubstring("absolute E"));
+    boost::filesystem::remove(path);
+}
+
+TEST_CASE("calibration flow: M83 after M82 re-enables scaling", "[calibration]")
+{
+    const std::string input =
+        "M82\n"
+        "M83\n"
+        "M486 S0\n"
+        "M486 A-.05\n"
+        "M486 S-1\n"
+        "M486 S0\n"
+        "G1 X10 Y10 E1 F1500\n";
+    auto url  = make_calibration_flow_url({{"-.05", 0.95}});
+    auto path = write_tmp_flow_gcode(input);
+    REQUIRE(run_calibration_flow_post_processor(url, path));
+    auto out = slurp(path);
+    boost::filesystem::remove(path);
+    CHECK(out.find("G1 X10 Y10 E0.95000 F1500") != std::string::npos);
+}
+
+TEST_CASE("calibration flow: URL and rewrite use locale-invariant decimals", "[calibration]")
+{
+    const std::string saved = std::setlocale(LC_NUMERIC, nullptr);
+    struct Restore {
+        std::string s;
+        ~Restore() { std::setlocale(LC_NUMERIC, s.c_str()); }
+    } restore{saved};
+
+    bool comma_locale = false;
+    for (const char* loc : {"de_DE.UTF-8", "de_DE", "fr_FR.UTF-8", "nl_NL.UTF-8"}) {
+        if (std::setlocale(LC_NUMERIC, loc)) {
+            char probe[8];
+            std::snprintf(probe, sizeof(probe), "%.1f", 1.5);
+            if (std::string(probe) == "1,5") { comma_locale = true; break; }
+        }
+    }
+
+    auto url = make_calibration_flow_url({{"-.05", 0.95}, {".05", 1.05}});
+    CHECK(url.find("-.05:0.95000") != std::string::npos);
+    CHECK(url.find("0,95000") == std::string::npos);  // never a comma decimal
+
+    if (comma_locale) {
+        const std::string input =
+            "M486 S0\nM486 A-.05\nM486 S-1\nM486 S0\nG1 X1 Y1 E1 F900\n";
+        auto path = write_tmp_flow_gcode(input);
+        REQUIRE(run_calibration_flow_post_processor(url, path));
+        auto out = slurp(path);
+        boost::filesystem::remove(path);
+        CHECK(out.find("G1 X1 Y1 E0.95000 F900") != std::string::npos);
+        CHECK(out.find("0,95000") == std::string::npos);
+    }
+}
+
+TEST_CASE("calibration flow: malformed URL throws", "[calibration]")
+{
+    auto path = write_tmp_flow_gcode("G1 X1 Y1 E1 F900\n");
+    CHECK_THROWS(run_calibration_flow_post_processor(
+        "::builtin::flow_calibration", path));  // no query string
+    CHECK_THROWS(run_calibration_flow_post_processor(
+        "::builtin::flow_calibration?foo=bar", path));  // no objects
     boost::filesystem::remove(path);
 }

--- a/tests/libslic3r/test_calibration.cpp
+++ b/tests/libslic3r/test_calibration.cpp
@@ -705,15 +705,44 @@ TEST_CASE("calibration flow: unknown object name passes through unscaled", "[cal
     CHECK(out.find("G1 X10 Y10 E1 F1500\n") != std::string::npos);  // unchanged
 }
 
-TEST_CASE("calibration flow: Klipper EXCLUDE_OBJECT markers", "[calibration]")
+TEST_CASE("calibration flow: Klipper EXCLUDE_OBJECT markers with sanitized names", "[calibration]")
 {
+    // Klipper flavor rewrites object-label names (LabelObjects::init replaces
+    // '-' and '.' with '_'), so the dialog's "-.05"/".05" pads are emitted as
+    // "__05"/"_05". The URL still carries the raw names; the post-processor
+    // must match them against the rewritten marker names.
     const std::string input =
-        "EXCLUDE_OBJECT_START NAME='-.05'\n"
+        "EXCLUDE_OBJECT_START NAME='__05'\n"
         "G1 X1 Y1 E1 F1500\n"
-        "EXCLUDE_OBJECT_END NAME='-.05'\n"
-        "EXCLUDE_OBJECT_START NAME='.05'\n"
+        "EXCLUDE_OBJECT_END NAME='__05'\n"
+        "EXCLUDE_OBJECT_START NAME='_05'\n"
         "G1 X2 Y2 E1 F1500\n"
-        "EXCLUDE_OBJECT_END NAME='.05'\n";
+        "EXCLUDE_OBJECT_END NAME='_05'\n";
+    auto url  = make_calibration_flow_url({{"-.05", 0.95}, {".05", 1.05}});
+    auto path = write_tmp_flow_gcode(input);
+    REQUIRE(run_calibration_flow_post_processor(url, path));
+    auto out = slurp(path);
+    boost::filesystem::remove(path);
+    CHECK(out.find("G1 X1 Y1 E0.95000 F1500") != std::string::npos);  // "__05" -> 0.95
+    CHECK(out.find("G1 X2 Y2 E1.05000 F1500") != std::string::npos);  // "_05"  -> 1.05
+}
+
+TEST_CASE("calibration flow: RepRapFirmware single-line M486 header", "[calibration]")
+{
+    // RRF emits the object definition on ONE line as `M486 S<id> A"<name>"`
+    // (Marlin uses two lines). The post-processor must read the inline name
+    // so id->factor is populated; otherwise every pad selects factor 1.0.
+    const std::string input =
+        "M486 S0 A\"-.05\"\n"
+        "M486 S-1\n"
+        "M486 S1 A\".05\"\n"
+        "M486 S-1\n"
+        "M486 S0\n"                  // body: object "-.05" -> 0.95
+        "G1 X1 Y1 E1 F1500\n"
+        "M486 S-1\n"
+        "M486 S1\n"                  // body: object ".05" -> 1.05
+        "G1 X2 Y2 E1 F1500\n"
+        "M486 S-1\n";
     auto url  = make_calibration_flow_url({{"-.05", 0.95}, {".05", 1.05}});
     auto path = write_tmp_flow_gcode(input);
     REQUIRE(run_calibration_flow_post_processor(url, path));


### PR DESCRIPTION
## Problem

[Issue #20](https://github.com/hyiger/PrusaSlicer/issues/20): the YOLO Flow Rate calibration plates are indistinguishable — there's no flow difference to see.

**Confirmed against the attached G-code.** Measuring E-per-mm of each pad's deposition moves (tracked by `M486` object) showed all 11 pads at **0.03706–0.03708** — a 0.05% spread that's just path-geometry noise. The pads carry the right labels (`-.05`…`.05`) but identical flow.

## Root cause

`CalibrationFlowRateDialog::generate_and_load` set the per-pad flow via a per-object `extrusion_multiplier` override (`obj->config`). But `extrusion_multiplier` is declared in **`GCodeConfig`** — it's resolved per-extruder and baked once into `Extruder::m_e_per_mm3`. It is **not** a `PrintObjectConfig`/`PrintRegionConfig` key, so `object_config_from_model_object` (which applies the object config with `ignore_nonexistent=true`) silently drops it. Every pad ended up extruding at the filament's global multiplier.

## Fix

Replace the dropped override with an **in-process G-code post-processor**, mirroring the existing Retraction calibration. It's dispatched through the standard `post_process` config via a `::builtin::flow_calibration?objects=<name>:<factor>,...` URL, and scales each pad's **deposition E** by the pad's factor.

- Object identity is keyed on the **object name** in the `M486` / `EXCLUDE_OBJECT` markers — never the numeric `M486` id, which is assigned in pointer order and does **not** match pad order (verified on the real file: `S0`→`-.02`, not `-.05`).
- The factor multiplies the slicer's baked-in flow, so the **center pad (factor 1.0) prints at the filament's current flow** and the others bracket it ±range — matching the guide's "add the winning modifier to your current multiplier" workflow.
- **Pure-E retract/deretract moves and travels are never touched** (no X/Y → skipped); the center pad stays byte-identical.
- Requires relative + linear E (refuses absolute-E/binary G-code loudly), which the dialog now pins along with `gcode_label_objects=firmware` and `binary_gcode=false`.
- A job-scoped marker injected via `custom_gcode_per_print_z` makes the persistent `post_process` hook a no-op on any normal print.

## Verification

**End-to-end on the issue's attached G-code** (applied a faithful mirror of the post-processor): per-pad E/mm now forms a clean monotonic gradient, exact to 5 decimals:

| label | E/mm | ratio vs min |
|---|---|---|
| -.05 | 0.03522 | 1.0000× |
| 0 | 0.03706 | 1.0522× (unchanged baseline) |
| .05 | 0.03892 | 1.1051× (= 1.05/0.95) |

- Center pad `0` byte-identical to original.
- All 1,953 pure-E retract/deretract lines identical; all 1,406 travel lines identical; 0 lines added/removed.

**Unit tests:** 11 new cases (43 `[calibration]` cases pass) covering URL round-trip, per-object scaling with non-sequential ids, arc (`G2`/`G3`) moves, center-pad identity, marker-absent no-op, unknown-name passthrough, Klipper `EXCLUDE_OBJECT`, binary/absolute-E refusal, M82/M83 mode tracking, and locale-invariant output.

Builds clean (libslic3r, tests, GUI lib, full app on arm64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)