### PR TITLE
fix(ci): drop doubled 'PrusaSlicer-' prefix from Windows installer name

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -202,7 +202,7 @@ jobs:
           choco install innosetup -y --no-progress
           # Compile the installer
           & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DMyAppVersion="$buildId" installer.iss
-          Write-Host "Created installer: Output\PrusaSlicer-$buildId-win64-setup.exe"
+          Write-Host "Created installer: Output\$buildId-win64-setup.exe"
 
       - name: Show sccache stats
         if: always()
@@ -213,10 +213,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: windows-x64
-          path: Output/PrusaSlicer-${{ steps.version.outputs.build_id }}-win64-setup.exe
+          path: Output/${{ steps.version.outputs.build_id }}-win64-setup.exe
 
       - name: Attach to release
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v2
         with:
-          files: Output/PrusaSlicer-${{ steps.version.outputs.build_id }}-win64-setup.exe
+          files: Output/${{ steps.version.outputs.build_id }}-win64-setup.exe

--- a/installer.iss
+++ b/installer.iss
@@ -22,7 +22,10 @@ AppSupportURL={#MyAppURL}/issues
 DefaultDirName={autopf}\{#MyAppName}
 DefaultGroupName={#MyAppName}
 AllowNoIcons=yes
-OutputBaseFilename=PrusaSlicer-{#MyAppVersion}-win64-setup
+; MyAppVersion is the full SLIC3R_BUILD_ID (e.g. "PrusaSlicer-2.9.6-Filament-Edition-1.10.0"),
+; which already carries the "PrusaSlicer-" prefix — so do NOT prepend it again here, or the
+; artifact becomes "PrusaSlicer-PrusaSlicer-...". Matches the mac/linux naming (build_id directly).
+OutputBaseFilename={#MyAppVersion}-win64-setup
 Compression=lzma2/fast
 SolidCompression=yes
 ArchitecturesAllowed=x64compatible


### PR DESCRIPTION
## Problem

The v1.10.0 release shipped the Windows installer as `PrusaSlicer-PrusaSlicer-2.9.6-Filament-Edition-1.10.0-win64-setup.exe` — a doubled `PrusaSlicer-` prefix.

## Cause

`SLIC3R_BUILD_ID` already carries the prefix (`PrusaSlicer-2.9.6-Filament-Edition-1.10.0`). The mac/linux jobs name their artifacts `{build_id}-...` directly (single prefix), but the Windows path prepended a second literal `PrusaSlicer-` in both `installer.iss` (`OutputBaseFilename`) and the three `build-windows.yml` references.

## Fix

Use `build_id` directly on the Windows side too, so the asset matches the others:
`PrusaSlicer-2.9.6-Filament-Edition-1.10.0-win64-setup.exe`.

CI-only / cosmetic — no source or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)