### PR TITLE
Fix Linux .deb/AppImage failing to launch (resources layout + webkit dep) — #23

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -109,9 +109,12 @@ jobs:
           wget -q "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-${{ matrix.linuxdeploy_arch }}.AppImage"
           chmod +x linuxdeploy-${{ matrix.linuxdeploy_arch }}.AppImage
 
-          # Create AppDir structure
+          # Create AppDir structure.
+          # Non-FHS builds resolve resources at <canonical binary dir>/../resources
+          # (src/CLI/Setup.cpp), i.e. usr/bin/../resources => usr/resources. They must
+          # live there, NOT usr/share/PrusaSlicer, or OnInit aborts with no window.
           mkdir -p AppDir/usr/bin
-          mkdir -p AppDir/usr/share/PrusaSlicer
+          mkdir -p AppDir/usr/resources
           mkdir -p AppDir/usr/share/applications
           mkdir -p AppDir/usr/share/icons/hicolor/128x128/apps
 
@@ -119,8 +122,8 @@ jobs:
           cp build-default/dist/bin/prusa-slicer AppDir/usr/bin/
           [ -L build-default/dist/bin/prusa-gcodeviewer ] && \
             cp -P build-default/dist/bin/prusa-gcodeviewer AppDir/usr/bin/ || true
