### PR TITLE
Fix retraction calibration: stale M207 docs + dead Tower-height field — #24

### DIFF
--- a/doc/Calibration_Guide.md
+++ b/doc/Calibration_Guide.md
@@ -94,17 +94,18 @@ The layer count for each level (default 4 layers) is printed from bottom to top.
 
 ## 4. Retraction
 
-**What it does:** Generates two cylindrical towers separated by a gap. The printer must retract filament when traveling between the towers, so any stringing between them indicates the retraction settings need adjustment. Each layer group uses a different retraction distance.
+**What it does:** Generates two cylindrical towers separated by a gap. The printer must retract filament when travelling between the towers, so any stringing between them indicates the retraction settings need adjustment. The tower is split into Z bands, and **each band is printed with a different retraction distance**, increasing from the start value at the bottom to the end value at the top.
 
 **How to use it:**
 
 1. Go to **Calibration → Retraction**.
-2. Set the start and end retraction distances, step size, tower height, diameter, and spacing.
+2. Set the start and end retraction distances and the step size. The tower **height is computed automatically** from the number of steps and your layer height (it is shown in the dialog) — you don't set it manually.
    - Defaults are derived from your current printer profile's retraction length (±1 mm).
    - Typical range: 0.2 mm to 2.0 mm for direct drive, 1.0 mm to 8.0 mm for Bowden.
+   - Leave **firmware retraction OFF** — the dialog forces it off and applies the test a different way (see the note below).
 3. Optionally enable the 5 mm brim for better bed adhesion.
-4. Click OK. The towers will appear on a 1 mm base plate with per-layer M207 retraction commands.
-5. Slice and print.
+4. Click OK. The towers appear on a 1 mm base plate.
+5. Slice, then **export (or upload) the G-code**, and print.
 
 **How to evaluate:**
 
@@ -114,9 +115,11 @@ Look at the space between the two towers at each height:
 - **Too much retraction**: Gaps or under-extrusion at the start of each layer (after the travel move), or clicking sounds from the extruder.
 - **Correct retraction**: Clean travel moves with no stringing and consistent extrusion after each retract.
 
-Find the lowest retraction distance that produces clean results — using more retraction than necessary increases print time and can cause clogs.
+Each Z band corresponds to a known retraction distance (start at the bottom, end at the top, stepping by your step size). Note the height where stringing stops and read off the retraction distance for that band. Find the lowest retraction distance that produces clean results — using more retraction than necessary increases print time and can cause clogs.
 
-> **Note:** This test uses `M207` (firmware retraction). Ensure firmware retraction is enabled in your printer settings.
+> **How the test is applied (and why the preview looks uniform):** This tool does **not** use `M207` firmware retraction — current Prusa/Buddy firmware (Core ONE, MK4, MINI, XL) doesn't implement it. Instead the dialog forces firmware retraction **off** and emits ordinary `G1 E` retractions; an in-process post-processor then **rewrites the retraction distance per Z band when you export or upload the G-code**.
+>
+> Because that rewrite runs at export/upload time, the **in-app G-code preview shows the same retraction everywhere** — this is expected and does **not** mean the test is broken. To confirm the gradient, open the **exported** `.gcode` file and look at the `G1 E-…` retraction values: they step up band by band. You will not find any `M207` commands.
 
 ---
 

--- a/src/slic3r/GUI/CalibrationRetractionDialog.cpp
+++ b/src/slic3r/GUI/CalibrationRetractionDialog.cpp
@@ -82,12 +82,15 @@ CalibrationRetractionDialog::CalibrationRetractionDialog(wxWindow* parent)
     m_retract_step->SetDigits(2);
     grid->Add(m_retract_step, 0, wxEXPAND);
 
-    // Tower height
+    // Tower height — computed from the retraction range, step, and layer
+    // height, shown read-only. It used to be an editable field, but when set
+    // below the levels-derived height it truncated the tower geometry while
+    // the post-processor's band table still spanned the full height, so the
+    // top retraction bands mapped above the tower and never printed.
     grid->Add(new wxStaticText(this, wxID_ANY, _L("Tower height (mm):")),
               0, wxALIGN_CENTER_VERTICAL);
