### PR TITLE
PA line + pattern via per-object post-processor (supersedes #28) — #21

### DIFF
--- a/doc/Calibration_Guide.md
+++ b/doc/Calibration_Guide.md
@@ -98,7 +98,7 @@ The layer count for each level (default 4 layers) is printed from bottom to top.
 
 > **Note:** The PA command is auto-detected from your printer profile: `M572 S` for Prusa printers (except MINI), `M900 K` for MINI and Marlin firmware, and `SET_PRESSURE_ADVANCE` for Klipper.
 
-**Evaluating the line / pattern styles:** the bands sit front-to-back, start PA at the front and end PA at the back, evenly spaced by your step (a band's PA is `start + index × step`). Inspect each chevron's corner: bulging/rounded = too little PA, gaps/under-extrusion = too much, sharp and clean = correct. Pick the band with the cleanest corner and set that PA. Unlike the tower, these print as a normal sliced job, so the preview shows the real toolpaths.
+**Evaluating the line / pattern styles:** the bands sit front-to-back (start PA at the front, end PA at the back), and **each band is printed with its PA value embossed below it**, so you can read the value directly. Inspect each chevron's corner: bulging/rounded = too little PA, gaps/under-extrusion = too much, sharp and clean = correct. Pick the band with the cleanest corner and set its labeled PA. Unlike the tower, these print as a normal sliced job, so the preview shows the real toolpaths.
 
 ---
 

--- a/doc/Calibration_Guide.md
+++ b/doc/Calibration_Guide.md
@@ -58,11 +58,19 @@ Choose the tier that shows the best overall balance and set your filament temper
 
 ## 3. Pressure Advance
 
-**What it does:** Generates a chevron (V-shape) pattern tower where each layer group is printed with a different Pressure Advance value. Pressure Advance compensates for the delay between the extruder motor pushing filament and it actually flowing from the nozzle.
+**What it does:** Runs a Pressure Advance test where different parts of the print use different PA values. Pressure Advance compensates for the delay between the extruder motor pushing filament and it actually flowing from the nozzle.
+
+**Test styles** (choose in the dialog's *Test style* dropdown):
+
+- **Chevron tower** *(default)* — a tall tower of nested V-shapes; PA changes once per layer group. Read the result by height.
+- **PA line** — a flat, single-layer row of long chevron bands, one per PA value.
+- **PA pattern** — a flat, single-layer row of compact chevron bands, one per PA value.
+
+The **line** and **pattern** styles print **one small chevron per PA value, side by side**. Each band is a separate object sliced by the normal pipeline; an in-process post-processor injects the firmware PA command at each band's boundary (keyed on the band's object label). Because the bands are sliced normally, their flow, temperatures, acceleration, leveling, and retraction match a real print — so the PA you read transfers directly. Bands run **front (start PA) → back (end PA)**.
 
 **How to use it:**
 
-1. Go to **Calibration → Pressure Advance**.
+1. Go to **Calibration → Pressure Advance** and pick a **Test style**.
 2. Set the start PA, end PA, and step size.
    - For direct drive extruders, try 0.0 to 0.1 with a step of 0.005.
    - For Bowden extruders, try 0.0 to 2.0 with a step of 0.05.
@@ -89,6 +97,8 @@ PA = start_PA + (layer_number / layers_per_level) × step
 The layer count for each level (default 4 layers) is printed from bottom to top. Set the optimal PA value in your printer firmware configuration.
 
 > **Note:** The PA command is auto-detected from your printer profile: `M572 S` for Prusa printers (except MINI), `M900 K` for MINI and Marlin firmware, and `SET_PRESSURE_ADVANCE` for Klipper.
+
+**Evaluating the line / pattern styles:** the bands sit front-to-back, start PA at the front and end PA at the back, evenly spaced by your step (a band's PA is `start + index × step`). Inspect each chevron's corner: bulging/rounded = too little PA, gaps/under-extrusion = too much, sharp and clean = correct. Pick the band with the cleanest corner and set that PA. Unlike the tower, these print as a normal sliced job, so the preview shows the real toolpaths.
 
 ---
 

--- a/src/libslic3r/CMakeLists.txt
+++ b/src/libslic3r/CMakeLists.txt
@@ -175,6 +175,8 @@ set(SLIC3R_SOURCES
     GCode/CalibrationRetractionPostProcessor.hpp
     GCode/CalibrationFlowPostProcessor.cpp
     GCode/CalibrationFlowPostProcessor.hpp
+    GCode/CalibrationPAPostProcessor.cpp
+    GCode/CalibrationPAPostProcessor.hpp
     GCode/CoolingBuffer.cpp
     GCode/CoolingBuffer.hpp
     GCode/ExtrusionProcessor.cpp

--- a/src/libslic3r/GCode/CalibrationPAPostProcessor.cpp
+++ b/src/libslic3r/GCode/CalibrationPAPostProcessor.cpp
@@ -225,7 +225,14 @@ bool run_calibration_pa_post_processor(const std::string &url, const std::string
 
     static const std::string kStart = "; printing object ";
     static const std::string kStop  = "; stop printing object ";
+    const std::string        marker = calibration_pa_marker();
 
+    // OctoPrint labeling emits an all-objects header (LabelObjects::all_objects_header)
+    // that lists every object with the SAME "; printing object" / "; stop printing
+    // object" comments BEFORE the start G-code. Only inject once the first-layer
+    // marker has been seen, so PA commands land at real band boundaries, never in
+    // that header (before homing / tool setup).
+    bool        started  = false;
     size_t      injected = 0;
     std::string line;
     line.reserve(256);
@@ -234,13 +241,16 @@ bool run_calibration_pa_post_processor(const std::string &url, const std::string
         if (!raw.empty() && raw.back() == '\r')
             raw.pop_back();
 
-        if (boost::starts_with(raw, kStart)) {
+        if (!started && raw.find(marker) != std::string::npos)
+            started = true;
+
+        if (started && boost::starts_with(raw, kStart)) {
             out << line << '\n';
             out << pa_command(params.cmd, pa_for_name(octoprint_object_name(raw.substr(kStart.size()))));
             ++injected;
             continue;
         }
-        if (boost::starts_with(raw, kStop)) {
+        if (started && boost::starts_with(raw, kStop)) {
             out << line << '\n';
             out << pa_command(params.cmd, params.base);   // restore baseline between bands
             continue;

--- a/src/libslic3r/GCode/CalibrationPAPostProcessor.cpp
+++ b/src/libslic3r/GCode/CalibrationPAPostProcessor.cpp
@@ -1,0 +1,258 @@
+///|/ Copyright (c) 2025
+///|/
+///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
+///|/
+#include "CalibrationPAPostProcessor.hpp"
+
+#include "libslic3r/Exception.hpp"
+#include "libslic3r/format.hpp"
+
+#include <LocalesUtils.hpp>
+
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/log/trivial.hpp>
+#include <boost/nowide/fstream.hpp>
+
+#include <algorithm>
+#include <cstdio>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace Slic3r {
+
+static constexpr const char *BUILTIN_PREFIX = "::builtin::pa_calibration";
+
+bool is_calibration_pa_url(const std::string &script)
+{
+    return boost::starts_with(script, BUILTIN_PREFIX);
+}
+
+namespace {
+
+const char *cmd_token(PACalibrationCommand cmd)
+{
+    switch (cmd) {
+    case PACalibrationCommand::Klipper: return "klipper";
+    case PACalibrationCommand::M900:    return "m900";
+    case PACalibrationCommand::M572:
+    default:                            return "m572";
+    }
+}
+
+PACalibrationCommand cmd_from_token(const std::string &t)
+{
+    if (t == "klipper") return PACalibrationCommand::Klipper;
+    if (t == "m900")    return PACalibrationCommand::M900;
+    return PACalibrationCommand::M572;
+}
+
+// Firmware pressure-advance command for a value (locale-invariant).
+std::string pa_command(PACalibrationCommand cmd, double pa)
+{
+    char buf[24];
+    std::snprintf(buf, sizeof(buf), "%.4f", pa);
+    switch (cmd) {
+    case PACalibrationCommand::Klipper: return std::string("SET_PRESSURE_ADVANCE ADVANCE=") + buf + "\n";
+    case PACalibrationCommand::M900:    return std::string("M900 K") + buf + "\n";
+    case PACalibrationCommand::M572:
+    default:                            return std::string("M572 S") + buf + "\n";
+    }
+}
+
+// Klipper sanitizes object-label names (see LabelObjects.cpp). Mirror it so the
+// PA map matches the rewritten names if a Klipper EXCLUDE_OBJECT form is used.
+std::string klipper_sanitize(const std::string &name)
+{
+    static const std::string banned = "\b\t\n\v\f\r \"#%&\'*-./:;<>\\";
+    std::string out = name;
+    std::replace_if(out.begin(), out.end(),
+                    [](char c) { return banned.find(c) != std::string::npos; }, '_');
+    return out;
+}
+
+struct PAParams
+{
+    PACalibrationCommand        cmd  = PACalibrationCommand::M572;
+    double                      base = 0.0;
+    std::map<std::string, double> pa; // object name -> PA
+};
+
+// Throws on a malformed URL.
+PAParams parse_url(const std::string &url)
+{
+    auto qpos = url.find('?');
+    if (qpos == std::string::npos)
+        throw Slic3r::RuntimeError(format("pa_calibration URL has no query string: %1%", url));
+
+    PAParams p;
+    bool     have_objects = false;
+
+    std::string query = url.substr(qpos + 1);
+    size_t      pos   = 0;
+    while (pos < query.size()) {
+        size_t      amp = query.find('&', pos);
+        std::string kv  = query.substr(pos, amp == std::string::npos ? std::string::npos : amp - pos);
+        pos             = amp == std::string::npos ? query.size() : amp + 1;
+
+        size_t eq = kv.find('=');
+        if (eq == std::string::npos)
+            continue;
+        std::string key = kv.substr(0, eq);
+        std::string val = kv.substr(eq + 1);
+
+        if (key == "cmd") {
+            p.cmd = cmd_from_token(val);
+        } else if (key == "base") {
+            p.base = std::stod(val);
+        } else if (key == "objects") {
+            size_t lp = 0;
+            while (lp < val.size()) {
+                size_t      comma = val.find(',', lp);
+                std::string pair  = val.substr(lp, comma == std::string::npos ? std::string::npos : comma - lp);
+                lp                = comma == std::string::npos ? val.size() : comma + 1;
+                // Split at the LAST ':' so a name may itself contain ':'.
+                size_t colon = pair.rfind(':');
+                if (colon == std::string::npos)
+                    throw Slic3r::RuntimeError(format("pa_calibration object missing ':': %1%", pair));
+                std::string name = pair.substr(0, colon);
+                double      pa   = std::stod(pair.substr(colon + 1));
+                p.pa[name]       = pa;
+                p.pa.emplace(klipper_sanitize(name), pa);
+            }
+            have_objects = true;
+        }
+    }
+
+    if (!have_objects || p.pa.empty())
+        throw Slic3r::RuntimeError(format("pa_calibration URL missing objects: %1%", url));
+    return p;
+}
+
+// OctoPrint object-label comments carry the name plus a trailing
+// " id:<n> copy <m>" suffix (LabelObjects::init). Recover the bare name.
+std::string octoprint_object_name(const std::string &after_prefix)
+{
+    std::string name = after_prefix;
+    boost::trim(name);
+    size_t id = name.rfind(" id:");
+    if (id != std::string::npos && name.find(" copy ", id) != std::string::npos)
+        name = name.substr(0, id);
+    return name;
+}
+
+} // namespace
+
+std::string make_calibration_pa_url(PACalibrationCommand cmd, double base_pa,
+                                    const std::vector<std::pair<std::string, double>> &objects)
+{
+    // Force the C numeric locale so the URL always uses '.' decimals; it is
+    // comma-delimited, so a comma decimal separator would make it ambiguous.
+    CNumericLocalesSetter locales_setter;
+
+    std::ostringstream out;
+    out << BUILTIN_PREFIX << "?cmd=" << cmd_token(cmd) << "&base=";
+    char buf[32];
+    std::snprintf(buf, sizeof(buf), "%.4f", base_pa);
+    out << buf << "&objects=";
+    for (size_t i = 0; i < objects.size(); ++i) {
+        if (i != 0) out << ',';
+        out << objects[i].first << ':';
+        std::snprintf(buf, sizeof(buf), "%.4f", objects[i].second);
+        out << buf;
+    }
+    return out.str();
+}
+
+bool run_calibration_pa_post_processor(const std::string &url, const std::string &gcode_path)
+{
+    BOOST_LOG_TRIVIAL(info) << "pa_calibration: starting in-process post-process on " << gcode_path;
+
+    CNumericLocalesSetter locales_setter;
+
+    const PAParams params = parse_url(url);
+
+    boost::filesystem::path src(gcode_path);
+
+    // Pass 1 — only a G-code carrying the job-scoped calibration marker should
+    // be rewritten; the post_process hook persists in the preset and runs for
+    // every slice, so a normal print must pass through untouched.
+    {
+        boost::nowide::ifstream scan(gcode_path);
+        if (!scan.is_open())
+            throw Slic3r::RuntimeError(format("pa_calibration: cannot open %1%", gcode_path));
+        const std::string marker = calibration_pa_marker();
+        bool              found  = false;
+        std::string       l;
+        while (std::getline(scan, l)) {
+            if (l.find(marker) != std::string::npos) { found = true; break; }
+        }
+        if (!found) {
+            BOOST_LOG_TRIVIAL(info) << "pa_calibration: marker absent, leaving " << gcode_path << " unchanged";
+            return false;
+        }
+    }
+
+    // A marker-carrying file should be ASCII (the dialog forces binary_gcode=false).
+    {
+        boost::nowide::ifstream sniff(gcode_path, std::ios::binary);
+        char magic[4] = {};
+        sniff.read(magic, 4);
+        if (sniff.gcount() == 4 && std::string(magic, 4) == "GCDE")
+            throw Slic3r::RuntimeError(format(
+                "pa_calibration: input %1% is binary G-code (.bgcode); the in-process "
+                "rewriter only operates on ASCII. Set binary_gcode=false for calibration prints.",
+                gcode_path));
+    }
+
+    boost::filesystem::path tmp = src;
+    tmp += ".pacal.tmp";
+
+    boost::nowide::ifstream in(gcode_path);
+    if (!in.is_open())
+        throw Slic3r::RuntimeError(format("pa_calibration: cannot open %1%", gcode_path));
+    boost::nowide::ofstream out(tmp.string(), std::ios::binary | std::ios::trunc);
+    if (!out.is_open())
+        throw Slic3r::RuntimeError(format("pa_calibration: cannot write %1%", tmp.string()));
+
+    auto pa_for_name = [&](const std::string &name) -> double {
+        auto it = params.pa.find(name);
+        return it == params.pa.end() ? params.base : it->second;
+    };
+
+    static const std::string kStart = "; printing object ";
+    static const std::string kStop  = "; stop printing object ";
+
+    size_t      injected = 0;
+    std::string line;
+    line.reserve(256);
+    while (std::getline(in, line)) {
+        std::string raw = line;
+        if (!raw.empty() && raw.back() == '\r')
+            raw.pop_back();
+
+        if (boost::starts_with(raw, kStart)) {
+            out << line << '\n';
+            out << pa_command(params.cmd, pa_for_name(octoprint_object_name(raw.substr(kStart.size()))));
+            ++injected;
+            continue;
+        }
+        if (boost::starts_with(raw, kStop)) {
+            out << line << '\n';
+            out << pa_command(params.cmd, params.base);   // restore baseline between bands
+            continue;
+        }
+        out << line << '\n';
+    }
+    in.close();
+    out.close();
+
+    boost::filesystem::rename(tmp, src);
+    BOOST_LOG_TRIVIAL(info) << "pa_calibration: injected PA at " << injected << " object boundaries in " << gcode_path;
+    return true;
+}
+
+} // namespace Slic3r

--- a/src/libslic3r/GCode/CalibrationPAPostProcessor.cpp
+++ b/src/libslic3r/GCode/CalibrationPAPostProcessor.cpp
@@ -250,7 +250,17 @@ bool run_calibration_pa_post_processor(const std::string &url, const std::string
     in.close();
     out.close();
 
-    boost::filesystem::rename(tmp, src);
+    boost::system::error_code ec;
+    boost::filesystem::rename(tmp, src, ec);
+    if (ec) {
+        // Fallback: rename can fail across filesystems, or (Windows) when the
+        // destination already exists; copy over it and drop the temp file.
+        boost::filesystem::copy_file(tmp, src, boost::filesystem::copy_options::overwrite_existing, ec);
+        if (ec)
+            throw Slic3r::RuntimeError(format("pa_calibration: failed replacing %1%: %2%",
+                                              src.string(), ec.message()));
+        boost::filesystem::remove(tmp, ec);
+    }
     BOOST_LOG_TRIVIAL(info) << "pa_calibration: injected PA at " << injected << " object boundaries in " << gcode_path;
     return true;
 }

--- a/src/libslic3r/GCode/CalibrationPAPostProcessor.hpp
+++ b/src/libslic3r/GCode/CalibrationPAPostProcessor.hpp
@@ -1,0 +1,58 @@
+///|/ Copyright (c) 2025
+///|/
+///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
+///|/
+#ifndef slic3r_CalibrationPAPostProcessor_hpp_
+#define slic3r_CalibrationPAPostProcessor_hpp_
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace Slic3r {
+
+// In-process post-processor for the flat (line / pattern) Pressure Advance
+// calibration. Unlike the chevron *tower* (which changes PA per Z layer), the
+// flat test prints one small chevron band per PA value, side by side on a
+// single layer. PA cannot vary within a layer through the slice pipeline, so —
+// exactly like the YOLO Flow Rate tool — each band is a separate object and
+// this post-processor INJECTS the firmware PA command at each object's start,
+// keyed on the object-label name. Everything else (temperatures, leveling,
+// flow, acceleration, axis, etc.) is produced by the real exporter, so it
+// matches a normal print of the same printer/filament.
+//
+// Triggered via the standard `post_process` config when an entry starts with
+// `::builtin::pa_calibration?...`. It rewrites ONLY a G-code carrying the
+// job-scoped calibration marker (calibration_pa_marker) and is a pass-through
+// no-op otherwise. The dialog forces OctoPrint object labeling, so the boundary
+// comments ("; printing object <name>" / "; stop printing object <name>") are
+// emitted on every G-code flavor.
+//
+// URL format:
+//     ::builtin::pa_calibration?cmd=<m572|m900|klipper>&base=<pa>&objects=<name>:<pa>,...
+// <name> is the object-label name (the PA value's text, e.g. "0.020"); <pa> is
+// the pressure-advance value for that band; <base> is restored after each band.
+
+enum class PACalibrationCommand { M572, M900, Klipper };
+
+bool is_calibration_pa_url(const std::string &script);
+
+inline constexpr const char *calibration_pa_marker()
+{
+    return "PRUSASLICER_PA_CALIBRATION";
+}
+
+// Run the post-processor against `gcode_path`. Returns true if the file was
+// rewritten, false if left untouched (no marker — i.e. not a PA calibration
+// print). Throws on a malformed URL, an unreadable file, or a marker-carrying
+// binary G-code.
+bool run_calibration_pa_post_processor(const std::string &url, const std::string &gcode_path);
+
+// Build a `::builtin::pa_calibration?...` URL. PA values are formatted
+// locale-invariantly ('.' decimals).
+std::string make_calibration_pa_url(PACalibrationCommand cmd, double base_pa,
+                                    const std::vector<std::pair<std::string, double>> &objects);
+
+} // namespace Slic3r
+
+#endif // slic3r_CalibrationPAPostProcessor_hpp_

--- a/src/libslic3r/GCode/PostProcessor.cpp
+++ b/src/libslic3r/GCode/PostProcessor.cpp
@@ -6,6 +6,7 @@
 #include "PostProcessor.hpp"
 #include "CalibrationRetractionPostProcessor.hpp"
 #include "CalibrationFlowPostProcessor.hpp"
+#include "CalibrationPAPostProcessor.hpp"
 
 #include "libslic3r/Utils.hpp"
 #include "libslic3r/format.hpp"
@@ -296,6 +297,18 @@ bool run_post_process_scripts(std::string &src_path, bool make_copy, const std::
                     BOOST_LOG_TRIVIAL(info) << "Running built-in post-processor: " << script;
                     try {
                         run_calibration_flow_post_processor(script, gcode_file.string());
+                    } catch (const std::exception &err) {
+                        delete_copy();
+                        throw Slic3r::RuntimeError(
+                            (boost::format("Built-in post-processor %1% on file %2% failed:\n%3%")
+                                 % script % path % err.what()).str());
+                    }
+                    continue;
+                }
+                if (is_calibration_pa_url(script)) {
+                    BOOST_LOG_TRIVIAL(info) << "Running built-in post-processor: " << script;
+                    try {
+                        run_calibration_pa_post_processor(script, gcode_file.string());
                     } catch (const std::exception &err) {
                         delete_copy();
                         throw Slic3r::RuntimeError(

--- a/src/slic3r/GUI/CalibrationPADialog.cpp
+++ b/src/slic3r/GUI/CalibrationPADialog.cpp
@@ -468,22 +468,21 @@ bool CalibrationPADialog::generate_flat(int kind)   // 1 = line, 2 = pattern
     }
 
     // --- Job-scoped calibration marker (first layer) ---
+    // The whole test is a single layer, and assign_custom_gcodes() keeps only one
+    // custom_gcode per layer — so the marker must be the SOLE entry, or a competing
+    // first-layer entry (a stale marker, a user pause/color change) could evict it
+    // and the post-processor would see no marker and inject no PA. Clear the list.
     {
         CustomGCode::Info& cg = model.custom_gcode_per_print_z();
-        const std::string marker_extra = std::string("; ") + calibration_pa_marker() + "\n";
-        cg.gcodes.erase(std::remove_if(cg.gcodes.begin(), cg.gcodes.end(),
-                            [&](const CustomGCode::Item& it) { return it.extra == marker_extra; }),
-                        cg.gcodes.end());
-        if (cg.gcodes.empty())
-            cg.mode = CustomGCode::SingleExtruder;
+        cg.mode = CustomGCode::SingleExtruder;
+        cg.gcodes.clear();
         CustomGCode::Item marker;
         marker.print_z  = layer_height / 2.0;
         marker.type     = CustomGCode::Custom;
         marker.extruder = 1;
         marker.color    = "";
-        marker.extra    = marker_extra;
+        marker.extra    = std::string("; ") + calibration_pa_marker() + "\n";
         cg.gcodes.push_back(marker);
-        std::sort(cg.gcodes.begin(), cg.gcodes.end());
     }
 
     // --- Speed overrides + OctoPrint labels (mirror the tower path) ---

--- a/src/slic3r/GUI/CalibrationPADialog.cpp
+++ b/src/slic3r/GUI/CalibrationPADialog.cpp
@@ -15,6 +15,9 @@
 #include "libslic3r/Model.hpp"
 #include "libslic3r/CalibrationModels.hpp"
 #include "libslic3r/TriangleMesh.hpp"
+#include "libslic3r/BoundingBox.hpp"
+#include "libslic3r/BuildVolume.hpp"
+#include "libslic3r/GCode/CalibrationPAPostProcessor.hpp"
 
 #include <wx/sizer.h>
 #include <wx/stattext.h>
@@ -42,7 +45,17 @@ CalibrationPADialog::CalibrationPADialog(wxWindow* parent)
     wxGetApp().UpdateDarkUI(this);
 
     auto* sizer = new wxBoxSizer(wxVERTICAL);
-    auto* grid  = new wxFlexGridSizer(4, 2, 10, 15);
+    auto* grid  = new wxFlexGridSizer(5, 2, 10, 15);
+
+    // Test style
+    grid->Add(new wxStaticText(this, wxID_ANY, _L("Test style:")),
+              0, wxALIGN_CENTER_VERTICAL);
+    m_mode = new wxChoice(this, wxID_ANY);
+    m_mode->Append(_L("Chevron tower (per-layer PA)"));
+    m_mode->Append(_L("PA line (flat, per-band)"));
+    m_mode->Append(_L("PA pattern (flat, per-band)"));
+    m_mode->SetSelection(0);
+    grid->Add(m_mode, 0, wxEXPAND);
 
     // Start PA
     grid->Add(new wxStaticText(this, wxID_ANY, _L("Start PA:")),
@@ -94,6 +107,7 @@ CalibrationPADialog::CalibrationPADialog(wxWindow* parent)
     m_brim->SetValue(false);
     sizer->Add(m_brim, 0, wxLEFT | wxRIGHT | wxBOTTOM, 15);
 
+    wxGetApp().UpdateDarkUI(m_mode);
     wxGetApp().UpdateDarkUI(m_start_pa);
     wxGetApp().UpdateDarkUI(m_end_pa);
     wxGetApp().UpdateDarkUI(m_pa_step);
@@ -119,6 +133,12 @@ CalibrationPADialog::CalibrationPADialog(wxWindow* parent)
 }
 
 bool CalibrationPADialog::generate_and_load()
+{
+    const int mode = m_mode ? m_mode->GetSelection() : 0;
+    return mode == 0 ? generate_tower() : generate_flat(mode);
+}
+
+bool CalibrationPADialog::generate_tower()
 {
     double start_pa = m_start_pa->GetValue();
     double end_pa   = m_end_pa->GetValue();
@@ -343,6 +363,220 @@ bool CalibrationPADialog::generate_and_load()
 
     apply_calibration_filename_prefix("PressureAdvance");
 
+    return true;
+}
+
+bool CalibrationPADialog::generate_flat(int kind)   // 1 = line, 2 = pattern
+{
+    const double start_pa = m_start_pa->GetValue();
+    const double end_pa   = m_end_pa->GetValue();
+    const double step     = m_pa_step->GetValue();
+    if (start_pa >= end_pa) {
+        wxMessageBox(_L("End PA must be greater than start PA."), _L("Error"), wxOK | wxICON_ERROR, this);
+        return false;
+    }
+    if (step <= 0.0) {
+        wxMessageBox(_L("PA step must be positive."), _L("Error"), wxOK | wxICON_ERROR, this);
+        return false;
+    }
+    const int num_bands = static_cast<int>(std::floor((end_pa - start_pa) / step + 1e-9)) + 1;
+    if (num_bands < 2) {
+        wxMessageBox(_L("PA range too small for the given step."), _L("Error"), wxOK | wxICON_ERROR, this);
+        return false;
+    }
+
+    const PresetBundle* pb = wxGetApp().preset_bundle;
+    if (!pb) return false;
+    double layer_height = 0.2;
+    if (const auto* opt = pb->prints.get_selected_preset().config.option<ConfigOptionFloat>("layer_height"))
+        layer_height = opt->getFloat();
+
+    Plater* plater = wxGetApp().plater();
+    if (!plater) return false;
+
+    auto fmt4 = [](double v) { char b[24]; std::snprintf(b, sizeof(b), "%.4f", v); return std::string(b); };
+
+    // --- Geometry: one 1-layer chevron band per PA value ---
+    const boost::filesystem::path tmp_dir = boost::filesystem::temp_directory_path();
+    std::vector<boost::filesystem::path> stl_paths;
+    stl_paths.reserve(num_bands);
+    for (int i = 0; i < num_bands; ++i) {
+        // Both styles are sharp 90° chevrons (a sharp corner is what reveals PA);
+        // "line" uses longer arms (reads as a long line), "pattern" is compact.
+        indexed_triangle_set its = (kind == 2)
+            ? Slic3r::make_pa_pattern(1, layer_height, 90.0, 18.0, 1.6)
+            : Slic3r::make_pa_pattern(1, layer_height, 90.0, 35.0, 1.2);
+        if (its.vertices.empty() || its.indices.empty()) {
+            wxMessageBox(_L("Failed to generate PA band geometry."), _L("Error"), wxOK | wxICON_ERROR, this);
+            return false;
+        }
+        const std::string fname = "pa_band_" + std::to_string(i) + ".stl";
+        boost::filesystem::path path = tmp_dir / fname;
+        if (!its_write_stl_binary(path.string().c_str(), fname.c_str(), its)) {
+            wxMessageBox(_L("Failed to write PA band STL."), _L("Error"), wxOK | wxICON_ERROR, this);
+            return false;
+        }
+        stl_paths.push_back(path);
+    }
+
+    std::vector<size_t> loaded = plater->load_files(stl_paths, true, false);
+    Model& model = wxGetApp().model();
+    if (loaded.size() < (size_t)num_bands) {
+        BOOST_LOG_TRIVIAL(error) << "PA flat calibration: expected " << num_bands
+                                 << " bands, loaded " << loaded.size();
+        return false;
+    }
+
+    // Name each band by its PA value — the key the post-processor matches.
+    std::vector<std::pair<std::string, double>> object_pa;
+    object_pa.reserve(num_bands);
+    for (int i = 0; i < num_bands && i < (int)loaded.size(); ++i) {
+        const double pa  = start_pa + i * step;
+        ModelObject* obj = model.objects[loaded[i]];
+        if (!obj) return false;
+        obj->name = fmt4(pa);
+        object_pa.emplace_back(obj->name, pa);
+    }
+
+    // --- Job-scoped calibration marker (first layer) ---
+    {
+        CustomGCode::Info& cg = model.custom_gcode_per_print_z();
+        const std::string marker_extra = std::string("; ") + calibration_pa_marker() + "\n";
+        cg.gcodes.erase(std::remove_if(cg.gcodes.begin(), cg.gcodes.end(),
+                            [&](const CustomGCode::Item& it) { return it.extra == marker_extra; }),
+                        cg.gcodes.end());
+        if (cg.gcodes.empty())
+            cg.mode = CustomGCode::SingleExtruder;
+        CustomGCode::Item marker;
+        marker.print_z  = layer_height / 2.0;
+        marker.type     = CustomGCode::Custom;
+        marker.extruder = 1;
+        marker.color    = "";
+        marker.extra    = marker_extra;
+        cg.gcodes.push_back(marker);
+        std::sort(cg.gcodes.begin(), cg.gcodes.end());
+    }
+
+    // --- Speed overrides + OctoPrint labels (mirror the tower path) ---
+    const double test_speed = m_test_speed ? m_test_speed->GetValue() : 100.0;
+    wxGetApp().preset_bundle->prints.discard_current_changes();
+    {
+        DynamicPrintConfig& config = wxGetApp().preset_bundle->prints.get_edited_preset().config;
+        config.set_key_value("layer_height", new ConfigOptionFloat(layer_height));
+        config.set_key_value("variable_layer_height", new ConfigOptionBool(false));
+        config.set_key_value("perimeter_speed",          new ConfigOptionFloat(test_speed));
+        config.set_key_value("external_perimeter_speed", new ConfigOptionFloatOrPercent(test_speed, false));
+        config.set_key_value("small_perimeter_speed",    new ConfigOptionFloatOrPercent(test_speed, false));
+        config.set_key_value("infill_speed",             new ConfigOptionFloat(test_speed));
+        config.set_key_value("solid_infill_speed",       new ConfigOptionFloatOrPercent(test_speed, false));
+        config.set_key_value("top_solid_infill_speed",   new ConfigOptionFloatOrPercent(test_speed, false));
+        config.set_key_value("gap_fill_speed",           new ConfigOptionFloat(test_speed));
+        config.set_key_value("brim_width", new ConfigOptionFloat(m_brim && m_brim->GetValue() ? 5.0 : 0.0));
+        // OctoPrint labels emit "; printing object <name>" on every flavor so the
+        // post-processor can tell the bands apart and key PA on the raw name.
+        config.set_key_value("gcode_label_objects",
+            new ConfigOptionEnum<LabelObjectsStyle>(LabelObjectsStyle::Octoprint));
+        wxGetApp().get_tab(Preset::TYPE_PRINT)->reload_config();
+    }
+    wxGetApp().preset_bundle->filaments.discard_current_changes();
+    {
+        DynamicPrintConfig& fil = wxGetApp().preset_bundle->filaments.get_edited_preset().config;
+        fil.set_key_value("slowdown_below_layer_time", new ConfigOptionInts({0}));
+        fil.set_key_value("min_print_speed", new ConfigOptionFloats({test_speed}));
+        wxGetApp().get_tab(Preset::TYPE_FILAMENT)->reload_config();
+    }
+
+    // --- Firmware PA command (mirror the tower detection) ---
+    GCodeFlavor flavor = gcfRepRapFirmware;
+    bool is_prusa_mini = false;
+    if (const auto* fo = pb->printers.get_selected_preset().config.option<ConfigOptionEnum<GCodeFlavor>>("gcode_flavor"))
+        flavor = fo->value;
+    if (const auto* mo = pb->printers.get_selected_preset().config.option<ConfigOptionString>("printer_model");
+        mo && !mo->value.empty()) {
+        std::string m = mo->value;
+        std::transform(m.begin(), m.end(), m.begin(), ::toupper);
+        is_prusa_mini = m.find("MINI") != std::string::npos;
+    }
+    PACalibrationCommand cmd;
+    switch (flavor) {
+    case gcfKlipper:        cmd = PACalibrationCommand::Klipper; break;
+    case gcfMarlinLegacy:
+    case gcfMarlinFirmware: cmd = PACalibrationCommand::M900; break;
+    default:               cmd = is_prusa_mini ? PACalibrationCommand::M900 : PACalibrationCommand::M572; break;
+    }
+
+    // --- ASCII output so the post-processor can rewrite it ---
+    wxGetApp().preset_bundle->printers.discard_current_changes();
+    {
+        DynamicPrintConfig& printer = wxGetApp().preset_bundle->printers.get_edited_preset().config;
+        printer.set_key_value("binary_gcode", new ConfigOptionBool(false));
+        wxGetApp().get_tab(Preset::TYPE_PRINTER)->reload_config();
+    }
+
+    // --- Wire the in-process post-processor ---
+    const std::string builtin_url = make_calibration_pa_url(cmd, 0.0, object_pa);
+    {
+        DynamicPrintConfig& print_config = wxGetApp().preset_bundle->prints.get_edited_preset().config;
+        std::vector<std::string> scripts;
+        if (const auto* pp = print_config.option<ConfigOptionStrings>("post_process"))
+            scripts = pp->values;
+        scripts.erase(std::remove_if(scripts.begin(), scripts.end(),
+                          [](const std::string& s) { return is_calibration_pa_url(s); }),
+                      scripts.end());
+        scripts.insert(scripts.begin(), builtin_url);
+        print_config.set_key_value("post_process", new ConfigOptionStrings(scripts));
+        wxGetApp().get_tab(Preset::TYPE_PRINT)->reload_config();
+    }
+    BOOST_LOG_TRIVIAL(info) << "PA flat calibration: " << num_bands << " bands, URL " << builtin_url;
+
+    // --- Lay the bands out in a grid (front-to-back = start..end PA) ---
+    bool placed = false;
+    if (plater->build_volume().type() == BuildVolume::Type::Rectangle && !loaded.empty()) {
+        const BoundingBoxf3 fp = model.objects[loaded[0]]->instance_bounding_box(0);
+        const double cell_w = (fp.max.x() - fp.min.x()) + 4.0;
+        const double cell_h = (fp.max.y() - fp.min.y()) + 4.0;
+        const BoundingBoxf bed = plater->build_volume().bounding_volume2d();
+        const Vec2d  bed_c    = bed.center();
+        const double usable_w = bed.size().x() - 10.0;
+        const double usable_h = bed.size().y() - 10.0;
+        const int max_cols = std::max(1, int(std::floor(usable_w / cell_w)));
+        int cols = std::min(num_bands, max_cols);
+        int rows = (num_bands + cols - 1) / cols;
+        while (rows * cell_h > usable_h && cols < max_cols) { ++cols; rows = (num_bands + cols - 1) / cols; }
+        if (rows * cell_h <= usable_h && cols * cell_w <= usable_w) {
+            const double left = bed_c.x() - cols * cell_w / 2.0;
+            const double top  = bed_c.y() + rows * cell_h / 2.0;
+            for (int i = 0; i < num_bands && i < (int)loaded.size(); ++i) {
+                ModelObject* obj = model.objects[loaded[i]];
+                if (obj->instances.empty()) continue;
+                const int c = i % cols, r = i / cols;
+                const Vec2d target(left + cell_w * (c + 0.5), top - cell_h * (r + 0.5));
+                const BoundingBoxf3 bb = obj->instance_bounding_box(0);
+                const Vec2d cur(0.5 * (bb.min.x() + bb.max.x()), 0.5 * (bb.min.y() + bb.max.y()));
+                ModelInstance* inst = obj->instances.front();
+                inst->set_offset(inst->get_offset() + Vec3d(target.x() - cur.x(), target.y() - cur.y(), 0.0));
+                obj->invalidate_bounding_box();
+            }
+            placed = true;
+        }
+    }
+    if (!placed)
+        plater->arrange(true);
+    plater->changed_objects(loaded);
+
+    for (const auto& p : stl_paths)
+        boost::filesystem::remove(p);
+
+    if (auto* nm = wxGetApp().notification_manager()) {
+        std::string msg =
+            std::string("PA ") + (kind == 2 ? "pattern" : "line") +
+            " test: one chevron band per PA value (front = start PA, back = end PA). "
+            "Temporary speed overrides applied — revert via the ⟲ buttons on the "
+            "Print/Filament tabs before slicing other models.";
+        nm->push_notification(NotificationType::CustomNotification,
+            NotificationManager::NotificationLevel::WarningNotificationLevel, msg);
+    }
+    apply_calibration_filename_prefix("PressureAdvance");
     return true;
 }
 

--- a/src/slic3r/GUI/CalibrationPADialog.cpp
+++ b/src/slic3r/GUI/CalibrationPADialog.cpp
@@ -420,6 +420,25 @@ bool CalibrationPADialog::generate_flat(int kind)   // 1 = line, 2 = pattern
             wxMessageBox(_L("Failed to generate PA band geometry."), _L("Error"), wxOK | wxICON_ERROR, this);
             return false;
         }
+
+        // Emboss the PA value as a printed label below the chevron so each band
+        // is self-documenting — the user reads the value directly instead of
+        // relying on bed position (which the arranger fallback may reorder).
+        const double pa = start_pa + i * step;
+        BoundingBoxf3 cb;
+        for (const auto& v : its.vertices) cb.merge(v.cast<double>());
+        indexed_triangle_set text = Slic3r::make_block_text(fmt4(pa), 5.0, layer_height, false);
+        if (!text.empty()) {
+            for (auto& v : text.vertices) std::swap(v.y(), v.z());   // lay the text flat
+            for (auto& f : text.indices)  std::swap(f[0], f[1]);     // fix winding after the swap
+            BoundingBoxf3 tb;
+            for (const auto& v : text.vertices) tb.merge(v.cast<double>());
+            const double tx = -0.5 * (tb.min.x() + tb.max.x());          // centre in X
+            const double ty = (cb.min.y() - 2.0) - tb.max.y();           // 2 mm below the chevron
+            its_translate(text, Vec3f(float(tx), float(ty), 0.0f));
+            its_merge(its, text);
+        }
+
         const std::string fname = "pa_band_" + std::to_string(i) + ".stl";
         boost::filesystem::path path = tmp_dir / fname;
         if (!its_write_stl_binary(path.string().c_str(), fname.c_str(), its)) {
@@ -593,9 +612,10 @@ bool CalibrationPADialog::generate_flat(int kind)   // 1 = line, 2 = pattern
     if (auto* nm = wxGetApp().notification_manager()) {
         std::string msg =
             std::string("PA ") + (kind == 2 ? "pattern" : "line") +
-            " test: one chevron band per PA value (front = start PA, back = end PA). "
-            "Temporary speed overrides applied — revert via the ⟲ buttons on the "
-            "Print/Filament tabs before slicing other models.";
+            " test: one chevron band per PA value, each labeled with its PA "
+            "(bands run front = start PA → back = end PA). Temporary speed overrides "
+            "applied — revert via the ⟲ buttons on the Print/Filament tabs before "
+            "slicing other models.";
         nm->push_notification(NotificationType::CustomNotification,
             NotificationManager::NotificationLevel::WarningNotificationLevel, msg);
     }

--- a/src/slic3r/GUI/CalibrationPADialog.cpp
+++ b/src/slic3r/GUI/CalibrationPADialog.cpp
@@ -29,6 +29,9 @@
 
 #include <algorithm>
 #include <cmath>
+#include <iomanip>
+#include <locale>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -394,7 +397,14 @@ bool CalibrationPADialog::generate_flat(int kind)   // 1 = line, 2 = pattern
     Plater* plater = wxGetApp().plater();
     if (!plater) return false;
 
-    auto fmt4 = [](double v) { char b[24]; std::snprintf(b, sizeof(b), "%.4f", v); return std::string(b); };
+    // Locale-invariant: band names are copied into the comma-delimited post-
+    // processor URL, so a comma decimal separator would corrupt it.
+    auto fmt4 = [](double v) {
+        std::ostringstream s;
+        s.imbue(std::locale::classic());
+        s << std::fixed << std::setprecision(4) << v;
+        return s.str();
+    };
 
     // --- Geometry: one 1-layer chevron band per PA value ---
     const boost::filesystem::path tmp_dir = boost::filesystem::temp_directory_path();
@@ -464,6 +474,10 @@ bool CalibrationPADialog::generate_flat(int kind)   // 1 = line, 2 = pattern
         DynamicPrintConfig& config = wxGetApp().preset_bundle->prints.get_edited_preset().config;
         config.set_key_value("layer_height", new ConfigOptionFloat(layer_height));
         config.set_key_value("variable_layer_height", new ConfigOptionBool(false));
+        // Sequential printing (complete_objects) takes the exporter's sequential
+        // branch, which does NOT emit custom_gcode_per_print_z — our marker would
+        // be absent and the post-processor would no-op. Force it off (as flow does).
+        config.set_key_value("complete_objects", new ConfigOptionBool(false));
         config.set_key_value("perimeter_speed",          new ConfigOptionFloat(test_speed));
         config.set_key_value("external_perimeter_speed", new ConfigOptionFloatOrPercent(test_speed, false));
         config.set_key_value("small_perimeter_speed",    new ConfigOptionFloatOrPercent(test_speed, false));

--- a/src/slic3r/GUI/CalibrationPADialog.cpp
+++ b/src/slic3r/GUI/CalibrationPADialog.cpp
@@ -559,13 +559,15 @@ bool CalibrationPADialog::generate_flat(int kind)   // 1 = line, 2 = pattern
         int rows = (num_bands + cols - 1) / cols;
         while (rows * cell_h > usable_h && cols < max_cols) { ++cols; rows = (num_bands + cols - 1) / cols; }
         if (rows * cell_h <= usable_h && cols * cell_w <= usable_w) {
-            const double left = bed_c.x() - cols * cell_w / 2.0;
-            const double top  = bed_c.y() + rows * cell_h / 2.0;
+            const double left   = bed_c.x() - cols * cell_w / 2.0;
+            const double bottom = bed_c.y() - rows * cell_h / 2.0;
             for (int i = 0; i < num_bands && i < (int)loaded.size(); ++i) {
                 ModelObject* obj = model.objects[loaded[i]];
                 if (obj->instances.empty()) continue;
                 const int c = i % cols, r = i / cols;
-                const Vec2d target(left + cell_w * (c + 0.5), top - cell_h * (r + 0.5));
+                // Row 0 at the FRONT (min Y) so band 0 = start PA is at the front,
+                // matching the docs/notification ("front = start PA, back = end").
+                const Vec2d target(left + cell_w * (c + 0.5), bottom + cell_h * (r + 0.5));
                 const BoundingBoxf3 bb = obj->instance_bounding_box(0);
                 const Vec2d cur(0.5 * (bb.min.x() + bb.max.x()), 0.5 * (bb.min.y() + bb.max.y()));
                 ModelInstance* inst = obj->instances.front();

--- a/src/slic3r/GUI/CalibrationPADialog.cpp
+++ b/src/slic3r/GUI/CalibrationPADialog.cpp
@@ -485,6 +485,12 @@ bool CalibrationPADialog::generate_flat(int kind)   // 1 = line, 2 = pattern
         config.set_key_value("solid_infill_speed",       new ConfigOptionFloatOrPercent(test_speed, false));
         config.set_key_value("top_solid_infill_speed",   new ConfigOptionFloatOrPercent(test_speed, false));
         config.set_key_value("gap_fill_speed",           new ConfigOptionFloat(test_speed));
+        // The bands are a single layer, so the WHOLE test is the first layer.
+        // first_layer_speed (default 30 mm/s) is applied after the role speeds
+        // and would otherwise clamp every band slow, hiding the PA differences.
+        config.set_key_value("first_layer_speed",            new ConfigOptionFloatOrPercent(test_speed, false));
+        config.set_key_value("first_layer_infill_speed",     new ConfigOptionFloatOrPercent(test_speed, false));
+        config.set_key_value("first_layer_speed_over_raft",  new ConfigOptionFloatOrPercent(test_speed, false));
         config.set_key_value("brim_width", new ConfigOptionFloat(m_brim && m_brim->GetValue() ? 5.0 : 0.0));
         // OctoPrint labels emit "; printing object <name>" on every flavor so the
         // post-processor can tell the bands apart and key PA on the raw name.

--- a/src/slic3r/GUI/CalibrationPADialog.cpp
+++ b/src/slic3r/GUI/CalibrationPADialog.cpp
@@ -520,7 +520,8 @@ bool CalibrationPADialog::generate_flat(int kind)   // 1 = line, 2 = pattern
     }
 
     // --- ASCII output so the post-processor can rewrite it ---
-    wxGetApp().preset_bundle->printers.discard_current_changes();
+    // Override only binary_gcode on the printer preset (do NOT discard it — that
+    // would wipe the user's unsaved start G-code / machine-limit / nozzle edits).
     {
         DynamicPrintConfig& printer = wxGetApp().preset_bundle->printers.get_edited_preset().config;
         printer.set_key_value("binary_gcode", new ConfigOptionBool(false));

--- a/src/slic3r/GUI/CalibrationPADialog.hpp
+++ b/src/slic3r/GUI/CalibrationPADialog.hpp
@@ -7,14 +7,18 @@
 
 #include <wx/dialog.h>
 #include <wx/checkbox.h>
+#include <wx/choice.h>
 #include <wx/spinctrl.h>
 
 namespace Slic3r { namespace GUI {
 
-/// Dialog for pressure advance (PA) calibration using a chevron pattern.
-/// Generates nested V-shaped chevrons inside a rectangular frame.  Each
-/// layer is printed with a different PA value — the user inspects which
-/// layer produces the sharpest corners at the chevron tips.
+/// Dialog for pressure advance (PA) calibration. Three test styles:
+///  - Tower: nested V-shaped chevrons, one PA value per layer group (sliced
+///    STL + per-Z PA command); pick the height with the sharpest tips.
+///  - Line / Pattern: flat single-layer tests printing one small chevron band
+///    per PA value, side by side. Each band is a separate object sliced by the
+///    real pipeline; an in-process post-processor injects the PA command at
+///    each band's boundary — so flow/temps/leveling match a normal print.
 class CalibrationPADialog : public wxDialog
 {
 public:
@@ -22,7 +26,10 @@ public:
 
 private:
     bool generate_and_load();
+    bool generate_tower();        // chevron tower, per-Z PA (original)
+    bool generate_flat(int kind); // 1 = line, 2 = pattern (per-band objects)
 
+    wxChoice*         m_mode{nullptr};       // 0 = Tower, 1 = Line, 2 = Pattern
     wxSpinCtrlDouble* m_start_pa{nullptr};
     wxSpinCtrlDouble* m_end_pa{nullptr};
     wxSpinCtrlDouble* m_pa_step{nullptr};

--- a/tests/libslic3r/test_calibration.cpp
+++ b/tests/libslic3r/test_calibration.cpp
@@ -10,6 +10,7 @@
 #include "libslic3r/TriangleMesh.hpp"
 #include "libslic3r/GCode/CalibrationRetractionPostProcessor.hpp"
 #include "libslic3r/GCode/CalibrationFlowPostProcessor.hpp"
+#include "libslic3r/GCode/CalibrationPAPostProcessor.hpp"
 
 #include <boost/filesystem.hpp>
 
@@ -863,4 +864,129 @@ TEST_CASE("calibration flow: malformed URL throws", "[calibration]")
     CHECK_THROWS(run_calibration_flow_post_processor(
         "::builtin::flow_calibration?foo=bar", path));  // no objects
     boost::filesystem::remove(path);
+}
+
+// ===========================================================================
+// PA flat-test post-processor (line / pattern via per-object PA injection)
+// ===========================================================================
+
+static std::string write_tmp_pa_gcode(const std::string& content)
+{
+    auto path = boost::filesystem::temp_directory_path() /
+                boost::filesystem::unique_path("pa_cal_%%%%.gcode");
+    std::ofstream f(path.string(), std::ios::binary);
+    f << content;
+    f.close();
+    return path.string();
+}
+
+static std::string read_file(const std::string& path)
+{
+    std::ifstream f(path, std::ios::binary);
+    std::ostringstream ss;
+    ss << f.rdbuf();
+    return ss.str();
+}
+
+// A two-band OctoPrint-labelled gcode carrying the PA calibration marker.
+static std::string two_band_gcode()
+{
+    return
+        "; PRUSASLICER_PA_CALIBRATION\n"
+        "; printing object 0.020 id:0 copy 0\n"
+        "G1 X1 Y1 E1 F1800\n"
+        "; stop printing object 0.020 id:0 copy 0\n"
+        "; printing object 0.040 id:1 copy 0\n"
+        "G1 X2 Y2 E1 F1800\n"
+        "; stop printing object 0.040 id:1 copy 0\n";
+}
+
+TEST_CASE("PA post: injects PA per object (OctoPrint, M572)", "[calibration]")
+{
+    const std::string url = make_calibration_pa_url(
+        PACalibrationCommand::M572, 0.0, { {"0.020", 0.02}, {"0.040", 0.04} });
+    auto path = write_tmp_pa_gcode(two_band_gcode());
+    REQUIRE(run_calibration_pa_post_processor(url, path));
+    const std::string out = read_file(path);
+    boost::filesystem::remove(path);
+
+    // PA set right after each object start, reset to base at each stop.
+    const auto start0 = out.find("; printing object 0.020");
+    const auto pa0    = out.find("M572 S0.0200");
+    const auto start1 = out.find("; printing object 0.040");
+    const auto pa1    = out.find("M572 S0.0400");
+    REQUIRE(pa0 != std::string::npos);
+    REQUIRE(pa1 != std::string::npos);
+    CHECK(start0 < pa0);
+    CHECK(pa0 < start1);                 // band 0's PA precedes band 1's start
+    CHECK(start1 < pa1);
+    CHECK(out.find("M572 S0.0000") != std::string::npos);   // base restored at stop
+}
+
+TEST_CASE("PA post: no-op without the marker", "[calibration]")
+{
+    const std::string url = make_calibration_pa_url(
+        PACalibrationCommand::M572, 0.0, { {"0.020", 0.02} });
+    // Same gcode but no calibration marker line.
+    auto path = write_tmp_pa_gcode(
+        "; printing object 0.020 id:0 copy 0\nG1 X1 Y1 E1 F1800\n");
+    CHECK_FALSE(run_calibration_pa_post_processor(url, path));   // left untouched
+    CHECK(read_file(path).find("M572") == std::string::npos);
+    boost::filesystem::remove(path);
+}
+
+TEST_CASE("PA post: firmware command variants", "[calibration]")
+{
+    auto run = [](PACalibrationCommand cmd) {
+        const std::string url = make_calibration_pa_url(cmd, 0.0, { {"0.020", 0.02} });
+        auto path = write_tmp_pa_gcode(
+            "; PRUSASLICER_PA_CALIBRATION\n; printing object 0.020 id:0 copy 0\n"
+            "G1 X1 Y1 E1 F1800\n; stop printing object 0.020 id:0 copy 0\n");
+        run_calibration_pa_post_processor(url, path);
+        std::string out = read_file(path);
+        boost::filesystem::remove(path);
+        return out;
+    };
+    CHECK(run(PACalibrationCommand::M900).find("M900 K0.0200") != std::string::npos);
+    CHECK(run(PACalibrationCommand::Klipper).find("SET_PRESSURE_ADVANCE ADVANCE=0.0200") != std::string::npos);
+}
+
+TEST_CASE("PA post: unknown object falls back to base PA", "[calibration]")
+{
+    const std::string url = make_calibration_pa_url(
+        PACalibrationCommand::M572, 0.015, { {"0.020", 0.02} });
+    auto path = write_tmp_pa_gcode(
+        "; PRUSASLICER_PA_CALIBRATION\n; printing object 9.999 id:7 copy 0\n"
+        "G1 X1 Y1 E1 F1800\n; stop printing object 9.999 id:7 copy 0\n");
+    run_calibration_pa_post_processor(url, path);
+    const std::string out = read_file(path);
+    boost::filesystem::remove(path);
+    CHECK(out.find("M572 S0.0150") != std::string::npos);   // base, since 9.999 unknown
+}
+
+TEST_CASE("PA post: malformed URL throws", "[calibration]")
+{
+    auto path = write_tmp_pa_gcode("; PRUSASLICER_PA_CALIBRATION\nG1 X1 Y1 E1\n");
+    CHECK_THROWS(run_calibration_pa_post_processor("::builtin::pa_calibration", path));
+    CHECK_THROWS(run_calibration_pa_post_processor("::builtin::pa_calibration?cmd=m572", path));
+    boost::filesystem::remove(path);
+}
+
+TEST_CASE("PA post: locale-independent decimals in URL and output", "[calibration]")
+{
+    char* cur = std::setlocale(LC_ALL, nullptr);
+    const std::string saved = cur ? cur : "C";
+    std::setlocale(LC_ALL, "de_DE.UTF-8");   // may be unavailable; harmless
+    const std::string url = make_calibration_pa_url(
+        PACalibrationCommand::M572, 0.0, { {"0.025", 0.025} });
+    CHECK(url.find("0,0250") == std::string::npos);
+    CHECK(url.find("0.0250") != std::string::npos);
+    auto path = write_tmp_pa_gcode(
+        "; PRUSASLICER_PA_CALIBRATION\n; printing object 0.025 id:0 copy 0\nG1 X1 Y1 E1\n");
+    run_calibration_pa_post_processor(url, path);
+    const std::string out = read_file(path);
+    std::setlocale(LC_ALL, saved.c_str());
+    boost::filesystem::remove(path);
+    CHECK(out.find("M572 S0.0250") != std::string::npos);
+    CHECK(out.find("S0,") == std::string::npos);
 }

--- a/tests/libslic3r/test_calibration.cpp
+++ b/tests/libslic3r/test_calibration.cpp
@@ -990,3 +990,27 @@ TEST_CASE("PA post: locale-independent decimals in URL and output", "[calibratio
     CHECK(out.find("M572 S0.0250") != std::string::npos);
     CHECK(out.find("S0,") == std::string::npos);
 }
+
+TEST_CASE("PA post: does not inject in the preamble object header", "[calibration]")
+{
+    const std::string url = make_calibration_pa_url(
+        PACalibrationCommand::M572, 0.0, { {"0.020", 0.02} });
+    // OctoPrint labeling lists every object up front (all_objects_header) with the
+    // SAME boundary comments, BEFORE the start G-code and the first-layer marker.
+    auto path = write_tmp_pa_gcode(
+        "; printing object 0.020 id:0 copy 0\n"            // preamble header (no PA here!)
+        "; stop printing object 0.020 id:0 copy 0\n"
+        "G28 ; home (start g-code)\n"
+        "; PRUSASLICER_PA_CALIBRATION\n"                   // first-layer marker
+        "; printing object 0.020 id:0 copy 0\n"            // real band boundary
+        "G1 X1 Y1 E1 F1800\n"
+        "; stop printing object 0.020 id:0 copy 0\n");
+    run_calibration_pa_post_processor(url, path);
+    const std::string out = read_file(path);
+    boost::filesystem::remove(path);
+
+    const auto first = out.find("M572 S0.0200");
+    REQUIRE(first != std::string::npos);
+    CHECK(out.find("G28") < first);                                   // injected after start g-code
+    CHECK(out.find("M572 S0.0200", first + 1) == std::string::npos);  // exactly once (body only)
+}


### PR DESCRIPTION
## Issue
[#21](https://github.com/hyiger/PrusaSlicer/issues/21) — add **PA line** and **PA pattern** styles. This **supersedes [#28](https://github.com/hyiger/PrusaSlicer/pull/28)** (the direct-G-code attempt).

## Why this replaces #28
#28 generated the flat tests as **direct G-code**, bypassing PrusaSlicer's `GCodeGenerator`. That meant re-deriving the entire exporter contract by hand — and review (Codex + an adversarial pass) surfaced **~26 findings, almost all the same class**: "the real exporter emits X, the hand-rolled path doesn't" (temps, M204 accel, units, tool select, extrusion axis, volumetric E, z-offset, placeholders, filament gcode, preview tags, secrets, …). An unbounded tail.

## This approach
Exactly how the **YOLO-flow** and **retraction** calibrations already work: **reuse the real slice pipeline.**

- Each PA value prints as its own **1-layer chevron band** (reusing the existing `make_pa_pattern` geometry), named by its PA value.
- The bands are **sliced normally**, so flow / temps / accel / leveling / axis / volumetric / z-offset / units / tool / placeholders / filament gcode / secrets / preview tags are all **inherited from the real exporter** — the entire #28 findings class **cannot recur**.
- A new **`CalibrationPAPostProcessor`** injects the firmware PA command (`M572`/`M900`/`SET_PRESSURE_ADVANCE`) at each labeled object's boundary, keyed on the object name — the only custom logic, cloned (and simplified) from `CalibrationFlowPostProcessor`.
- The dialog forces OctoPrint labeling + ASCII output and applies the same speed/cooling overrides as the chevron tower. Tower path unchanged.

## Tradeoff (honest)
The canonical PA *line* uses an intra-line slow→fast→slow transition, which sliced per-object bands can't do. Both styles are therefore **sharp-corner chevron bands** (one corner per PA, read across the row — the same principle as the existing PA *tower*, just flat). You lose the speed-transition variant; you gain a PA reading conditioned identically to a real print.

## Tests
6 new post-processor unit tests (per-object injection order, marker no-op, M572/M900/Klipper variants, unknown-name → base, malformed URL throws, locale-invariant). **All 51 `[calibration]` cases pass; `libslic3r` + `libslic3r_gui` build clean (arm64).**

## Validation owed (your printer)
Slice a Line/Pattern test on a Core One preset and confirm: the preview shows one chevron per PA front-to-back; the exported G-code has `; printing object <pa>` boundaries each followed by the PA command; and a print reads cleanly. (The whole point is that everything *except* the injected PA line is real sliced output.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)