-          cp -r build-default/dist/resources/* AppDir/usr/share/PrusaSlicer/ 2>/dev/null || \
-            cp -r resources/* AppDir/usr/share/PrusaSlicer/
+          cp -r build-default/dist/resources/* AppDir/usr/resources/ 2>/dev/null || \
+            cp -r resources/* AppDir/usr/resources/
 
           # Desktop file and icon
           cp src/platform/unix/PrusaSlicer.desktop AppDir/usr/share/applications/
@@ -150,10 +153,11 @@ jobs:
             DEB_ARCH="arm64"
           fi
 
-          # Create directory structure
+          # Create directory structure.
+          # Resources must sit at usr/resources (usr/bin/../resources), see Setup.cpp.
           mkdir -p deb/DEBIAN
           mkdir -p deb/usr/bin
-          mkdir -p deb/usr/share/PrusaSlicer
+          mkdir -p deb/usr/resources
           mkdir -p deb/usr/share/applications
           mkdir -p deb/usr/share/icons/hicolor/128x128/apps
 
@@ -170,7 +174,7 @@ jobs:
            advance, retraction, and more.
           Section: graphics
           Priority: optional
-          Depends: libgtk-3-0, libglu1-mesa, libdbus-1-3
+          Depends: libgtk-3-0 | libgtk-3-0t64, libwebkit2gtk-4.1-0, libglu1-mesa, libdbus-1-3
           CTRL
           # Strip leading whitespace from control file (heredoc was indented)
           sed -i 's/^          //' deb/DEBIAN/control
@@ -179,8 +183,8 @@ jobs:
           cp build-default/dist/bin/prusa-slicer deb/usr/bin/
           [ -L build-default/dist/bin/prusa-gcodeviewer ] && \
             cp -P build-default/dist/bin/prusa-gcodeviewer deb/usr/bin/ || true
-          cp -r build-default/dist/resources/* deb/usr/share/PrusaSlicer/ 2>/dev/null || \
-            cp -r resources/* deb/usr/share/PrusaSlicer/
+          cp -r build-default/dist/resources/* deb/usr/resources/ 2>/dev/null || \
+            cp -r resources/* deb/usr/resources/
 
           # Desktop file and icon
           cp src/platform/unix/PrusaSlicer.desktop deb/usr/share/applications/

--- a/doc/Linux_Install.md
+++ b/doc/Linux_Install.md
@@ -1,0 +1,71 @@
+# Linux installation & troubleshooting (Filament Edition)
+
+The Linux release ships two artifacts per architecture (`x64`, `arm64`):
+
+- `…-linux-<arch>.AppImage` — portable, no install
+- `…-linux-<arch>.deb` — Debian/Ubuntu package
+
+## AppImage
+
+```bash
+chmod +x PrusaSlicer-*-linux-x64.AppImage
+./PrusaSlicer-*-linux-x64.AppImage
+```
+
+### "Cannot mount AppImage" / nothing happens on launch
+
+Type-2 AppImages self-mount through **libfuse2**, which Ubuntu 23.04 and newer
+(including 24.04 and 26.04) no longer install by default. Either install it:
+
+```bash
+sudo apt install libfuse2          # or: libfuse2t64 on 24.04+
+```
+
+…or run the AppImage without FUSE by extracting it on the fly:
+
+```bash
+./PrusaSlicer-*-linux-x64.AppImage --appimage-extract-and-run
+```
+
+### "Failed to integrate with the system"
+
+This is the first-run desktop-integration prompt. It is safe to decline; it does
+not affect slicing.
+
+## .deb
+
+```bash
+sudo apt install ./PrusaSlicer-*-linux-x64.deb
+prusa-slicer
+```
+
+The package depends on `libgtk-3-0`, `libwebkit2gtk-4.1-0`, `libglu1-mesa`, and
+`libdbus-1-3`. `apt install ./file.deb` pulls these automatically; `dpkg -i`
+does not — run `sudo apt -f install` afterwards if you used `dpkg`.
+
+## Diagnosing a non-starting build
+
+Run the binary from a terminal so errors are visible:
+
+```bash
+# AppImage: extract and run the inner binary directly
+./PrusaSlicer-*.AppImage --appimage-extract
+./squashfs-root/usr/bin/prusa-slicer
+
+# deb: run the installed binary
+/usr/bin/prusa-slicer
+```
+
+- **Resource/assets error** (missing profiles, "resources directory") → packaging
+  bug, please report. The binary expects its `resources` directory beside `bin`
+  (`usr/bin/../resources`).
+- **`libwebkit2gtk-4.1.so.0: cannot open shared object file`** →
+  `sudo apt install libwebkit2gtk-4.1-0`.
+- Check for any missing shared libraries:
+
+  ```bash
+  ldd /usr/bin/prusa-slicer | grep 'not found'
+  ```
+
+If you build from source instead, the standard `cmake --preset default
+-DPrusaSlicer_BUILD_DEPS=ON` flow works on current Ubuntu.


### PR DESCRIPTION
## Issue
[#23](https://github.com/hyiger/PrusaSlicer/issues/23) — the `.deb` and `.AppImage` release artifacts don't start (source builds work, so it's purely a packaging bug).

## Root cause (high confidence)
Non-FHS builds resolve resources at `canonical(binary)/../resources` ([Setup.cpp:297](../blob/master/src/CLI/Setup.cpp#L297)) — i.e. `usr/bin/../resources` = **`usr/resources`**. The packaging steps put resources in `usr/share/PrusaSlicer/` instead, so the binary finds no resources dir and `GUI_App::OnInit` aborts via `wxCHECK_MSG` ([GUI_App.cpp:1404](../blob/master/src/slic3r/GUI/GUI_App.cpp#L1404)):
- **.deb** → no window appears.
- **AppImage** → desktop-integration can't read its icon from `resources_dir()/icons` → "cannot integrate with the system" dialogs.

Secondary: the **.deb omitted `libwebkit2gtk-4.1-0`** though the binary hard-links it, so it failed to load at runtime on a clean machine.

## Fix (minimal CI patch — Option A)
- AppImage + deb: copy resources to **`usr/resources`** (sibling of `usr/bin`).
- deb `Depends`: add `libwebkit2gtk-4.1-0`, plus a `libgtk-3-0t64` alternative so it installs on Ubuntu 24.04/26.04.
- New `doc/Linux_Install.md`: documents the **libfuse2** requirement on Ubuntu 23.04+ (the AppImage self-mount dep — the tertiary cause on 26.04) and `ldd`/extract diagnostics.

## Verification owed (no Ubuntu 26.04 box here)
CI-only change; confirm on the next Linux build that:
- `./*.AppImage --appimage-extract` shows `squashfs-root/usr/resources/profiles` present, and the inner binary launches.
- `dpkg -c *.deb` shows `usr/resources/` beside `usr/bin/`, and the package installs + runs in a clean Ubuntu 24.04 container.

The FHS approach (`-DSLIC3R_FHS=ON`, which would also suppress the integration prompt) was considered and deferred per the triage decision to keep this a minimal, no-recompile patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)