-    m_tower_height = new wxSpinCtrl(this, wxID_ANY, wxEmptyString,
-        wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 10, 200, 100);
-    grid->Add(m_tower_height, 0, wxEXPAND);
+    m_tower_height_label = new wxStaticText(this, wxID_ANY, wxEmptyString);
+    grid->Add(m_tower_height_label, 0, wxALIGN_CENTER_VERTICAL);
 
     // Tower diameter
     grid->Add(new wxStaticText(this, wxID_ANY, _L("Tower diameter (mm):")),
@@ -112,7 +115,7 @@ CalibrationRetractionDialog::CalibrationRetractionDialog(wxWindow* parent)
     wxGetApp().UpdateDarkUI(m_start_retract);
     wxGetApp().UpdateDarkUI(m_end_retract);
     wxGetApp().UpdateDarkUI(m_retract_step);
-    wxGetApp().UpdateDarkUI(m_tower_height);
+    wxGetApp().UpdateDarkUI(m_tower_height_label);
     wxGetApp().UpdateDarkUI(m_tower_diameter);
     wxGetApp().UpdateDarkUI(m_tower_spacing);
     wxGetApp().UpdateDarkUI(m_brim);
@@ -129,10 +132,49 @@ CalibrationRetractionDialog::CalibrationRetractionDialog(wxWindow* parent)
     Layout();
     CenterOnParent();
 
+    // Keep the computed tower-height display in sync with the inputs.
+    auto on_input_changed = [this](wxSpinDoubleEvent&) { update_computed_height(); };
+    m_start_retract->Bind(wxEVT_SPINCTRLDOUBLE, on_input_changed);
+    m_end_retract->Bind(wxEVT_SPINCTRLDOUBLE, on_input_changed);
+    m_retract_step->Bind(wxEVT_SPINCTRLDOUBLE, on_input_changed);
+    update_computed_height();
+
     Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
         if (generate_and_load())
             EndModal(wxID_OK);
     }, wxID_OK);
+}
+
+// Layer height of the current print preset (falls back to 0.2 mm).
+static double current_layer_height()
+{
+    if (const PresetBundle* pb = wxGetApp().preset_bundle) {
+        if (const auto* opt = pb->prints.get_selected_preset()
+                                  .config.option<ConfigOptionFloat>("layer_height"))
+            return opt->getFloat();
+    }
+    return 0.2;
+}
+
+void CalibrationRetractionDialog::update_computed_height()
+{
+    if (!m_tower_height_label)
+        return;
+
+    const double start = m_start_retract->GetValue();
+    const double end   = m_end_retract->GetValue();
+    const double step  = m_retract_step->GetValue();
+
+    if (end <= start || step <= 0.0) {
+        m_tower_height_label->SetLabel(_L("—"));
+        return;
+    }
+
+    const int    num_levels   = static_cast<int>(std::round((end - start) / step)) + 1;
+    const double level_height = LAYERS_PER_LEVEL * current_layer_height();
+    const double height       = num_levels * level_height;
+    m_tower_height_label->SetLabel(wxString::Format(_L("%.1f mm (auto)"), height));
+    Layout();
 }
 
 bool CalibrationRetractionDialog::generate_and_load()
@@ -140,7 +182,6 @@ bool CalibrationRetractionDialog::generate_and_load()
     double start   = m_start_retract->GetValue();
     double end     = m_end_retract->GetValue();
     double step    = m_retract_step->GetValue();
-    int    height  = m_tower_height->GetValue();
     int    diam    = m_tower_diameter->GetValue();
     int    spacing = m_tower_spacing->GetValue();
 
@@ -162,21 +203,14 @@ bool CalibrationRetractionDialog::generate_and_load()
         return false;
     }
 
