### PR TITLE
PostProcessor: skip stale PA-pattern builtin URLs (Codex P1)

### DIFF
--- a/src/libslic3r/GCode/PostProcessor.cpp
+++ b/src/libslic3r/GCode/PostProcessor.cpp
@@ -317,6 +317,15 @@ bool run_post_process_scripts(std::string &src_path, bool make_copy, const std::
                     }
                     continue;
                 }
+                // Legacy compatibility: the PA Pattern test was removed in 1.9.2, but a
+                // stale `::builtin::pa_calibration?...` entry may still sit in an older
+                // print preset's post_process list. Skip it — otherwise it falls through
+                // to the external-script path below and every normal export fails trying
+                // to run it as a shell command.
+                if (script.rfind("::builtin::pa_calibration", 0) == 0) {
+                    BOOST_LOG_TRIVIAL(info) << "Skipping removed built-in post-processor: " << script;
+                    continue;
+                }
                 BOOST_LOG_TRIVIAL(info) << "Executing script " << script << " on file " << path;
                 std::string std_err;
                 const int result = run_script(script, gcode_file.string(), std_err);


### PR DESCRIPTION
## P1 follow-up to #33

Codex flagged this on #33 (after merge): removing the PA Pattern test removed the in-process runner that recognized its `::builtin::pa_calibration?...` `post_process` entry. If a user had run the old Pattern test and **saved** the print preset, that stale entry remains — and with the handler gone it now falls through to the external-script path, so **every normal export fails** trying to execute the URL as a shell/Windows command.

## Fix

Add a compatibility branch in `run_post_process_scripts` (after the other built-in handlers, before the external-script fallback) that **skips** any `::builtin::pa_calibration` entry. Stale presets degrade gracefully instead of breaking exports.

Builds clean; all 50 `[calibration]` tests pass. Must land before 1.9.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
