### PR TITLE
fix(calibration): mirror XYZ shrinkage gauge Z-arm labels so they read correctly

### DIFF
--- a/src/libslic3r/CalibrationModels.cpp
+++ b/src/libslic3r/CalibrationModels.cpp
@@ -1028,7 +1028,12 @@ indexed_triangle_set make_shrinkage_gauge(double length, int *skipped_holes)
                         int face) {
         // face: 0 = lay flat on a top (+Z) face (read from above);
         //       3 = stand on a +Y side face (read from the front).
-        const bool mirror = (face == 0);   // top face is viewed from the opposite hand
+        // BOTH are raised text viewed from the face's OUTWARD normal, where world
+        // +X maps to the viewer's LEFT — so the glyphs (built left-to-right in +X)
+        // read mirrored unless pre-flipped. make_block_text's mirror_x does that
+        // flip. (Previously only face 0 was mirrored, so the Z-arm's face-3 labels
+        // printed mirrored.)
+        const bool mirror = (face == 0 || face == 3);
         auto label = make_block_text(text, SHRINK_LABEL_H, SHRINK_LABEL_D, mirror);
         if (label.empty()) return;
 


### PR DESCRIPTION
The Z-arm (vertical) distance labels stand on the **+Y side face** and are viewed from that face's outward normal, where world **+X maps to the viewer's left** — so the digits (built left-to-right in +X) printed **mirrored**. The top-face X/Y-arm labels (`face == 0`) already pass `mirror_x = true` to correct this; the Z-arm (`face == 3`) was left unmirrored.

Fix: mirror both raised-text faces — `mirror = (face == 0 || face == 3)`.

Pre-existing since the gauge labels were added (my #40 change only moved *when* labels are merged, not their orientation); surfaced while testing #40 in v1.11.0. Builds clean; libslic3r `[calibration]` suite green (53 cases). Text legibility confirmed visually in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)