-    // Get layer height from current print config
-    double layer_height = 0.2;
-    const PresetBundle* pb = wxGetApp().preset_bundle;
-    if (pb) {
-        const auto* opt = pb->prints.get_selected_preset()
-                              .config.option<ConfigOptionFloat>("layer_height");
-        if (opt)
-            layer_height = opt->getFloat();
-    }
+    // Layer height from the current print config (same source as the dialog's
+    // computed tower-height display).
+    double layer_height = current_layer_height();
 
-    // Compute actual tower height to fit all levels evenly
+    // Tower height is derived from the levels so every band prints in full.
+    // (It is shown read-only in the dialog; see update_computed_height.)
     double level_height = LAYERS_PER_LEVEL * layer_height;
     double actual_height = num_levels * level_height;
-    if (actual_height > height)
-        actual_height = height;
 
     BOOST_LOG_TRIVIAL(info) << "Generating retraction towers: start=" << start
                             << " end=" << end << " step=" << step

--- a/src/slic3r/GUI/CalibrationRetractionDialog.cpp
+++ b/src/slic3r/GUI/CalibrationRetractionDialog.cpp
@@ -35,6 +35,14 @@ namespace Slic3r { namespace GUI {
 // Number of layers printed at each retraction value
 static constexpr int LAYERS_PER_LEVEL = 5;
 
+// Height of the base plate make_retraction_towers() puts under the cylinders.
+// The retraction bands span z = TOWER_BASE_HEIGHT .. TOWER_BASE_HEIGHT +
+// num_levels*level_height, and make_retraction_towers() treats its argument as
+// the *total* model height (base + cylinders). So the derived height must
+// include the base, or the cylinders fall one base-height short of the top
+// band and the highest retraction value has no geometry to print.
+static constexpr double TOWER_BASE_HEIGHT = 1.0;  // mm; matches CalibrationModels.cpp
+
 CalibrationRetractionDialog::CalibrationRetractionDialog(wxWindow* parent)
     : wxDialog(parent, wxID_ANY, _L("Retraction Calibration"),
                wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE)
@@ -172,7 +180,7 @@ void CalibrationRetractionDialog::update_computed_height()
 
     const int    num_levels   = static_cast<int>(std::round((end - start) / step)) + 1;
     const double level_height = LAYERS_PER_LEVEL * current_layer_height();
-    const double height       = num_levels * level_height;
+    const double height       = TOWER_BASE_HEIGHT + num_levels * level_height;
     m_tower_height_label->SetLabel(wxString::Format(_L("%.1f mm (auto)"), height));
     Layout();
 }
@@ -208,9 +216,11 @@ bool CalibrationRetractionDialog::generate_and_load()
     double layer_height = current_layer_height();
 
     // Tower height is derived from the levels so every band prints in full.
-    // (It is shown read-only in the dialog; see update_computed_height.)
+    // Includes the 1 mm base (TOWER_BASE_HEIGHT) because the bands span
+    // z = base .. base + num_levels*level_height and make_retraction_towers
+    // takes the total model height. (Shown read-only; see update_computed_height.)
     double level_height = LAYERS_PER_LEVEL * layer_height;
-    double actual_height = num_levels * level_height;
+    double actual_height = TOWER_BASE_HEIGHT + num_levels * level_height;
 
     BOOST_LOG_TRIVIAL(info) << "Generating retraction towers: start=" << start
                             << " end=" << end << " step=" << step
@@ -404,7 +414,7 @@ bool CalibrationRetractionDialog::generate_and_load()
     std::vector<std::pair<double, double>> levels;
     levels.reserve(num_levels);
     for (int i = 0; i < num_levels; ++i) {
-        double z_top   = 1.0 + double(i + 1) * level_height;
+        double z_top   = TOWER_BASE_HEIGHT + double(i + 1) * level_height;
         double retract = start + i * step;
         levels.emplace_back(z_top, retract);
     }

--- a/src/slic3r/GUI/CalibrationRetractionDialog.hpp
+++ b/src/slic3r/GUI/CalibrationRetractionDialog.hpp
@@ -8,14 +8,15 @@
 #include <wx/dialog.h>
 #include <wx/checkbox.h>
 #include <wx/spinctrl.h>
+#include <wx/stattext.h>
 
 namespace Slic3r { namespace GUI {
 
 /// Retraction calibration: generates two cylindrical towers.
-/// Retraction distance varies per layer group by emitting a post-process
-/// Python script that rewrites each `G1 E-x` retract/recovery in the
-/// sliced G-code based on the current Z. This works on Buddy firmware,
-/// which does not implement M207/G10/G11.
+/// Retraction distance varies per Z band via an in-process post-processor
+/// that rewrites each `G1 E-x` retract/recovery in the exported G-code based
+/// on its Z height. This works on Buddy firmware, which does not implement
+/// M207/G10/G11.
 class CalibrationRetractionDialog : public wxDialog
 {
 public:
@@ -25,10 +26,14 @@ private:
     wxSpinCtrlDouble* m_start_retract{nullptr};
     wxSpinCtrlDouble* m_end_retract{nullptr};
     wxSpinCtrlDouble* m_retract_step{nullptr};
-    wxSpinCtrl*       m_tower_height{nullptr};
+    wxStaticText*     m_tower_height_label{nullptr};
     wxSpinCtrl*       m_tower_diameter{nullptr};
     wxSpinCtrl*       m_tower_spacing{nullptr};
     wxCheckBox*       m_brim{nullptr};
+
+    // Tower height is derived from the retraction range, step, and layer
+    // height; this refreshes the read-only display from the current inputs.
+    void update_computed_height();
 
     bool generate_and_load();
 };


### PR DESCRIPTION
## Issue
[#24](https://github.com/hyiger/PrusaSlicer/issues/24) — three complaints, all real:
1. Zero `M207` in the output (even with firmware retraction enabled).
2. Retraction doesn't vary up the tower.
3. The "Tower height" field seems meaningless.

## Root causes (high confidence)
1. **`M207` is by design absent — the docs were wrong.** The tool was reworked for Buddy firmware (Core ONE/MK4/MINI/XL don't implement M207). The dialog forces `use_firmware_retraction=false` and a post-processor rewrites plain `G1 E` retracts per Z band. No `M207` will ever appear.
2. **"No variance" = preview-only confusion.** The per-Z rewrite runs at **export/upload**, not in the in-app preview (`run_post_process_scripts` is called from `finalize_gcode`/`prepare_upload`, not the preview's `export_gcode`). In the preview every retract sits at the sentinel value → looks uniform. The gradient *is* in the exported file. *(If an exported file is still uniform for the reporter, that's a separate secondary cause — see the issue thread; needs a real Core ONE `.gcode`.)*
3. **"Tower height" was dead and harmful.** Height is actually `num_levels × level_height`; the field only clamped *downward*. Set below the derived height it truncated the tower geometry while the post-processor band table ([dialog:372-376](src/slic3r/GUI/CalibrationRetractionDialog.cpp)) still spanned the full height → top bands printed above the tower and never appeared.

## Fix
- **Docs:** rewrote guide §4 — removed the `M207`/firmware-retraction claims, described the real slicer-side per-Z rewrite, and explained that the gradient shows only in the **exported** G-code, not the preview.
- **Tower height → read-only computed:** replaced the editable spin field with a live-updated label showing the derived height; removed the downward clamp so geometry and bands always agree. (Per the triage decision: read-only/computed, not removed or authoritative.)

## Verification
- `libslic3r_gui` compiles clean (incremental build, exit 0).
- Manual: Calibration → Retraction shows the computed height updating as Start/End/Step change; export a tower and confirm `G1 E-…` retraction magnitudes step up per Z band (and no `M207`). The in-app preview is expected to look uniform.
- Existing `tests/libslic3r/test_calibration.cpp [calibration]` retraction tests unaffected (no post-processor logic changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)