### PR TITLE
feat(maintenance): guided INDX cold pull with serial and G-code delivery

### DIFF
--- a/doc/Cold_Pull_Guide.md
+++ b/doc/Cold_Pull_Guide.md
@@ -94,20 +94,31 @@ printer's screen; only the delivery differs.
 
 | Route | Use when | Notes |
 |---|---|---|
-| **Run over USB serial from here** *(default)* | You can connect the printer over USB | PrusaSlicer drives the procedure and shows live progress. Cancel restores printer state. Requires the *Serial Printing Screen* prerequisite above. |
-| **Save G-code file** | You cannot or would rather not use USB serial | Writes a `.gcode` file. Copy it to a USB drive and start it like any other print. |
+| **Run over USB serial from here** | The printer is connected over USB | PrusaSlicer drives the procedure and shows live progress. Cancel restores printer state. Requires the *Serial Printing Screen* prerequisite above. |
+| **Save G-code file** | No USB connection, or you would rather not use one | Writes a `.gcode` file. Copy it to a USB drive and start it like any other print. |
 | **Upload G-code to the printer** | You have PrusaLink / Connect set up | Same file, uploaded over the network. Only offered when a physical printer with a print host is configured. **Never auto-starts** — you start it from the printer's menu. |
 
-**Serial is the default and has been validated on hardware.** It gives live
-progress, and its Cancel button restores printer state (heaters off, guards
-re-enabled) — something the G-code routes cannot offer, since stopping a print
-part-way leaves session settings behind for you to restore by hand.
+### Which one is selected for you
 
-The G-code routes exist for anyone who cannot connect over USB, or would rather
-not. They run the identical procedure with the identical prompts, and they need
-one fewer prerequisite: a print job is driven by the media queue and the normal
-print state machine, so the *Serial Printing Screen* setting does not apply to
-them.
+The dialog checks for a printer on USB serial when it opens:
+
+- **Printer detected** → *Run over USB serial* is selected. It is the
+  hardware-validated path, and the only one offering live progress and a Cancel
+  that restores printer state (heaters off, guards re-enabled).
+- **Nothing detected** → the serial entry is **disabled** and labelled *(no
+  printer detected)*, and *Save G-code file* is selected instead. Connect the
+  printer and reopen the dialog to enable it.
+
+Detection only enumerates ports; it does not open one. So it reports that a
+printer is *plugged in*, not that it is free — a port held by another
+application (PrusaLink, another slicer, a serial monitor) still shows as
+detected and will only fail when the procedure actually starts.
+
+The G-code routes run the identical procedure with the identical prompts, and
+need one fewer prerequisite: a print job is driven by the media queue and the
+normal print state machine, so the *Serial Printing Screen* setting does not
+apply to them. Their trade-off is that stopping part-way leaves session settings
+behind for you to restore by hand — see [§7](#7-cancelling-part-way).
 
 ---
 

--- a/doc/Cold_Pull_Guide.md
+++ b/doc/Cold_Pull_Guide.md
@@ -1,0 +1,343 @@
+# Cold Pull Guide (INDX)
+
+This guide explains the **Maintenance → Cold Pull (INDX)** tool: what it does, how
+to run it, and what to do when it goes wrong.
+
+A cold pull clears a partially clogged nozzle. You melt fresh filament into the
+hot end, let it cool until it grips the debris inside, then yank it out — the
+plug comes away with the carbonised material embedded in it.
+
+> **Scope.** This tool targets the **CORE One INDX** (`COREONE_INDX` /
+> `COREONEL_INDX`). Prusa's own built-in cold-pull wizard (`M1702`) is *not*
+> enabled for INDX — the feature gate at `ProjectOptions.cmake:716` lists only
+> MK3.5, MK4, XL, COREONE and COREONEL, so `M1702` compiles to an empty stub on
+> INDX and the menu entry does not exist. That absence is why this tool exists.
+
+---
+
+## Contents
+
+1. [When to use it](#1-when-to-use-it)
+2. [Prerequisites](#2-prerequisites-required)
+3. [Choosing how to run it](#3-choosing-how-to-run-it)
+4. [Parameters](#4-parameters)
+5. [Walkthrough](#5-walkthrough)
+6. [Reading the result](#6-reading-the-result)
+7. [Cancelling](#7-cancelling-part-way)
+8. [Troubleshooting](#8-troubleshooting)
+9. [How it works](#9-how-it-works)
+
+---
+
+## 1. When to use it
+
+Good candidates:
+
+- Under-extrusion that survives a nozzle-temperature increase
+- Inconsistent flow, or extrusion that curls off to one side
+- A colour or material change that keeps bleeding old filament
+- Clicking from the extruder under normal print flow rates
+
+**A cold pull only reaches the melt zone.** If filament cannot enter the hot end
+at all, the blockage is *above* the melt zone and no cold pull will clear it —
+see [§8](#8-troubleshooting). The procedure includes a check for exactly this,
+early enough to stop before wasting twenty minutes.
+
+Plan for **10–20 minutes**, most of it cooling. You must stay at the printer:
+it stops and waits for knob presses at five points.
+
+---
+
+## 2. Prerequisites (required)
+
+The dialog opens with a pre-flight gate listing these. **Continue stays disabled
+until all boxes are ticked** — that is deliberate. None of these can be set or
+even *read* over G-code; all are GUI-only settings, so the host has no way to
+check them for you.
+
+| Do this at the printer | Why it matters |
+|---|---|
+| **Settings → Filament Sensor → OFF** | Left on, the printer grabs and autoloads the filament while you are hand-inserting it. |
+| **Settings → Auto Retract → OFF** | Left on, the printer can treat the filament as retracted and **silently discard** the extrusion and pull moves. The procedure appears to run normally while nothing actually moves. |
+| **Remove the PTFE tube** from this tool | The pulled plug travels up and out of the top port. With the tube fitted there is nowhere for it to go. |
+| **Settings → Hardware → Experimental Settings → "Serial Printing Screen" → OFF** | **Serial route only.** See the warning below. Leaving this screen prompts you to save and reboot. |
+| Light-coloured PLA on hand; stay at the printer | PLA shows extracted debris clearly. Heaters switch off after ~30 minutes unattended (safety timer). |
+
+> ### ⚠️ Why "Serial Printing Screen" matters
+>
+> With it **on**, the firmware treats a serial session as a print job. A
+> **5-second inactivity timeout** then runs the *end-of-print* sequence in the
+> middle of your procedure — nozzle wipe, **tool dock**, steppers off — while
+> the host is still sending extrusion commands. The next `G1 E` hits a machine
+> with no nozzle attached and the printer crashes with
+> **`E move without tool`** (`planner.cpp:2177`).
+>
+> This is a real firmware bug, not a misconfiguration; it was reproduced on
+> hardware. The tool now works around it in code (see [§9](#9-how-it-works))
+> and the serial route has since completed successfully on hardware — but
+> turning the setting off removes the hazard at its source, so it stays a
+> prerequisite.
+>
+> **The G-code routes are unaffected** — a print job is driven by the media
+> queue and the normal print state machine, so this timeout never applies.
+
+Light-coloured PLA is strongly preferred. Black filament makes it nearly
+impossible to judge whether the tip came out clean.
+
+---
+
+## 3. Choosing how to run it
+
+**Maintenance → Cold Pull (INDX)…** offers three routes under *How to run it*.
+All three run the identical procedure and show the identical prompts on the
+printer's screen; only the delivery differs.
+
+| Route | Use when | Notes |
+|---|---|---|
+| **Run over USB serial from here** *(default)* | You can connect the printer over USB | PrusaSlicer drives the procedure and shows live progress. Cancel restores printer state. Requires the *Serial Printing Screen* prerequisite above. |
+| **Save G-code file** | You cannot or would rather not use USB serial | Writes a `.gcode` file. Copy it to a USB drive and start it like any other print. |
+| **Upload G-code to the printer** | You have PrusaLink / Connect set up | Same file, uploaded over the network. Only offered when a physical printer with a print host is configured. **Never auto-starts** — you start it from the printer's menu. |
+
+**Serial is the default and has been validated on hardware.** It gives live
+progress, and its Cancel button restores printer state (heaters off, guards
+re-enabled) — something the G-code routes cannot offer, since stopping a print
+part-way leaves session settings behind for you to restore by hand.
+
+The G-code routes exist for anyone who cannot connect over USB, or would rather
+not. They run the identical procedure with the identical prompts, and they need
+one fewer prerequisite: a print job is driven by the media queue and the normal
+print state machine, so the *Serial Printing Screen* setting does not apply to
+them.
+
+---
+
+## 4. Parameters
+
+| Field | Range | Default | Meaning |
+|---|---|---|---|
+| **Nozzle** | 1–8 | 1 | The nozzle to clean, numbered as on the machine. Internally converted to the firmware's 0-based `T` index — nozzle 1 sends `T0`. |
+| **Flush temp** | 200–290 °C | 290 | Melting temperature for the flush. Capped at 290 because the firmware clamps settable targets there (`HEATER_0_MAXTEMP` 305 minus a 15 °C margin); a higher value would make the heat-wait never finish. |
+| **Pull temp** | 60–120 °C | 80 | Temperature at which the plug is pulled. 80 is field-verified. |
+
+> **INDX temperatures are not comparable to other printers.** INDX measures
+> nozzle temperature with a sensor **17 mm above the tip** (`nozzle_tip_position_mm`
+> 28 − `temp_sensor_position_mm` 11), and only **15 %** of the resulting gradient
+> is compensated (`compensation_factor = 0.15`) — see
+> `src/feature/indx_hotend_temp_model/indx_hotend_temp_compensation.cpp`. The
+> displayed value therefore reads *higher* than the true melt zone.
+>
+> Do not substitute numbers from MK4/XL cold-pull guides, which are
+> thermistor-based and measure a different thing. If 80 °C will not release the
+> plug, raise in **5–10 °C steps**, up to about 120.
+
+---
+
+## 5. Walkthrough
+
+Prompts appear on the **printer's** screen and wait for a knob press. The
+sequence is the same on all three routes.
+
+### Before starting
+Complete every item in [§2](#2-prerequisites-required).
+
+### Prompt 1 — Setup check
+> *Setup check: filament sensor OFF, auto retract OFF, PTFE tube removed.*
+
+A last confirmation before anything heats. Press the knob to continue.
+
+### Prompt 2 — Insert filament
+> *Insert light PLA into the top port until it stops at the drive gears.*
+
+Push PLA into the top port until it meets resistance at the gears. **Do not
+force it**, and do not try to push it all the way through — the INDX extruder is
+geared (~550 steps/mm) and cannot be hand-fed. The motor does the feeding.
+
+The nozzle is still cold here, deliberately: insertion depth only reaches the
+gears, so there is no reason to have you working near a hot end.
+
+### Heating and purge (automatic)
+The nozzle heats to the flush temperature, then pushes roughly 60 mm of filament
+through in three passes. Watch the tip — fresh PLA should appear.
+
+### Prompt 3 — Tip check ⚠️ *the decision point*
+> *Tip check. PLA out: press knob to continue. NOTHING out: press knob then Stop print.*
+
+- **PLA came out** → press the knob and continue.
+- **Nothing came out** → press the knob, then **Stop the print immediately**.
+  There is a 15-second grace window before packing begins.
+
+Nothing extruding means the blockage is *above* the melt zone, where a cold pull
+cannot reach it. Continuing wastes twenty minutes and will not help. See
+[§8](#8-troubleshooting).
+
+> **If you stop here**, the restore block at the end never runs. Afterwards send
+> `M302 S170` and `M591 R`, or simply power-cycle the printer, to restore the
+> cold-extrusion guard and stuck-filament detection.
+
+### Packing and cooling (automatic)
+The heater drops toward 180 °C while small extrusions pack the melt zone, then
+the fan runs full and the hot end cools to 60 °C with a two-minute hold. This is
+the longest phase — several minutes with nothing visible happening.
+
+### Prompt 4 — Pull ready
+> *Pull ready at 80C. Motor will yank the plug — keep hands clear.*
+
+**Keep hands clear of the head.** The extruder retracts hard (50 mm/s) on the
+knob press.
+
+### Prompt 5 — Remove the strand
+> *Pull done. Remove strand from top port. Pressing knob starts auto wipe and dock.*
+
+Lift the strand out of the top port and set it aside **before** pressing the
+knob. The printer then wipes and docks the tool automatically; doing this first
+keeps the strand out of the way of those movements.
+
+### Finishing
+The end-of-print sequence runs: nozzle wipe, tool dock, steppers off. Wait for
+*Finished*.
+
+---
+
+## 6. Reading the result
+
+Inspect the extracted tip.
+
+| What you see | Meaning |
+|---|---|
+| **Three thin strands** with visible dark debris | A good pull. The strands are the nozzle's internal geometry. |
+| A clean, sharply moulded tip with no debris | The nozzle is clean — you are done. |
+| A blunt, stubby tip | Pulled too warm or too soon. Repeat, raising the pull temperature 5–10 °C. |
+| Filament snapped off inside | Pulled too cold. Repeat at a higher pull temperature. |
+
+**Repeat until the tip comes out clean** — typically one to three cycles.
+
+### Afterwards
+Restore what you changed in [§2](#2-prerequisites-required):
+
+- Filament Sensor → **on**
+- Auto Retract → **on**
+- Refit the PTFE tube
+- *Serial Printing Screen* → back on, if you turned it off and want it
+
+---
+
+## 7. Cancelling part-way
+
+**Serial route.** Click *Cancel* in the progress dialog. The worker stops at the
+next step and restores printer state — heaters off, fan off, cold-extrusion
+guard and stuck-filament detection re-enabled, motor current restored, steppers
+released. If a prompt is showing on the printer, press the knob so the cleanup
+commands can run. A second Cancel offers **Force Stop (M112)**, an emergency
+stop that requires a printer reset.
+
+**G-code routes.** Press the knob to dismiss any prompt, then **Stop** on the
+printer. If you stop before the restore block, send `M302 S170` and `M591 R`
+afterwards, or power-cycle.
+
+---
+
+## 8. Troubleshooting
+
+### Nothing extrudes during the purge
+The blockage is above the melt zone — in the heatbreak or the cold side — and a
+cold pull cannot reach it. Stop the procedure. Options: remove and inspect the
+tool, or contact Bondtech (who manufacture the INDX system).
+
+### The plug will not release, or the filament snaps
+Pulled too cold. Repeat with the pull temperature raised 5–10 °C. Work upward;
+120 °C is the sensible ceiling.
+
+### The tip comes out blunt with no debris
+Pulled too warm — the plug released before gripping anything. Lower the pull
+temperature 5–10 °C, or make sure the deep-cool phase completed.
+
+### Printer shows `E move without tool` and crashes
+The tool was docked mid-procedure while commands were still being sent. On the
+serial route this means *Serial Printing Screen* is still on — see the warning
+in [§2](#2-prerequisites-required). Reset the printer (the crash dump is saved
+and safe to discard), turn that setting off, reboot, and prefer a G-code route.
+
+### The procedure appears to run but nothing moves
+**Auto Retract is still on.** The planner discards E moves when it considers the
+filament retracted, so everything looks normal while nothing happens. Turn it
+off and start again.
+
+### The printer grabs the filament as I insert it
+**Filament Sensor is still on**, triggering autoload. Turn it off and start
+again.
+
+### Heaters switched off mid-procedure
+A prompt was left unanswered for ~30 minutes and the safety timer turned the
+heaters off. Restart the procedure and stay at the machine.
+
+### Serial route: "No Prusa printer found on USB serial"
+Check the cable, and close anything else holding the port — PrusaLink, another
+slicer, OctoPrint, a serial monitor. Override the port with the
+`PRUSASLICER_MAINTENANCE_PORT` environment variable if auto-detection picks
+wrong.
+
+---
+
+## 9. How it works
+
+The recipe, and why each step is shaped the way it is:
+
+| Phase | Commands | Rationale |
+|---|---|---|
+| Pick tool | `T<n> M0` | `M0` bypasses tool mapping. **Heating requires a latched tool** — an unlatched hot end never becomes thermally managed, so the heater will not arm. |
+| Prepare | `M302 S0`, `M83`, `M591 S0` | Allow cold extrusion (`EXTRUDE_MINTEMP` is 170 and would otherwise silently strip the pull moves), relative E, and disable stuck-filament detection so the deliberate stall does not trip it. |
+| Flush | `M109 S290`, 3 × `G1 E20 F120` | Melt and displace old material. |
+| Pack | `M104 S180`, 8 × `G1 E2 F60` with dwells | Small extrusions while cooling pack the melt zone so the plug forms a complete cast of the nozzle interior. |
+| Deep cool | `M106 S255`, `M109 R60`, `G4 S120` | The plug must grip before the pull. `M109 R` regulates *at* the target and can exit early if the cooling slope flattens, so a fixed dwell follows it. |
+| Reheat | `M109 R80` | Just enough softening to release from the walls while still gripping the debris. |
+| Pull | `M906 E650`, `G1 E-40 F3000`, `G1 E-30 F1200` | Raised motor current for the stiff plug; a fast yank, then a slower feed to bring the strand up and out. |
+| Restore | `M906 E550`, `M591 R`, `M302 S170` | Undo every session change. |
+
+### Why the serial route sends `G4 P1` first
+
+A defence against the firmware bug in [§2](#2-prerequisites-required). Buddy
+treats any `G` command — and `M73`/`M74`/`M109`/`M190` — arriving over serial as
+the start of a print. The inactivity timestamp is stamped when that command is
+*queued*, but the only code that refreshes it runs solely from `State::Printing`,
+which cannot be reached until the arming command *finishes*.
+
+Arming with a long-blocking command such as `M109` therefore means the first
+timeout check already sees the entire heat-up as elapsed time — instantly
+exceeding the 5-second limit and triggering the end-of-print teardown.
+
+Sending `G4 P1` (a 1 ms dwell) first arms the state machine with a command that
+completes immediately, so the state reaches `Printing` with a fresh timestamp.
+From then on the timer refreshes continuously, and long prompts are safe.
+
+As a second layer, the tool re-issues `T<n>` before each block of E moves. If
+anything docks the tool unexpectedly, the re-pick repopulates it and the next
+extrusion cannot hit the assert.
+
+### Firmware references
+
+Verified against Prusa-Firmware-Buddy `6.6.3+15625` (commit `ff6658da4`):
+
+| Behaviour | Location |
+|---|---|
+| `HAS_COLDPULL` excludes INDX | `ProjectOptions.cmake:716` |
+| Serial-print arming | `src/common/serial_printing.cpp:56-99` |
+| 5-second timeout | `src/common/serial_printing.hpp:33` |
+| End-of-print teardown | `src/common/marlin_server.cpp:983` |
+| `E move without tool` assert | `lib/Marlin/Marlin/src/module/planner.cpp:2177` |
+| Auto-retract planner hook | `lib/Marlin/Marlin/src/module/planner.cpp:2196` |
+| M0 message limit (`MAX_CMD_SIZE` 96) | `include/marlin/Configuration_COREONE_adv.h:578` |
+| Safety timer | `src/feature/safety_timer/safety_timer.hpp:40` |
+
+---
+
+## Appendix — running the G-code by hand
+
+The generated file is plain, readable G-code with a documented header; you can
+open and edit it. Two conventions to preserve if you do:
+
+- **`M0` messages must be ≤ 95 characters** for the whole line, must start with
+  a plain word, and must contain no semicolons. Longer lines are cropped
+  mid-sentence and raise a warning — which matters most for the safety-critical
+  prompts.
+- **Do not reorder the tool pick.** `T<n>` must come before any heating, or the
+  hot end never becomes thermally managed and the heater will not arm.

--- a/doc/Cold_Pull_Guide.md
+++ b/doc/Cold_Pull_Guide.md
@@ -118,11 +118,17 @@ application (PrusaLink, another slicer, a serial monitor) still shows as
 detected and will only fail when the procedure actually starts.
 
 **The model is verified before anything is sent.** Port detection matches any
-Prusa printer, so on connecting the tool queries `M115` and refuses to continue
-unless the machine reports an INDX (`COREONEINDX` or `COREONEL-INDX`). This
-procedure sends toolchanger picks, 290 °C targets and INDX motor currents; on an
-MK4, XL or MINI those would be wrong and potentially damaging. If a non-INDX
-printer answers, the run aborts before a single command is sent.
+Prusa printer, so the tool queries `M115` on each candidate port and uses the
+first that reports an INDX. With several Prusa printers attached it will find
+the INDX rather than giving up on whichever enumerated first. If none of them
+is an INDX, the run aborts before a single command is sent, listing what it
+found.
+
+This matters because the procedure sends toolchanger picks, 290 °C targets and
+INDX motor currents — all wrong, and potentially damaging, on an MK4, XL or
+MINI. The generated G-code file carries the same protection differently: it
+opens with `M862.3 P"COREONEINDX"`, so the printer's own print preview refuses
+the job on a mismatched model.
 
 The G-code routes run the identical procedure with the identical prompts, and
 need one fewer prerequisite: a print job is driven by the media queue and the

--- a/doc/Cold_Pull_Guide.md
+++ b/doc/Cold_Pull_Guide.md
@@ -50,17 +50,20 @@ it stops and waits for knob presses at five points.
 
 ## 2. Prerequisites (required)
 
-The dialog opens with a pre-flight gate listing these. **Continue stays disabled
-until all boxes are ticked** — that is deliberate. None of these can be set or
-even *read* over G-code; all are GUI-only settings, so the host has no way to
-check them for you.
+After you choose a delivery route, a pre-flight gate lists the relevant items.
+**Continue stays disabled until all boxes are ticked** — that is deliberate.
+None of these can be set or even *read* over G-code; all are GUI-only settings,
+so the host has no way to check them for you.
+
+The list adapts to the route: the *Serial Printing Screen* item below appears
+only for the serial route, since it cannot affect a G-code print job.
 
 | Do this at the printer | Why it matters |
 |---|---|
 | **Settings → Filament Sensor → OFF** | Left on, the printer grabs and autoloads the filament while you are hand-inserting it. |
 | **Settings → Auto Retract → OFF** | Left on, the printer can treat the filament as retracted and **silently discard** the extrusion and pull moves. The procedure appears to run normally while nothing actually moves. |
 | **Remove the PTFE tube** from this tool | The pulled plug travels up and out of the top port. With the tube fitted there is nowhere for it to go. |
-| **Settings → Hardware → Experimental Settings → "Serial Printing Screen" → OFF** | **Serial route only.** See the warning below. Leaving this screen prompts you to save and reboot. |
+| **Settings → Hardware → Experimental Settings → "Serial Printing Screen" → OFF** | **Serial route only** — this item is not shown for the G-code routes. See the warning below. Leaving this screen prompts you to save and reboot. |
 | Light-coloured PLA on hand; stay at the printer | PLA shows extracted debris clearly. Heaters switch off after ~30 minutes unattended (safety timer). |
 
 > ### ⚠️ Why "Serial Printing Screen" matters
@@ -113,6 +116,13 @@ Detection only enumerates ports; it does not open one. So it reports that a
 printer is *plugged in*, not that it is free — a port held by another
 application (PrusaLink, another slicer, a serial monitor) still shows as
 detected and will only fail when the procedure actually starts.
+
+**The model is verified before anything is sent.** Port detection matches any
+Prusa printer, so on connecting the tool queries `M115` and refuses to continue
+unless the machine reports an INDX (`COREONEINDX` or `COREONEL-INDX`). This
+procedure sends toolchanger picks, 290 °C targets and INDX motor currents; on an
+MK4, XL or MINI those would be wrong and potentially damaging. If a non-INDX
+printer answers, the run aborts before a single command is sent.
 
 The G-code routes run the identical procedure with the identical prompts, and
 need one fewer prerequisite: a print job is driven by the media queue and the

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -155,6 +155,8 @@ set(SLIC3R_GUI_SOURCES
     GUI/CalibrationFanDialog.hpp
     GUI/CalibrationBedMeshDialog.cpp
     GUI/CalibrationBedMeshDialog.hpp
+    GUI/MaintenanceColdPullDialog.cpp
+    GUI/MaintenanceColdPullDialog.hpp
     GUI/UpdatesUIManager.cpp
     GUI/UpdatesUIManager.hpp
     GUI/FrequentlyChangedParameters.cpp
@@ -255,6 +257,8 @@ set(SLIC3R_GUI_SOURCES
     Utils/Serial.hpp
     Utils/BedMeshSerial.cpp
     Utils/BedMeshSerial.hpp
+    Utils/MaintenanceSerial.cpp
+    Utils/MaintenanceSerial.hpp
     GUI/ConfigWizard.cpp
     GUI/ConfigWizard.hpp
     GUI/ConfigWizard_private.hpp

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -1914,6 +1914,17 @@ void MainFrame::init_menubar_as_editor()
             _L("Fetch, probe, display, and compare bed mesh data"));
     }
 
+    // Maintenance menu — printer service procedures run over USB serial,
+    // following the same worker/progress pattern as the bed mesh tools.
+    auto maintenanceMenu = new wxMenu();
+    {
+        append_menu_item(maintenanceMenu, wxID_ANY, _L("&Cold Pull (INDX)…"),
+            _L("Run a guided cold pull on a connected INDX to clear a clogged nozzle. "
+               "Prompts appear on the printer's screen"),
+            [this](wxCommandEvent&) { if (m_plater) m_plater->cold_pull_maintenance(); },
+            "", nullptr, []() { return true; }, this);
+    }
+
     // Help menu
     auto helpMenu = generate_help_menu();
 
@@ -1931,6 +1942,8 @@ void MainFrame::init_menubar_as_editor()
         m_bar_menus.AppendMenuItem(viewMenu, _L("&View"));
 
     m_bar_menus.AppendMenuItem(calibrationMenu, _L("Ca&libration"));
+
+    m_bar_menus.AppendMenuItem(maintenanceMenu, _L("Main&tenance"));
 
     m_bar_menus.AppendMenuItem(wxGetApp().get_config_menu(this), _L("&Configuration"));
 
@@ -1950,6 +1963,7 @@ void MainFrame::init_menubar_as_editor()
     m_menubar->Append(windowMenu, _L("&Window"));
     if (viewMenu) m_menubar->Append(viewMenu, _L("&View"));
     m_menubar->Append(calibrationMenu, _L("Ca&libration"));
+    m_menubar->Append(maintenanceMenu, _L("Main&tenance"));
     // Add additional menus from C++
     m_menubar->Append(wxGetApp().get_config_menu(this), _L("&Configuration"));
     m_menubar->Append(helpMenu, _L("&Help"));

--- a/src/slic3r/GUI/MaintenanceColdPullDialog.cpp
+++ b/src/slic3r/GUI/MaintenanceColdPullDialog.cpp
@@ -17,7 +17,8 @@ namespace Slic3r { namespace GUI {
 // Pre-flight gate
 // ---------------------------------------------------------------------------
 
-MaintenanceColdPullPreflightDialog::MaintenanceColdPullPreflightDialog(wxWindow* parent)
+MaintenanceColdPullPreflightDialog::MaintenanceColdPullPreflightDialog(wxWindow* parent,
+                                                                       bool for_serial)
     : wxDialog(parent, wxID_ANY, _L("Cold Pull — Before You Start"),
                wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE)
 {
@@ -43,7 +44,7 @@ MaintenanceColdPullPreflightDialog::MaintenanceColdPullPreflightDialog(wxWindow*
     // Each entry: the checkbox label (the action) and why it matters. The
     // "why" is what stops people from reflexively ticking boxes.
     struct Item { wxString label, why; };
-    const Item items[] = {
+    std::vector<Item> items = {
         { _L("Filament Sensor is turned OFF"),
           _L("Settings → Filament Sensor. If left on, the printer grabs and "
              "autoloads the filament while you are hand-inserting it.") },
@@ -54,19 +55,29 @@ MaintenanceColdPullPreflightDialog::MaintenanceColdPullPreflightDialog(wxWindow*
         { _L("The PTFE tube is removed from this tool"),
           _L("The pulled plug travels up and out of the top port. With the "
              "tube fitted there is nowhere for it to go.") },
-        { _L("\"Serial Printing Screen\" is turned OFF, and the printer rebooted"),
-          _L("Settings → Hardware → Experimental Settings (leaving the screen "
-             "prompts to save and reboot). Left on, the printer treats this "
-             "session as a print, and a 5-second inactivity timeout runs the "
-             "end-of-print sequence mid-procedure — wiping the nozzle and "
-             "docking the tool while the host is still extruding. That crashed "
-             "a real printer with \"E move without tool\".") },
+    };
+
+    // Serial-only. A G-code print job is driven by the media queue and the
+    // normal print state machine, so this timeout cannot apply to it -- asking
+    // those users to change the setting and reboot would be asking for a change
+    // that cannot affect their run.
+    if (for_serial) {
+        items.push_back(
+            { _L("\"Serial Printing Screen\" is turned OFF, and the printer rebooted"),
+              _L("Settings → Hardware → Experimental Settings (leaving the screen "
+                 "prompts to save and reboot). Left on, the printer treats this "
+                 "session as a print, and a 5-second inactivity timeout runs the "
+                 "end-of-print sequence mid-procedure — wiping the nozzle and "
+                 "docking the tool while the host is still extruding. That crashed "
+                 "a real printer with \"E move without tool\".") });
+    }
+
+    items.push_back(
         { _L("Light-colored PLA is on hand, and you will stay at the printer"),
           _L("PLA shows the extracted debris clearly. The procedure stops and "
              "waits for knob presses on the printer's screen at several "
              "points, and the printer turns the heaters off after 30 minutes "
-             "unattended.") },
-    };
+             "unattended.") });
 
     for (const Item& it : items) {
         auto* cb = new wxCheckBox(this, wxID_ANY, it.label);

--- a/src/slic3r/GUI/MaintenanceColdPullDialog.cpp
+++ b/src/slic3r/GUI/MaintenanceColdPullDialog.cpp
@@ -1,0 +1,241 @@
+///|/ Copyright (c) 2026
+///|/
+///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
+///|/
+#include "MaintenanceColdPullDialog.hpp"
+#include "GUI_App.hpp"
+#include "I18N.hpp"
+
+#include <wx/sizer.h>
+#include <wx/stattext.h>
+#include <wx/statbox.h>
+#include <wx/button.h>
+
+namespace Slic3r { namespace GUI {
+
+// ---------------------------------------------------------------------------
+// Pre-flight gate
+// ---------------------------------------------------------------------------
+
+MaintenanceColdPullPreflightDialog::MaintenanceColdPullPreflightDialog(wxWindow* parent)
+    : wxDialog(parent, wxID_ANY, _L("Cold Pull — Before You Start"),
+               wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE)
+{
+    SetFont(wxGetApp().normal_font());
+    wxGetApp().UpdateDarkUI(this);
+
+    // Target text width. Without an explicit Wrap() wxStaticText breaks only at
+    // embedded newlines, so a long paragraph forces the whole dialog as wide as
+    // the paragraph is long.
+    const int text_width = FromDIP(380);
+
+    auto* top = new wxBoxSizer(wxVERTICAL);
+
+    auto* intro = new wxStaticText(this, wxID_ANY,
+        _L("Nothing has been sent to the printer yet. Do these at the printer "
+           "first — the host cannot check or change them for you."));
+    intro->Wrap(text_width);
+    top->Add(intro, 0, wxALL, 10);
+
+    auto* list_box = new wxStaticBoxSizer(wxVERTICAL, this,
+                                          _L("Confirm each item"));
+
+    // Each entry: the checkbox label (the action) and why it matters. The
+    // "why" is what stops people from reflexively ticking boxes.
+    struct Item { wxString label, why; };
+    const Item items[] = {
+        { _L("Filament Sensor is turned OFF"),
+          _L("Settings → Filament Sensor. If left on, the printer grabs and "
+             "autoloads the filament while you are hand-inserting it.") },
+        { _L("Auto Retract is turned OFF"),
+          _L("Settings → Auto Retract. If left on, the printer can treat the "
+             "filament as retracted and silently discard the extrusion and "
+             "pull moves — the procedure appears to run but nothing moves.") },
+        { _L("The PTFE tube is removed from this tool"),
+          _L("The pulled plug travels up and out of the top port. With the "
+             "tube fitted there is nowhere for it to go.") },
+        { _L("\"Serial Printing Screen\" is turned OFF, and the printer rebooted"),
+          _L("Settings → Hardware → Experimental Settings (leaving the screen "
+             "prompts to save and reboot). Left on, the printer treats this "
+             "session as a print, and a 5-second inactivity timeout runs the "
+             "end-of-print sequence mid-procedure — wiping the nozzle and "
+             "docking the tool while the host is still extruding. That crashed "
+             "a real printer with \"E move without tool\".") },
+        { _L("Light-colored PLA is on hand, and you will stay at the printer"),
+          _L("PLA shows the extracted debris clearly. The procedure stops and "
+             "waits for knob presses on the printer's screen at several "
+             "points, and the printer turns the heaters off after 30 minutes "
+             "unattended.") },
+    };
+
+    for (const Item& it : items) {
+        auto* cb = new wxCheckBox(this, wxID_ANY, it.label);
+        cb->Bind(wxEVT_CHECKBOX,
+                 [this](wxCommandEvent&) { update_continue_enabled(); });
+        m_checks.push_back(cb);
+        list_box->Add(cb, 0, wxLEFT | wxRIGHT | wxTOP, 8);
+
+        auto* why = new wxStaticText(this, wxID_ANY, it.why);
+        wxFont why_font = why->GetFont();
+        why_font.SetPointSize(why_font.GetPointSize() - 1);
+        why->SetFont(why_font);
+        // Wrap AFTER the smaller font is applied -- Wrap() measures with the
+        // font current at call time.
+        why->Wrap(text_width - FromDIP(16));
+        list_box->Add(why, 0, wxLEFT | wxRIGHT | wxBOTTOM, 8);
+        list_box->AddSpacer(FromDIP(2));
+    }
+
+    top->Add(list_box, 0, wxEXPAND | wxLEFT | wxRIGHT, 10);
+
+    auto* buttons = CreateStdDialogButtonSizer(wxOK | wxCANCEL);
+    if (auto* ok = static_cast<wxButton*>(FindWindow(wxID_OK)))
+        ok->SetLabel(_L("Continue"));
+    top->Add(buttons, 0, wxEXPAND | wxALL, 10);
+
+    update_continue_enabled();
+
+    SetSizerAndFit(top);
+    CenterOnParent();
+}
+
+void MaintenanceColdPullPreflightDialog::update_continue_enabled()
+{
+    bool all_checked = true;
+    for (const wxCheckBox* cb : m_checks)
+        all_checked = all_checked && cb->GetValue();
+    if (auto* ok = FindWindow(wxID_OK))
+        ok->Enable(all_checked);
+}
+
+// ---------------------------------------------------------------------------
+// Parameters
+// ---------------------------------------------------------------------------
+
+MaintenanceColdPullDialog::MaintenanceColdPullDialog(wxWindow* parent,
+                                                     bool upload_available)
+    : wxDialog(parent, wxID_ANY, _L("Cold Pull (INDX)"),
+               wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE)
+    , m_upload_available(upload_available)
+{
+    SetFont(wxGetApp().normal_font());
+    wxGetApp().UpdateDarkUI(this);
+
+    auto* top = new wxBoxSizer(wxVERTICAL);
+
+    // Description — what's about to happen. Prerequisites are handled by the
+    // pre-flight dialog that runs before this one. Wrap explicitly, or the
+    // paragraph sets the dialog width.
+    const int text_width = FromDIP(380);
+    auto* intro = new wxStaticText(this, wxID_ANY,
+        _L("Runs a guided cold pull on one INDX nozzle to clear a clog: pick "
+           "tool, hot flush, pack while cooling, deep cool, then a motorized "
+           "pull. You confirm each step on the PRINTER's screen.\n\n"
+           "Typical duration: 10–20 minutes, mostly cooling."));
+    intro->Wrap(text_width);
+    top->Add(intro, 0, wxALL, 10);
+
+    // Delivery method. Serial is the default -- it has been validated on
+    // hardware and gives live progress plus a Cancel that restores printer
+    // state. The G-code routes produce the same procedure as a print job for
+    // anyone who cannot or would rather not connect over USB serial.
+    wxArrayString choices;
+    choices.Add(_L("Save G-code file (run it from a USB drive)"));
+    if (m_upload_available)
+        choices.Add(_L("Upload G-code to the printer"));
+    choices.Add(_L("Run over USB serial from here"));
+
+    m_delivery = new wxRadioBox(this, wxID_ANY, _L("How to run it"),
+                                wxDefaultPosition, wxDefaultSize,
+                                choices, 1, wxRA_SPECIFY_COLS);
+    // Serial is always the last entry; "Upload" is only present when a print
+    // host is configured, so derive the index rather than hard-coding it.
+    m_delivery->SetSelection(m_delivery->GetCount() - 1);
+    top->Add(m_delivery, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 10);
+
+    auto* delivery_hint = new wxStaticText(this, wxID_ANY,
+        _L("Prompts appear on the printer either way. The serial route needs "
+           "\"Serial Printing Screen\" turned off and shows live progress here; "
+           "the G-code routes run as an ordinary print job."));
+    wxFont dh_font = delivery_hint->GetFont();
+    dh_font.SetPointSize(dh_font.GetPointSize() - 1);
+    delivery_hint->SetFont(dh_font);
+    delivery_hint->Wrap(text_width);
+    top->Add(delivery_hint, 0, wxLEFT | wxRIGHT | wxBOTTOM, 10);
+
+    auto* params_box  = new wxStaticBoxSizer(wxVERTICAL, this, _L("Parameters"));
+    auto* params_grid = new wxFlexGridSizer(4, 2, 8, 12);
+    params_grid->AddGrowableCol(1);
+
+    // Nozzle number as printed on the machine: docks are labeled 1–8.
+    // tool() converts to the 0-based index the T command expects.
+    params_grid->Add(new wxStaticText(this, wxID_ANY, _L("Nozzle (1–8):")),
+                     0, wxALIGN_CENTER_VERTICAL);
+    m_tool = new wxSpinCtrl(this, wxID_ANY, wxEmptyString,
+                            wxDefaultPosition, wxDefaultSize,
+                            wxSP_ARROW_KEYS, 1, 8, 1);
+    params_grid->Add(m_tool, 0, wxEXPAND);
+
+    // Flush temperature. Buddy clamps settable nozzle targets to 290 on
+    // Core One (HEATER_0_MAXTEMP 305 − 15 safety margin); anything higher
+    // would make the heat-wait spin forever, so the spinner caps there.
+    params_grid->Add(new wxStaticText(this, wxID_ANY, _L("Flush temp (°C):")),
+                     0, wxALIGN_CENTER_VERTICAL);
+    m_flush_temp = new wxSpinCtrl(this, wxID_ANY, wxEmptyString,
+                                  wxDefaultPosition, wxDefaultSize,
+                                  wxSP_ARROW_KEYS, 200, 290, 290);
+    params_grid->Add(m_flush_temp, 0, wxEXPAND);
+
+    // Pull temperature.
+    params_grid->Add(new wxStaticText(this, wxID_ANY, _L("Pull temp (°C):")),
+                     0, wxALIGN_CENTER_VERTICAL);
+    m_pull_temp = new wxSpinCtrl(this, wxID_ANY, wxEmptyString,
+                                 wxDefaultPosition, wxDefaultSize,
+                                 wxSP_ARROW_KEYS, 60, 120, 80);
+    params_grid->Add(m_pull_temp, 0, wxEXPAND);
+
+    // Helper note. INDX reads nozzle temperature via an IR estimate that runs
+    // high vs. the true melt zone, so these are INDX-frame values — don't
+    // substitute numbers from thermistor printers (MK4 etc.).
+    params_grid->Add(0, 0);
+    auto* hint = new wxStaticText(this, wxID_ANY,
+        _L("80 is the field-verified pull temp; raise in 5–10 °C steps only "
+           "if the plug won't release."));
+    wxFont hint_font = hint->GetFont();
+    hint_font.SetPointSize(hint_font.GetPointSize() - 1);
+    hint->SetFont(hint_font);
+    hint->Wrap(text_width - FromDIP(90)); // sits in the value column
+    params_grid->Add(hint, 0, wxALIGN_CENTER_VERTICAL);
+
+    params_box->Add(params_grid, 0, wxEXPAND | wxALL, 8);
+    top->Add(params_box, 0, wxEXPAND | wxLEFT | wxRIGHT, 10);
+
+    // Standard buttons.
+    auto* buttons = CreateStdDialogButtonSizer(wxOK | wxCANCEL);
+    if (auto* ok = static_cast<wxButton*>(FindWindow(wxID_OK)))
+        ok->SetLabel(_L("Start"));
+    top->Add(buttons, 0, wxEXPAND | wxALL, 10);
+
+    SetSizerAndFit(top);
+    CenterOnParent();
+}
+
+ColdPullDelivery MaintenanceColdPullDialog::delivery() const
+{
+    // "Upload" is only present in the list when a print host is configured, so
+    // map by position rather than by a fixed index.
+    const int sel = m_delivery->GetSelection();
+    if (sel == 0)
+        return ColdPullDelivery::SaveGcode;
+    if (m_upload_available && sel == 1)
+        return ColdPullDelivery::UploadGcode;
+    return ColdPullDelivery::Serial;
+}
+
+// The spinner shows the nozzle number printed on the machine (1–8); the
+// firmware's T command is 0-based, so hand back the index, not the label.
+int MaintenanceColdPullDialog::tool()         const { return m_tool->GetValue() - 1; }
+int MaintenanceColdPullDialog::flush_temp_c() const { return m_flush_temp->GetValue(); }
+int MaintenanceColdPullDialog::pull_temp_c()  const { return m_pull_temp->GetValue(); }
+
+}} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/MaintenanceColdPullDialog.cpp
+++ b/src/slic3r/GUI/MaintenanceColdPullDialog.cpp
@@ -113,10 +113,12 @@ void MaintenanceColdPullPreflightDialog::update_continue_enabled()
 // ---------------------------------------------------------------------------
 
 MaintenanceColdPullDialog::MaintenanceColdPullDialog(wxWindow* parent,
-                                                     bool upload_available)
+                                                     bool upload_available,
+                                                     bool serial_available)
     : wxDialog(parent, wxID_ANY, _L("Cold Pull (INDX)"),
                wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE)
     , m_upload_available(upload_available)
+    , m_serial_available(serial_available)
 {
     SetFont(wxGetApp().normal_font());
     wxGetApp().UpdateDarkUI(this);
@@ -135,28 +137,43 @@ MaintenanceColdPullDialog::MaintenanceColdPullDialog(wxWindow* parent,
     intro->Wrap(text_width);
     top->Add(intro, 0, wxALL, 10);
 
-    // Delivery method. Serial is the default -- it has been validated on
-    // hardware and gives live progress plus a Cancel that restores printer
-    // state. The G-code routes produce the same procedure as a print job for
-    // anyone who cannot or would rather not connect over USB serial.
+    // Delivery method. With a printer detected on USB serial, that route is the
+    // default: it is the hardware-validated path and the only one offering live
+    // progress and a Cancel that restores printer state. With nothing detected
+    // the entry is disabled -- selecting it could only fail -- and the G-code
+    // file route becomes the default.
     wxArrayString choices;
     choices.Add(_L("Save G-code file (run it from a USB drive)"));
     if (m_upload_available)
         choices.Add(_L("Upload G-code to the printer"));
-    choices.Add(_L("Run over USB serial from here"));
+    choices.Add(m_serial_available
+                    ? _L("Run over USB serial from here")
+                    : _L("Run over USB serial from here (no printer detected)"));
 
     m_delivery = new wxRadioBox(this, wxID_ANY, _L("How to run it"),
                                 wxDefaultPosition, wxDefaultSize,
                                 choices, 1, wxRA_SPECIFY_COLS);
+
     // Serial is always the last entry; "Upload" is only present when a print
     // host is configured, so derive the index rather than hard-coding it.
-    m_delivery->SetSelection(m_delivery->GetCount() - 1);
+    const int serial_index = m_delivery->GetCount() - 1;
+    if (m_serial_available) {
+        m_delivery->SetSelection(serial_index);
+    } else {
+        m_delivery->Enable(serial_index, false);
+        m_delivery->SetSelection(0);
+    }
     top->Add(m_delivery, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 10);
 
     auto* delivery_hint = new wxStaticText(this, wxID_ANY,
-        _L("Prompts appear on the printer either way. The serial route needs "
-           "\"Serial Printing Screen\" turned off and shows live progress here; "
-           "the G-code routes run as an ordinary print job."));
+        m_serial_available
+            ? _L("Prompts appear on the printer either way. The serial route "
+                 "needs \"Serial Printing Screen\" turned off and shows live "
+                 "progress here; the G-code routes run as an ordinary print job.")
+            : _L("No printer was found on USB serial, so that route is "
+                 "unavailable. Connect the printer over USB and reopen this "
+                 "dialog to enable it. The G-code routes run the same procedure "
+                 "as an ordinary print job, with the same on-screen prompts."));
     wxFont dh_font = delivery_hint->GetFont();
     dh_font.SetPointSize(dh_font.GetPointSize() - 1);
     delivery_hint->SetFont(dh_font);

--- a/src/slic3r/GUI/MaintenanceColdPullDialog.hpp
+++ b/src/slic3r/GUI/MaintenanceColdPullDialog.hpp
@@ -52,7 +52,13 @@ class MaintenanceColdPullDialog : public wxDialog
 public:
     // upload_available gates the "Upload to printer" choice: it is only
     // offered when a physical printer with a print host is configured.
-    explicit MaintenanceColdPullDialog(wxWindow* parent, bool upload_available);
+    //
+    // serial_available gates the serial choice: with a printer detected on USB
+    // serial it is the default, otherwise that entry is disabled and the
+    // G-code file route becomes the default.
+    MaintenanceColdPullDialog(wxWindow* parent,
+                              bool upload_available,
+                              bool serial_available);
 
     ColdPullDelivery delivery() const;
 
@@ -69,6 +75,7 @@ private:
     wxSpinCtrl* m_pull_temp{nullptr};
 
     bool m_upload_available{false};
+    bool m_serial_available{false};
 };
 
 }} // namespace Slic3r::GUI

--- a/src/slic3r/GUI/MaintenanceColdPullDialog.hpp
+++ b/src/slic3r/GUI/MaintenanceColdPullDialog.hpp
@@ -1,0 +1,76 @@
+///|/ Copyright (c) 2026
+///|/
+///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
+///|/
+#ifndef slic3r_MaintenanceColdPullDialog_hpp_
+#define slic3r_MaintenanceColdPullDialog_hpp_
+
+#include <wx/dialog.h>
+#include <wx/checkbox.h>
+#include <wx/radiobox.h>
+#include <wx/spinctrl.h>
+
+#include <vector>
+
+namespace Slic3r { namespace GUI {
+
+// Pre-flight gate shown BEFORE anything is sent to the printer. Lists the
+// physical/settings prerequisites the host cannot verify or perform itself,
+// each as a checkbox; Continue stays disabled until every box is ticked.
+//
+// This is deliberately a hard gate rather than a wall of text: skipping a
+// prerequisite doesn't fail loudly, it fails subtly (an enabled filament
+// sensor grabs the filament during hand-insertion; auto retract silently
+// discards the pull's E moves), and by then the nozzle is already hot.
+class MaintenanceColdPullPreflightDialog : public wxDialog
+{
+public:
+    explicit MaintenanceColdPullPreflightDialog(wxWindow* parent);
+
+private:
+    void update_continue_enabled();
+
+    std::vector<wxCheckBox*> m_checks;
+};
+
+// How the procedure reaches the printer.
+enum class ColdPullDelivery {
+    // Write a G-code file the user runs as an ordinary print job. Preferred:
+    // a print job is immune to the serial-print inactivity timeout.
+    SaveGcode,
+    // Upload the same file to the configured printer (PrusaLink / Connect).
+    UploadGcode,
+    // Stream commands over USB serial, driving the printer directly.
+    Serial,
+};
+
+// Configuration dialog shown before running the INDX cold-pull maintenance
+// procedure. Collects the delivery method, nozzle number and temperatures,
+// and returns them via the accessors after ShowModal() == wxID_OK.
+class MaintenanceColdPullDialog : public wxDialog
+{
+public:
+    // upload_available gates the "Upload to printer" choice: it is only
+    // offered when a physical printer with a print host is configured.
+    explicit MaintenanceColdPullDialog(wxWindow* parent, bool upload_available);
+
+    ColdPullDelivery delivery() const;
+
+    // 0-based tool index for the firmware T command. The dialog displays the
+    // nozzle number as labeled on the machine (1–8) and converts here.
+    int tool()         const;
+    int flush_temp_c() const;
+    int pull_temp_c()  const;
+
+private:
+    wxRadioBox* m_delivery{nullptr};
+    wxSpinCtrl* m_tool{nullptr};
+    wxSpinCtrl* m_flush_temp{nullptr};
+    wxSpinCtrl* m_pull_temp{nullptr};
+
+    bool m_upload_available{false};
+};
+
+}} // namespace Slic3r::GUI
+
+#endif // slic3r_MaintenanceColdPullDialog_hpp_

--- a/src/slic3r/GUI/MaintenanceColdPullDialog.hpp
+++ b/src/slic3r/GUI/MaintenanceColdPullDialog.hpp
@@ -25,7 +25,9 @@ namespace Slic3r { namespace GUI {
 class MaintenanceColdPullPreflightDialog : public wxDialog
 {
 public:
-    explicit MaintenanceColdPullPreflightDialog(wxWindow* parent);
+    // for_serial adds the serial-only prerequisite ("Serial Printing Screen"),
+    // which does not apply to the G-code print-job routes.
+    MaintenanceColdPullPreflightDialog(wxWindow* parent, bool for_serial);
 
 private:
     void update_continue_enabled();

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -7275,12 +7275,6 @@ void Plater::probe_bed_mesh()
 
 void Plater::cold_pull_maintenance()
 {
-    // Pre-flight gate first: prerequisites must be confirmed before anything
-    // is sent to the printer.
-    MaintenanceColdPullPreflightDialog preflight(this);
-    if (preflight.ShowModal() != wxID_OK)
-        return;
-
     // Offer the upload route only when a physical printer with a print host is
     // configured; otherwise the choice would be a dead end.
     DynamicPrintConfig* ph_config =
@@ -7305,6 +7299,16 @@ void Plater::cold_pull_maintenance()
 
     const ColdPullDelivery delivery = cfg.delivery();
 
+    // Pre-flight gate AFTER the route is known, so the checklist can match it:
+    // "Serial Printing Screen" is a serial-only prerequisite, and demanding it
+    // (plus a printer reboot) from someone exporting a G-code file would be
+    // asking for a change that cannot affect their run. Still the last gate
+    // before anything is sent.
+    MaintenanceColdPullPreflightDialog preflight(this,
+                                                 delivery == ColdPullDelivery::Serial);
+    if (preflight.ShowModal() != wxID_OK)
+        return;
+
     // --- G-code file routes. Preferred over serial: a print job is immune to
     // the serial-print inactivity timeout.
     if (delivery != ColdPullDelivery::Serial) {
@@ -7324,9 +7328,14 @@ void Plater::cold_pull_maintenance()
                 return;
             out_path = into_path(dlg.GetPath());
         } else {
-            // Upload: stage the file in the temp dir, then hand it to the
-            // print-host queue under a stable name.
-            out_path = boost::filesystem::temp_directory_path() / fname;
+            // Upload: stage under a UNIQUE temp name. PrintHostJobQueue runs
+            // jobs asynchronously and fs::remove()s each source once it has
+            // been processed (PrintHost.cpp:301), so a fixed path would let a
+            // second queued upload overwrite the first's payload and then
+            // delete the file out from under it. Only the remote name (fname)
+            // needs to be stable.
+            out_path = boost::filesystem::temp_directory_path()
+                     / boost::filesystem::unique_path("cold_pull-%%%%-%%%%.gcode");
         }
 
         try {
@@ -7419,7 +7428,6 @@ void Plater::cold_pull_maintenance()
     // UI pump: tick the progress dialog until the worker finishes.
     Utils::MaintenanceProgress shown;
     bool continue_running = true;
-    bool cancel_prompted  = false;
     while (!worker_done.load()) {
         {
             std::lock_guard<std::mutex> lk(progress_mutex);
@@ -7435,33 +7443,37 @@ void Plater::cold_pull_maintenance()
             continue_running = dlg.Pulse(label);
         }
         if (!continue_running) {
-            cancel_requested = true;
-            if (!cancel_prompted) {
-                cancel_prompted = true;
-                dlg.Resume();
-                wxMessageDialog confirm(
-                    find_toplevel_parent(this),
-                    _L("Cancel requested. The worker stops at the next step and "
-                       "restores the printer state (heaters off, guards re-enabled).\n\n"
-                       "If a prompt dialog is showing on the printer, press its knob "
-                       "to let the cleanup commands run.\n\n"
-                       "Press 'Force Stop' to send M112 (emergency stop) instead. "
-                       "This halts the printer immediately but requires a power "
-                       "cycle or front-panel reset to recover."),
-                    _L("Cancel Cold Pull"),
-                    wxYES_NO | wxCANCEL | wxICON_WARNING);
-                confirm.SetYesNoCancelLabels(_L("Stop and clean up"),
-                                             _L("Force Stop (M112)"),
-                                             _L("Keep going"));
-                const int ans = confirm.ShowModal();
-                if (ans == wxID_NO) {
-                    force_stop_requested = true;
-                } else if (ans == wxID_CANCEL) {
-                    cancel_requested = false;
-                    cancel_prompted  = false;
-                }
-                // wxID_YES → keep cancel_requested=true and pump on.
+            // Do NOT set cancel_requested here. The worker polls it, so setting
+            // it before the confirmation would let cleanup begin while the user
+            // is still choosing -- making "Keep going" unable to resume, and a
+            // later "Force Stop" arrive after the worker had already exited,
+            // while the UI still claimed M112 was sent. Decide first, act after.
+            dlg.Resume();
+            wxMessageDialog confirm(
+                find_toplevel_parent(this),
+                _L("Cancel requested. The worker stops at the next step and "
+                   "restores the printer state (heaters off, guards re-enabled).\n\n"
+                   "If a prompt dialog is showing on the printer, press its knob "
+                   "to let the cleanup commands run.\n\n"
+                   "Press 'Force Stop' to send M112 (emergency stop) instead. "
+                   "This halts the printer immediately but requires a power "
+                   "cycle or front-panel reset to recover."),
+                _L("Cancel Cold Pull"),
+                wxYES_NO | wxCANCEL | wxICON_WARNING);
+            confirm.SetYesNoCancelLabels(_L("Stop and clean up"),
+                                         _L("Force Stop (M112)"),
+                                         _L("Keep going"));
+            const int ans = confirm.ShowModal();
+            if (ans == wxID_YES) {
+                cancel_requested = true;
+            } else if (ans == wxID_NO) {
+                // Force stop implies cancel: the watchdog ORs both flags, and
+                // the worker checks force-stop first so M112 wins.
+                force_stop_requested = true;
+                cancel_requested     = true;
             }
+            // wxID_CANCEL ("Keep going") → nothing was ever set, so the
+            // procedure simply continues.
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(150));
     }

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -7288,8 +7288,13 @@ void Plater::cold_pull_maintenance()
     const auto* ph_host = ph_config ? ph_config->option<ConfigOptionString>("print_host") : nullptr;
     const bool upload_available = ph_host != nullptr && !ph_host->value.empty();
 
+    // Probe for a printer on USB serial so the dialog can default to the serial
+    // route when one is present and disable it when none is. Enumerating ports
+    // does not open them, so this is cheap.
+    const bool serial_available = !Utils::detect_printer_port().empty();
+
     // Collect delivery method and procedure parameters.
-    MaintenanceColdPullDialog cfg(this, upload_available);
+    MaintenanceColdPullDialog cfg(this, upload_available, serial_available);
     if (cfg.ShowModal() != wxID_OK)
         return;
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -7285,7 +7285,16 @@ void Plater::cold_pull_maintenance()
     // Probe for a printer on USB serial so the dialog can default to the serial
     // route when one is present and disable it when none is. Enumerating ports
     // does not open them, so this is cheap.
-    const bool serial_available = !Utils::detect_printer_port().empty();
+    //
+    // An explicit port override counts as available on its own: it exists to
+    // rescue exactly the case where auto-detection does not recognise the
+    // device, so gating it behind that same detection would make it unusable.
+    // The M115 model check still applies to the overridden port.
+    const char* maintenance_port_override = std::getenv("PRUSASLICER_MAINTENANCE_PORT");
+    const bool  has_port_override =
+        maintenance_port_override != nullptr && *maintenance_port_override != '\0';
+    const bool serial_available =
+        has_port_override || !Utils::detect_printer_port().empty();
 
     // Collect delivery method and procedure parameters.
     MaintenanceColdPullDialog cfg(this, upload_available, serial_available);
@@ -7389,7 +7398,7 @@ void Plater::cold_pull_maintenance()
         return;
     }
 
-    const char* override_port = std::getenv("PRUSASLICER_MAINTENANCE_PORT");
+    const char* override_port = maintenance_port_override;
 
     // Progress dialog with the same two-stage cancel as the bed probe:
     // first Cancel click → cooperative stop (restores printer state),

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -7464,9 +7464,16 @@ void Plater::cold_pull_maintenance()
                                          _L("Force Stop (M112)"),
                                          _L("Keep going"));
             const int ans = confirm.ShowModal();
-            if (ans == wxID_YES) {
+            // The worker keeps running while the dialog is open and may have
+            // failed and exited in the meantime. Setting the flags after that
+            // point only writes atomics nobody polls, so check before acting --
+            // otherwise a serial disconnect with a hot nozzle would still be
+            // reported as "emergency stop sent". result.force_stopped is the
+            // authority on what actually reached the printer.
+            const bool worker_still_running = !worker_done.load();
+            if (ans == wxID_YES && worker_still_running) {
                 cancel_requested = true;
-            } else if (ans == wxID_NO) {
+            } else if (ans == wxID_NO && worker_still_running) {
                 // Force stop implies cancel: the watchdog ORs both flags, and
                 // the worker checks force-stop first so M112 wins.
                 force_stop_requested = true;
@@ -7487,9 +7494,20 @@ void Plater::cold_pull_maintenance()
                         "the Filament Sensor and Auto Retract on the printer and "
                         "refit the PTFE tube."),
                      _L("Cold Pull (INDX)"), wxOK | wxICON_INFORMATION);
-    } else if (force_stop_requested.load()) {
+    } else if (result.force_stopped) {
         wxMessageBox(_L("Emergency stop sent. Reset the printer before continuing."),
                      _L("Cold Pull (INDX)"), wxOK | wxICON_WARNING);
+    } else if (force_stop_requested.load()) {
+        // Requested but never delivered -- the worker had already stopped. Say
+        // so plainly: the printer may still be hot with its guards down.
+        wxMessageBox(GUI::format_wxstr(
+            _L("Force stop was requested but NOT sent — the procedure had "
+               "already stopped on its own:\n\n%1%\n\n"
+               "No emergency stop reached the printer. Check it directly: the "
+               "nozzle may still be hot. If needed, turn the heaters off from "
+               "the printer's menu."),
+            wxString::FromUTF8(result.error.empty() ? "unknown error" : result.error)),
+            _L("Cold Pull (INDX)"), wxOK | wxICON_WARNING);
     } else if (result.cancelled) {
         wxMessageBox(_L("Cold pull cancelled. Printer state was restored (heaters "
                         "off, guards re-enabled). If a dialog is still on the "

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -7508,6 +7508,18 @@ void Plater::cold_pull_maintenance()
                "the printer's menu."),
             wxString::FromUTF8(result.error.empty() ? "unknown error" : result.error)),
             _L("Cold Pull (INDX)"), wxOK | wxICON_WARNING);
+    } else if (result.restore_attempted && !result.restore_verified) {
+        // Cleanup ran but the printer did not acknowledge all of it. Never
+        // claim the machine is safe in this state.
+        wxMessageBox(GUI::format_wxstr(
+            _L("Cold pull stopped, but the printer did NOT confirm the cleanup "
+               "commands:\n\n%1%\n\n"
+               "CHECK THE PRINTER DIRECTLY. The nozzle may still be hot, and "
+               "cold extrusion and stuck-filament detection may still be "
+               "disabled. Turn the heaters off from the printer's menu, and "
+               "power-cycle it to restore the guards."),
+            wxString::FromUTF8(result.error.empty() ? "cancelled" : result.error)),
+            _L("Cold Pull (INDX)"), wxOK | wxICON_WARNING);
     } else if (result.cancelled) {
         wxMessageBox(_L("Cold pull cancelled. Printer state was restored (heaters "
                         "off, guards re-enabled). If a dialog is still on the "

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -23,7 +23,9 @@
 #include "slic3r/Utils/PrusaConnect.hpp"
 #include "slic3r/Utils/FilamentDB.hpp"
 #include "slic3r/Utils/BedMeshSerial.hpp"
+#include "slic3r/Utils/MaintenanceSerial.hpp"
 #include "CalibrationBedMeshDialog.hpp"
+#include "MaintenanceColdPullDialog.hpp"
 
 #include <cstddef>
 #include <algorithm>
@@ -7268,6 +7270,217 @@ void Plater::probe_bed_mesh()
         wxMessageBox(wxString::FromUTF8(result.error.empty() ? "Probing failed." : result.error),
                      _L("Probe Bed Mesh"),
                      wxOK | wxICON_ERROR);
+    }
+}
+
+void Plater::cold_pull_maintenance()
+{
+    // Pre-flight gate first: prerequisites must be confirmed before anything
+    // is sent to the printer.
+    MaintenanceColdPullPreflightDialog preflight(this);
+    if (preflight.ShowModal() != wxID_OK)
+        return;
+
+    // Offer the upload route only when a physical printer with a print host is
+    // configured; otherwise the choice would be a dead end.
+    DynamicPrintConfig* ph_config =
+        wxGetApp().preset_bundle->physical_printers.get_selected_printer_config();
+    const auto* ph_host = ph_config ? ph_config->option<ConfigOptionString>("print_host") : nullptr;
+    const bool upload_available = ph_host != nullptr && !ph_host->value.empty();
+
+    // Collect delivery method and procedure parameters.
+    MaintenanceColdPullDialog cfg(this, upload_available);
+    if (cfg.ShowModal() != wxID_OK)
+        return;
+
+    Utils::ColdPullOptions gcode_opts;
+    gcode_opts.tool         = cfg.tool();
+    gcode_opts.flush_temp_c = cfg.flush_temp_c();
+    gcode_opts.pull_temp_c  = cfg.pull_temp_c();
+
+    const ColdPullDelivery delivery = cfg.delivery();
+
+    // --- G-code file routes. Preferred over serial: a print job is immune to
+    // the serial-print inactivity timeout.
+    if (delivery != ColdPullDelivery::Serial) {
+        const std::string gcode = Utils::generate_cold_pull_gcode(gcode_opts);
+        const std::string fname =
+            "cold_pull_nozzle" + std::to_string(cfg.tool() + 1) + ".gcode";
+
+        boost::filesystem::path out_path;
+        if (delivery == ColdPullDelivery::SaveGcode) {
+            const std::string last_dir = wxGetApp().app_config->get("last_output_path");
+            wxFileDialog dlg(this, _L("Save Cold Pull G-code"),
+                             wxString::FromUTF8(last_dir),
+                             wxString::FromUTF8(fname),
+                             "G-code files (*.gcode)|*.gcode|All files|*",
+                             wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+            if (dlg.ShowModal() != wxID_OK)
+                return;
+            out_path = into_path(dlg.GetPath());
+        } else {
+            // Upload: stage the file in the temp dir, then hand it to the
+            // print-host queue under a stable name.
+            out_path = boost::filesystem::temp_directory_path() / fname;
+        }
+
+        try {
+            boost::nowide::ofstream os(out_path.string(), std::ios::binary);
+            os << gcode;
+            os.close();
+            if (!os)
+                throw std::runtime_error("write failed");
+        } catch (const std::exception& e) {
+            wxMessageBox(GUI::format_wxstr(_L("Could not write %1%: %2%"),
+                                           out_path.string(), e.what()),
+                         _L("Cold Pull (INDX)"), wxOK | wxICON_ERROR);
+            return;
+        }
+
+        if (delivery == ColdPullDelivery::SaveGcode) {
+            wxGetApp().app_config->set("last_output_path",
+                                       out_path.parent_path().string());
+            wxMessageBox(GUI::format_wxstr(
+                _L("Saved to %1%.\n\n"
+                   "Copy it to a USB drive and start it on the printer like any "
+                   "other print. It will stop and wait for knob presses at each "
+                   "step.\n\n"
+                   "Check first: Filament Sensor OFF, Auto Retract OFF, PTFE "
+                   "tube removed."),
+                out_path.string()),
+                _L("Cold Pull (INDX)"), wxOK | wxICON_INFORMATION);
+        } else {
+            PrintHostJob job(ph_config);
+            if (job.empty()) {
+                wxMessageBox(_L("No print host is configured for the selected printer."),
+                             _L("Cold Pull (INDX)"), wxOK | wxICON_ERROR);
+                return;
+            }
+            job.upload_data.source_path = out_path;
+            job.upload_data.upload_path = fname;
+            // Never auto-start: the user must confirm the prerequisites at the
+            // printer before this runs.
+            job.upload_data.post_action = PrintHostPostUploadAction::None;
+            wxGetApp().printhost_job_queue().enqueue(std::move(job));
+            wxMessageBox(GUI::format_wxstr(
+                _L("Uploading %1% to the printer.\n\n"
+                   "It is NOT started automatically — start it from the "
+                   "printer's menu when you are ready. It will stop and wait "
+                   "for knob presses at each step.\n\n"
+                   "Check first: Filament Sensor OFF, Auto Retract OFF, PTFE "
+                   "tube removed."),
+                fname),
+                _L("Cold Pull (INDX)"), wxOK | wxICON_INFORMATION);
+        }
+        return;
+    }
+
+    const char* override_port = std::getenv("PRUSASLICER_MAINTENANCE_PORT");
+
+    // Progress dialog with the same two-stage cancel as the bed probe:
+    // first Cancel click → cooperative stop (restores printer state),
+    // second click → offer M112 force stop.
+    wxProgressDialog dlg(_L("Cold Pull (INDX)"),
+                         _L("Connecting…"),
+                         100,
+                         find_toplevel_parent(this),
+                         wxPD_APP_MODAL | wxPD_CAN_ABORT | wxPD_AUTO_HIDE | wxPD_ELAPSED_TIME);
+
+    std::atomic<bool> cancel_requested{ false };
+    std::atomic<bool> force_stop_requested{ false };
+    std::atomic<bool> worker_done{ false };
+    std::mutex progress_mutex;
+    Utils::MaintenanceProgress latest_progress;
+    Utils::MaintenanceResult result;
+
+    Utils::ColdPullOptions options;
+    options.tool                 = cfg.tool();
+    options.flush_temp_c         = cfg.flush_temp_c();
+    options.pull_temp_c          = cfg.pull_temp_c();
+    options.explicit_port        = override_port ? std::string(override_port) : std::string();
+    options.cancel_requested     = &cancel_requested;
+    options.force_stop_requested = &force_stop_requested;
+
+    std::thread worker([&]() {
+        result = Utils::run_cold_pull(
+            [&](const Utils::MaintenanceProgress& p) {
+                std::lock_guard<std::mutex> lk(progress_mutex);
+                latest_progress = p;
+            },
+            options);
+        worker_done = true;
+    });
+
+    // UI pump: tick the progress dialog until the worker finishes.
+    Utils::MaintenanceProgress shown;
+    bool continue_running = true;
+    bool cancel_prompted  = false;
+    while (!worker_done.load()) {
+        {
+            std::lock_guard<std::mutex> lk(progress_mutex);
+            shown = latest_progress;
+        }
+        wxString label = wxString::FromUTF8(shown.stage);
+        if (!shown.detail.empty())
+            label += " — " + wxString::FromUTF8(shown.detail);
+        if (shown.total_steps > 0 && shown.step > 0) {
+            const int percent = std::min(99, int(100.0 * shown.step / shown.total_steps));
+            continue_running = dlg.Update(percent, label);
+        } else {
+            continue_running = dlg.Pulse(label);
+        }
+        if (!continue_running) {
+            cancel_requested = true;
+            if (!cancel_prompted) {
+                cancel_prompted = true;
+                dlg.Resume();
+                wxMessageDialog confirm(
+                    find_toplevel_parent(this),
+                    _L("Cancel requested. The worker stops at the next step and "
+                       "restores the printer state (heaters off, guards re-enabled).\n\n"
+                       "If a prompt dialog is showing on the printer, press its knob "
+                       "to let the cleanup commands run.\n\n"
+                       "Press 'Force Stop' to send M112 (emergency stop) instead. "
+                       "This halts the printer immediately but requires a power "
+                       "cycle or front-panel reset to recover."),
+                    _L("Cancel Cold Pull"),
+                    wxYES_NO | wxCANCEL | wxICON_WARNING);
+                confirm.SetYesNoCancelLabels(_L("Stop and clean up"),
+                                             _L("Force Stop (M112)"),
+                                             _L("Keep going"));
+                const int ans = confirm.ShowModal();
+                if (ans == wxID_NO) {
+                    force_stop_requested = true;
+                } else if (ans == wxID_CANCEL) {
+                    cancel_requested = false;
+                    cancel_prompted  = false;
+                }
+                // wxID_YES → keep cancel_requested=true and pump on.
+            }
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(150));
+    }
+    worker.join();
+    dlg.Update(100);
+
+    if (result.error.empty()) {
+        wxMessageBox(_L("Cold pull complete. Inspect the extracted tip: three thin "
+                        "strands with visible debris means a good pull. Repeat 1–2 "
+                        "more times until the tip comes out clean, then re-enable "
+                        "the Filament Sensor and Auto Retract on the printer and "
+                        "refit the PTFE tube."),
+                     _L("Cold Pull (INDX)"), wxOK | wxICON_INFORMATION);
+    } else if (force_stop_requested.load()) {
+        wxMessageBox(_L("Emergency stop sent. Reset the printer before continuing."),
+                     _L("Cold Pull (INDX)"), wxOK | wxICON_WARNING);
+    } else if (result.cancelled) {
+        wxMessageBox(_L("Cold pull cancelled. Printer state was restored (heaters "
+                        "off, guards re-enabled). If a dialog is still on the "
+                        "printer screen, press the knob to dismiss it."),
+                     _L("Cold Pull (INDX)"), wxOK | wxICON_INFORMATION);
+    } else {
+        wxMessageBox(wxString::FromUTF8(result.error),
+                     _L("Cold Pull (INDX)"), wxOK | wxICON_ERROR);
     }
 }
 

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -261,6 +261,8 @@ public:
     // Bed mesh overlay
     void fetch_bed_mesh();
     void probe_bed_mesh();
+    // Maintenance procedures over USB serial
+    void cold_pull_maintenance();
     void save_bed_mesh_csv();
     void load_bed_mesh_csv();
     void compare_bed_mesh_csv();

--- a/src/slic3r/Utils/MaintenanceSerial.cpp
+++ b/src/slic3r/Utils/MaintenanceSerial.cpp
@@ -184,6 +184,37 @@ std::string detect_printer_port()
     return pick_prusa_port();
 }
 
+// Extract the MACHINE_TYPE value from M115 output, or "" if absent.
+// Buddy emits "... MACHINE_TYPE:Prusa-<id_str> EXTRUDER_COUNT:n UUID:..."
+// (src/marlin_stubs/host/M115.cpp).
+static std::string machine_type_from_m115(const std::vector<std::string>& lines)
+{
+    constexpr std::string_view kKey = "MACHINE_TYPE:";
+    for (const auto& line : lines) {
+        const auto pos = line.find(kKey);
+        if (pos == std::string::npos)
+            continue;
+        std::string tail = line.substr(pos + kKey.size());
+        // Value runs to the next space (the following key is EXTRUDER_COUNT).
+        const auto end = tail.find(' ');
+        if (end != std::string::npos)
+            tail = tail.substr(0, end);
+        return tail;
+    }
+    return {};
+}
+
+// True when the reported machine type is an INDX variant. The id strings are
+// "COREONEINDX" and "COREONEL-INDX" (include/common/printer_model_data.hpp),
+// so a case-insensitive "INDX" substring covers both and any future variant.
+static bool machine_type_is_indx(const std::string& machine_type)
+{
+    std::string upper = machine_type;
+    std::transform(upper.begin(), upper.end(), upper.begin(),
+                   [](unsigned char c) { return std::toupper(c); });
+    return upper.find("INDX") != std::string::npos;
+}
+
 // ---------------------------------------------------------------------------
 // Cold pull as a standalone G-code file (print-job delivery)
 // ---------------------------------------------------------------------------
@@ -374,6 +405,45 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
             BOOST_LOG_TRIVIAL(warning) << "[Maintenance] >> M112 (force stop)";
         };
 
+        // --- MODEL GATE. Port auto-detection matches any Prusa printer, so a
+        // connected MK4/XL/MINI would otherwise receive this INDX-specific
+        // sequence: toolchanger picks, 290 C targets and INDX motor currents.
+        // Confirm we are talking to an INDX before sending anything else.
+        emit("Connecting", "Identifying printer");
+        {
+            std::vector<std::string> m115_lines;
+            error_code ec;
+            asio::write(serial, asio::buffer(std::string("M115\n")), ec);
+            if (ec) {
+                result.error = "Could not query the printer: " + ec.message();
+                return result;
+            }
+            std::string m115_err;
+            if (!stream_until_ok(serial, io, 10'000, 10'000, nullptr,
+                    [&](const std::string& line) {
+                        BOOST_LOG_TRIVIAL(debug) << "[Maintenance] M115 << " << line;
+                        m115_lines.push_back(line);
+                    }, m115_err)) {
+                result.error = "The printer did not answer M115 (" + m115_err
+                             + "). Cannot confirm it is an INDX, so nothing was sent.";
+                return result;
+            }
+            const std::string machine_type = machine_type_from_m115(m115_lines);
+            if (machine_type.empty()) {
+                result.error = "The printer did not report a model in M115. "
+                               "Cannot confirm it is an INDX, so nothing was sent.";
+                return result;
+            }
+            if (!machine_type_is_indx(machine_type)) {
+                result.error = "Connected printer reports \"" + machine_type
+                             + "\", which is not an INDX. This procedure sends "
+                               "INDX-specific tool-change, temperature and motor-current "
+                               "commands and must not run on another model. Nothing was sent.";
+                return result;
+            }
+            BOOST_LOG_TRIVIAL(info) << "[Maintenance] confirmed INDX: " << machine_type;
+        }
+
         // Send one command and stream to "ok". `stage` drives the progress
         // dialog and `detail` describes the step in plain language. The caption
         // is emitted ONCE and then left alone: firmware chatter (temperature
@@ -413,8 +483,10 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
         // Best-effort state restore for the cooperative-cancel path. Short
         // timeouts, errors ignored: if an M0 dialog is still up on the printer
         // these queue behind it and execute once the user presses the knob.
+        // Reached from both the cancel path and any command failure, so the
+        // caption must not say "cancelling".
         auto restore_printer_state = [&]() {
-            emit("Cancelling", "Restoring printer state");
+            emit("Restoring", "Putting the printer back to a safe state");
             const char* cleanup[] = {
                 "M104 S0",   // heater off
                 "M107",      // fan off
@@ -601,8 +673,17 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
                 return result;
             }
             if (!run(s.stage, s.cmd, s.detail, s.overall, kIdle)) {
-                // On cooperative cancel mid-stream, still restore state.
-                if (result.cancelled && !is_force_stop())
+                // Any failure past this point can leave the printer hot with
+                // its guards down -- a heating timeout is the obvious case:
+                // nozzle still targeting the flush temperature, cold extrusion
+                // permitted and stuck-filament detection off. Attempt cleanup
+                // for every failure except a force stop, where M112 has already
+                // halted the machine and further commands are pointless.
+                //
+                // Best-effort by design: if the port itself died the writes
+                // simply fail and we fall through to reporting the original
+                // error, which is the one worth showing the user.
+                if (!is_force_stop())
                     restore_printer_state();
                 return result;
             }

--- a/src/slic3r/Utils/MaintenanceSerial.cpp
+++ b/src/slic3r/Utils/MaintenanceSerial.cpp
@@ -179,6 +179,11 @@ static void drain_serial(Serial& serial, asio::io_context& io)
     (void)done;
 }
 
+std::string detect_printer_port()
+{
+    return pick_prusa_port();
+}
+
 // ---------------------------------------------------------------------------
 // Cold pull as a standalone G-code file (print-job delivery)
 // ---------------------------------------------------------------------------

--- a/src/slic3r/Utils/MaintenanceSerial.cpp
+++ b/src/slic3r/Utils/MaintenanceSerial.cpp
@@ -264,8 +264,7 @@ std::string generate_cold_pull_gcode(const ColdPullOptions& options)
       << "; refuse this file unless it is a CORE One INDX. The sequence sends\n"
       << "; toolchanger picks, high nozzle temperatures and INDX motor\n"
       << "; currents, which are wrong and potentially damaging on an MK4, XL\n"
-      << "; or MINI. On a CORE One L INDX, change COREONEINDX to COREONEL-INDX.\n"
-      << "; Do not delete the line.\n"
+      << "; or MINI. Do not delete the line.\n"
       << "; ============================================================\n\n";
 
     // Standard Prusa model gate: on a mismatch the firmware sets
@@ -294,10 +293,18 @@ std::string generate_cold_pull_gcode(const ColdPullOptions& options)
     }
     g << "\n";
 
-    g << "M0 Tip check. PLA out: press knob to continue. NOTHING out: press knob then Stop print\n"
+    // The recovery instruction has to live IN the prompt. Someone standing at
+    // the printer following this cannot see the file header, and stopping here
+    // skips the M591 R / M302 S170 restore block at the end -- leaving the
+    // machine with stuck-filament detection and the cold-extrusion guard off.
+    // A power cycle restores both (M302 is RAM-only; M591 without P is
+    // re-applied from EEPROM at boot), so it is the one action that fits.
+    g << "M0 Tip check. PLA out: press knob. NOTHING out: press knob, Stop print, power cycle\n"
       << "G4 S15                ; grace window to reach Stop before packing starts\n"
       << "; If nothing extruded, the blockage is above the melt zone and a\n"
-      << "; cold pull cannot reach it.\n\n";
+      << "; cold pull cannot reach it. Power-cycling after the Stop restores the\n"
+      << "; cold-extrusion guard and stuck-filament detection that this file\n"
+      << "; disabled; the restore block at the end never runs in that case.\n\n";
 
     g << "M117 Cooling - packing\n"
       << "M109 S" << flush << "             ; prompts are unbounded - the safety timer may have\n"

--- a/src/slic3r/Utils/MaintenanceSerial.cpp
+++ b/src/slic3r/Utils/MaintenanceSerial.cpp
@@ -596,6 +596,16 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
             };
             bool all_confirmed = true;
             for (const char* cmd : cleanup) {
+                // Escalation must work FROM here. Cleanup can block behind an
+                // M0 prompt the user never answers, which is precisely when
+                // they reach for Force Stop -- so poll the flag between
+                // commands and hand it to the wait below. Leaving that wait
+                // uninterruptible made the emergency stop useless exactly when
+                // the printer was most likely to still be hot.
+                if (is_force_stop()) {
+                    send_emergency_stop();
+                    return; // restore_verified stays false: cleanup is incomplete
+                }
                 error_code ec;
                 asio::write(serial, asio::buffer(std::string(cmd) + "\n"), ec);
                 if (ec) {
@@ -605,8 +615,15 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
                     break; // port gone; the rest cannot land either
                 }
                 std::string cleanup_err;
-                if (!stream_until_ok(serial, io, 5'000, 5'000, nullptr,
+                // Pass the force-stop flag (NOT the combined cancel: we are
+                // already cancelling, and cooperative cancel must not abort
+                // the very cleanup it asked for).
+                if (!stream_until_ok(serial, io, 5'000, 5'000, options.force_stop_requested,
                                      [](const std::string&) {}, cleanup_err)) {
+                    if (is_force_stop()) {
+                        send_emergency_stop();
+                        return; // restore_verified stays false
+                    }
                     BOOST_LOG_TRIVIAL(warning)
                         << "[Maintenance] cleanup unacknowledged (" << cmd << "): " << cleanup_err;
                     all_confirmed = false;

--- a/src/slic3r/Utils/MaintenanceSerial.cpp
+++ b/src/slic3r/Utils/MaintenanceSerial.cpp
@@ -245,8 +245,21 @@ std::string generate_cold_pull_gcode(const ColdPullOptions& options)
       << "; If you Stop at the tip check, the restore block never runs -\n"
       << "; afterwards send M302 S170 and M591 R, or power-cycle, to put\n"
       << "; back the cold-extrusion guard and stuck-filament detection.\n"
-      << "; A prompt left ~30 min turns the heaters off (safety timer).\n"
+      << "; A prompt left ~30 min turns the heaters off (safety timer); the\n"
+      << "; procedure re-asserts temperature after each prompt to cover that.\n"
+      << "; ------------------------------------------------------------\n"
+      << "; PRINTER MODEL CHECK: the M862.3 line below makes the printer\n"
+      << "; refuse this file unless it is a CORE One INDX. The sequence sends\n"
+      << "; toolchanger picks, high nozzle temperatures and INDX motor\n"
+      << "; currents, which are wrong and potentially damaging on an MK4, XL\n"
+      << "; or MINI. On a CORE One L INDX, change COREONEINDX to COREONEL-INDX.\n"
+      << "; Do not delete the line.\n"
       << "; ============================================================\n\n";
+
+    // Standard Prusa model gate: on a mismatch the firmware sets
+    // Check::printer_model and print preview refuses the job
+    // (src/common/gcode/gcode_info.cpp:273-292).
+    g << "M862.3 P\"COREONEINDX\"   ; refuse to run on a non-INDX printer\n\n";
 
     g << "M117 Cold pull - guided\n"
       << "M0 Setup check: filament sensor OFF, auto retract OFF, PTFE tube removed. Press to continue\n\n";
@@ -275,6 +288,8 @@ std::string generate_cold_pull_gcode(const ColdPullOptions& options)
       << "; cold pull cannot reach it.\n\n";
 
     g << "M117 Cooling - packing\n"
+      << "M109 S" << flush << "             ; prompts are unbounded - the safety timer may have\n"
+      << "                      ; cleared the target, so re-assert before packing\n"
       << "M104 S180             ; fall toward 180, packing pushes on the way\n";
     for (int i = 0; i < 8; ++i) {
         g << "G1 E2 F60\n";
@@ -298,6 +313,8 @@ std::string generate_cold_pull_gcode(const ColdPullOptions& options)
       << "C. Motor will yank the plug - keep hands clear. Press to pull\n\n";
 
     g << "M117 PULLING\n"
+      << "M104 S" << pull << "              ; re-assert: yanking at high current against a\n"
+      << "M109 R" << pull << "              ; room-temperature plug can snap it or strain the drive\n"
       << "M906 E650             ; E current up for the stiff plug\n"
       << "G1 E-40 F3000         ; 50mm/s yank\n"
       << "G1 E-30 F1200         ; feed the strand up out of the gear\n"
@@ -402,7 +419,12 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
         auto send_emergency_stop = [&]() {
             error_code ec;
             asio::write(serial, asio::buffer(std::string("M112\n")), ec);
-            BOOST_LOG_TRIVIAL(warning) << "[Maintenance] >> M112 (force stop)";
+            // Only claim the stop if the bytes actually went out; a disconnect
+            // here is exactly the case where the nozzle may still be hot and
+            // the user must not be told otherwise.
+            result.force_stopped = !ec;
+            BOOST_LOG_TRIVIAL(warning) << "[Maintenance] >> M112 (force stop), delivered="
+                                       << (!ec ? "yes" : "no");
         };
 
         // --- MODEL GATE. Port auto-detection matches any Prusa printer, so a
@@ -606,6 +628,11 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
               // can restore printer state on cancel, unlike the print-job flow.
               "M0 Tip check. PLA out: press knob to continue. NOTHING out: press knob then cancel in slicer",
               "Check the nozzle tip, then answer the prompt on the printer",               kPrompt },
+            // Prompts are user-paced and unbounded. Past the firmware's ~30 min
+            // safety timer the heater target is cleared, so the temperature
+            // before the prompt cannot be assumed to have survived it. Re-assert
+            // and wait; a no-op when the nozzle is still at target.
+            { "Packing",      "M109 S" + flush, "Confirming nozzle is still at temperature", kHeat },
             { "Packing",      "M104 S180",   "Cooling toward 180 C while packing",         kQuick },
             { "Packing",      re_pick,       "Confirming nozzle is picked",                kPick  },
             { "Packing",      "G1 E2 F60",   "Packing the melt zone (1 of 8)",             kMove  },
@@ -634,6 +661,12 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
             { "Waiting at printer",
               "M0 Pull ready at " + pull + "C. Motor will yank the plug - keep hands clear. Press to pull",
               "Keep hands clear, then press the knob to pull",                             kPrompt },
+            // Same unbounded-wait hazard, and worse here: yanking at high motor
+            // current against a plug that has cooled to room temperature can
+            // snap the filament or strain the drive. Re-establish the pull
+            // temperature before committing to the pull.
+            { "Pulling",      "M104 S" + pull,  "Restoring pull temperature",              kQuick },
+            { "Pulling",      "M109 R" + pull,  "Confirming pull temperature",             kHeat  },
             // Re-assert the tool after the long cool/reheat waits, which are
             // the likeliest window for an unnoticed dock.
             { "Pulling",      re_pick,          "Confirming nozzle is picked",             kPick  },

--- a/src/slic3r/Utils/MaintenanceSerial.cpp
+++ b/src/slic3r/Utils/MaintenanceSerial.cpp
@@ -63,16 +63,28 @@ static std::string explain_serial_error(const std::string& port, const std::stri
     return "Serial error on " + port + ": " + what;
 }
 
-static std::string pick_prusa_port()
+// All plausible Prusa printer ports, best candidates first. Returning every
+// candidate (rather than just the first) lets the caller probe each for an
+// INDX -- with two Prusa printers attached, the first enumerated one may well
+// be the MK4 the user did not mean.
+static std::vector<std::string> prusa_port_candidates()
 {
     auto ports = scan_serial_ports_extended();
+    std::vector<std::string> out;
     for (const auto& p : ports)
         if (p.is_printer)
-            return p.port;
+            out.push_back(p.port);
     for (const auto& p : ports)
-        if (p.id_vendor == 0x2C99) // Prusa Research USB VID
-            return p.port;
-    return {};
+        if (p.id_vendor == 0x2C99 // Prusa Research USB VID
+            && std::find(out.begin(), out.end(), p.port) == out.end())
+            out.push_back(p.port);
+    return out;
+}
+
+static std::string pick_prusa_port()
+{
+    const auto candidates = prusa_port_candidates();
+    return candidates.empty() ? std::string{} : candidates.front();
 }
 
 // Long-running read: streams lines, calls line_cb per non-empty line, honors
@@ -344,11 +356,69 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
 {
     MaintenanceResult result;
 
-    std::string port = options.explicit_port.empty() ? pick_prusa_port()
-                                                     : options.explicit_port;
-    if (port.empty()) {
+    // Find the INDX among however many Prusa printers are attached. Probing
+    // only the first enumerated port would abort with "not an INDX" whenever
+    // an MK4 happens to enumerate ahead of the INDX the user meant, and there
+    // is no port picker in the UI to work around that.
+    //
+    // An explicit port is honoured as-is (still model-checked below) so the
+    // PRUSASLICER_MAINTENANCE_PORT override stays authoritative.
+    std::vector<std::string> candidates;
+    if (!options.explicit_port.empty())
+        candidates.push_back(options.explicit_port);
+    else
+        candidates = prusa_port_candidates();
+
+    if (candidates.empty()) {
         result.error = "No Prusa printer found on USB serial. "
                        "Make sure it is connected and not busy with another app.";
+        return result;
+    }
+
+    std::string port;
+    std::vector<std::string> rejected; // "port (MODEL)" for the error message
+    for (const auto& candidate : candidates) {
+        try {
+            asio::io_context probe_io;
+            Serial probe(probe_io, candidate, 115200);
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+            drain_serial(probe, probe_io);
+
+            std::vector<std::string> lines;
+            error_code ec;
+            asio::write(probe, asio::buffer(std::string("M115\n")), ec);
+            if (ec) {
+                rejected.push_back(candidate + " (no response)");
+                continue;
+            }
+            std::string probe_err;
+            if (!stream_until_ok(probe, probe_io, 10'000, 10'000, nullptr,
+                    [&](const std::string& line) { lines.push_back(line); }, probe_err)) {
+                rejected.push_back(candidate + " (no response)");
+                continue;
+            }
+            const std::string machine_type = machine_type_from_m115(lines);
+            if (machine_type_is_indx(machine_type)) {
+                port = candidate;
+                BOOST_LOG_TRIVIAL(info) << "[Maintenance] INDX found on " << candidate
+                                        << " (" << machine_type << ")";
+                break;
+            }
+            rejected.push_back(candidate + " ("
+                               + (machine_type.empty() ? "unknown model" : machine_type) + ")");
+        } catch (const std::exception& e) {
+            rejected.push_back(candidate + " (" + e.what() + ")");
+        }
+    }
+
+    if (port.empty()) {
+        std::string detail;
+        for (const auto& r : rejected)
+            detail += (detail.empty() ? "" : ", ") + r;
+        result.error = "No INDX printer found on USB serial. This procedure sends "
+                       "INDX-specific tool-change, temperature and motor-current "
+                       "commands and must not run on another model. Nothing was sent."
+                     + (detail.empty() ? std::string{} : " Checked: " + detail + ".");
         return result;
     }
     result.port_used = port;
@@ -507,8 +577,15 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
         // these queue behind it and execute once the user presses the knob.
         // Reached from both the cancel path and any command failure, so the
         // caption must not say "cancelling".
+        //
+        // Every command here is safety-critical, so success is TRACKED rather
+        // than assumed: a dead port or a timeout mid-cleanup can leave the
+        // nozzle hot with cold extrusion permitted and stall detection off.
+        // Reporting "state restored" in that situation would be a lie the user
+        // could get burned by, so restore_verified gates the UI message.
         auto restore_printer_state = [&]() {
             emit("Restoring", "Putting the printer back to a safe state");
+            result.restore_attempted = true;
             const char* cleanup[] = {
                 "M104 S0",   // heater off
                 "M107",      // fan off
@@ -517,15 +594,27 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
                 "M906 E550", // restore INDX default E current
                 "M84",       // release steppers
             };
+            bool all_confirmed = true;
             for (const char* cmd : cleanup) {
                 error_code ec;
                 asio::write(serial, asio::buffer(std::string(cmd) + "\n"), ec);
-                if (ec) return; // port gone; nothing more we can do
-                std::string ignore_err;
-                std::vector<std::string> sink;
-                (void)stream_until_ok(serial, io, 5'000, 5'000, nullptr,
-                                      [](const std::string&) {}, ignore_err);
+                if (ec) {
+                    BOOST_LOG_TRIVIAL(warning)
+                        << "[Maintenance] cleanup write failed (" << cmd << "): " << ec.message();
+                    all_confirmed = false;
+                    break; // port gone; the rest cannot land either
+                }
+                std::string cleanup_err;
+                if (!stream_until_ok(serial, io, 5'000, 5'000, nullptr,
+                                     [](const std::string&) {}, cleanup_err)) {
+                    BOOST_LOG_TRIVIAL(warning)
+                        << "[Maintenance] cleanup unacknowledged (" << cmd << "): " << cleanup_err;
+                    all_confirmed = false;
+                    // Keep going: a later command may still land, and each one
+                    // that does leaves the printer safer than stopping here.
+                }
             }
+            result.restore_verified = all_confirmed;
         };
 
         // Timeout tiers. M0 prompt waits are user-paced: Buddy emits

--- a/src/slic3r/Utils/MaintenanceSerial.cpp
+++ b/src/slic3r/Utils/MaintenanceSerial.cpp
@@ -1,0 +1,616 @@
+///|/ Copyright (c) 2026
+///|/
+///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
+///|/
+#include "MaintenanceSerial.hpp"
+#include "Serial.hpp"
+
+#include <boost/asio.hpp>
+#include <boost/asio/deadline_timer.hpp>
+#include <boost/log/trivial.hpp>
+
+#include <algorithm>
+#include <cctype>
+#include <chrono>
+#include <cstring>
+#include <thread>
+#include <vector>
+
+// The cold-pull recipe below was verified line-by-line against
+// Prusa-Firmware-Buddy v6.6.3 (COREONE_INDX):
+//  - Heating requires a picked/latched tool (base_hotend.cpp:50) → T<n> first.
+//  - G1 E below EXTRUDE_MINTEMP 170 is silently stripped unless M302 S0
+//    (planner.cpp:2280).
+//  - M0 = QuickPause dialog on the printer LCD with a custom message; it holds
+//    only the gcode queue, tool stays picked+heated (marlin_stubs/M0.cpp).
+//    Messages: whole line ≤95 chars (MAX_CMD_SIZE 96), first token a plain
+//    word, no semicolons (parser string_arg fallback).
+//  - M109 R regulates AT the target and can exit early when the cooling slope
+//    flattens (<1.5 °C/min) → follow with M104 S0 + fixed dwell.
+//  - The pull retract cannot unlock the nozzle away from the dock; the lock is
+//    mechanical and dock-gated (toolchanger_indx.cpp:525-575).
+//  - Firmware E current default is 550 mA; 650 is what the firmware itself
+//    uses for lock moves, safe for the stiff-plug pull (M906).
+
+namespace Slic3r {
+namespace Utils {
+
+namespace asio = boost::asio;
+using boost::system::error_code;
+
+// ---------------------------------------------------------------------------
+// Transport helpers. These mirror the file-static helpers in BedMeshSerial.cpp
+// (deliberately self-contained, same as that feature, so neither depends on
+// the other's internals).
+// ---------------------------------------------------------------------------
+
+static std::string explain_serial_error(const std::string& port, const std::string& what)
+{
+    std::string lower = what;
+    std::transform(lower.begin(), lower.end(), lower.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    if (lower.find("permission denied") != std::string::npos ||
+        lower.find("access is denied")  != std::string::npos)
+        return "Port " + port + " is in use by another application "
+               "(OctoPrint, Pronterface, PrusaConnect, or another slicer).";
+    if (lower.find("resource busy")     != std::string::npos ||
+        lower.find("device or resource busy") != std::string::npos)
+        return "Port " + port + " is busy. Close any other application that "
+               "might be connected to the printer and try again.";
+    if (lower.find("no such file")      != std::string::npos ||
+        lower.find("no such device")    != std::string::npos)
+        return "Port " + port + " disappeared. Is the printer still plugged in?";
+    return "Serial error on " + port + ": " + what;
+}
+
+static std::string pick_prusa_port()
+{
+    auto ports = scan_serial_ports_extended();
+    for (const auto& p : ports)
+        if (p.is_printer)
+            return p.port;
+    for (const auto& p : ports)
+        if (p.id_vendor == 0x2C99) // Prusa Research USB VID
+            return p.port;
+    return {};
+}
+
+// Long-running read: streams lines, calls line_cb per non-empty line, honors
+// an overall deadline, an idle timeout (since last byte), and a cancel flag.
+// Returns true iff an "ok" line was received. Identical in behaviour to
+// BedMeshSerial's stream_until_ok.
+static bool stream_until_ok(Serial& serial,
+                            asio::io_context& io,
+                            unsigned overall_timeout_ms,
+                            unsigned idle_timeout_ms,
+                            std::atomic<bool>* cancel_requested,
+                            const std::function<void(const std::string&)>& line_cb,
+                            std::string& error)
+{
+    asio::deadline_timer timer(io);
+    std::string buffer;
+    bool saw_ok = false;
+    char ch = 0;
+
+    const auto start  = std::chrono::steady_clock::now();
+    auto last_byte_at = start;
+
+    while (!saw_ok) {
+        if (cancel_requested && cancel_requested->load()) {
+            error = "Cancelled";
+            return false;
+        }
+        const auto now = std::chrono::steady_clock::now();
+        const long overall_left = overall_timeout_ms -
+            std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count();
+        const long idle_left = idle_timeout_ms -
+            std::chrono::duration_cast<std::chrono::milliseconds>(now - last_byte_at).count();
+        if (overall_left <= 0) { error = "Overall timeout elapsed"; return false; }
+        if (idle_left    <= 0) { error = "Idle timeout (no firmware output)"; return false; }
+
+        const long slice_ms = std::min({ overall_left, idle_left, 500L });
+
+        io.restart();
+        bool read_done = false;
+        bool timed_out = false;
+        error_code  read_ec;
+
+        asio::async_read(serial, asio::buffer(&ch, 1),
+            [&](const error_code& ec, size_t) {
+                read_ec = ec;
+                read_done = true;
+                timer.cancel();
+            });
+        timer.expires_from_now(boost::posix_time::milliseconds(slice_ms));
+        timer.async_wait([&](const error_code& ec) {
+            if (!ec) { timed_out = true; serial.cancel(); }
+        });
+        io.run();
+
+        if (timed_out)
+            continue;
+
+        if (!read_done || read_ec) {
+            error = std::string("Serial read error")
+                  + (read_ec ? std::string(": ") + read_ec.message() : std::string());
+            return false;
+        }
+
+        last_byte_at = std::chrono::steady_clock::now();
+
+        if (ch == '\r')
+            continue;
+        if (ch == '\n') {
+            if (buffer == "ok") {
+                saw_ok = true;
+                break;
+            }
+            if (!buffer.empty() && line_cb)
+                line_cb(buffer);
+            buffer.clear();
+        } else {
+            buffer.push_back(ch);
+        }
+    }
+    return saw_ok;
+}
+
+// Drain unsolicited output buffered on the CDC endpoint (temperature reports,
+// remnants of an aborted command) so the first stream doesn't see stale bytes.
+static void drain_serial(Serial& serial, asio::io_context& io)
+{
+    char buf[1024];
+    asio::deadline_timer t(io);
+    bool done = false;
+    io.restart();
+    asio::async_read(serial, asio::buffer(buf, sizeof(buf)),
+        asio::transfer_at_least(1),
+        [&](const error_code&, std::size_t n) {
+            if (n > 0)
+                BOOST_LOG_TRIVIAL(debug) << "[Maintenance] drained " << n << " bytes";
+            done = true;
+            t.cancel();
+        });
+    t.expires_from_now(boost::posix_time::milliseconds(250));
+    t.async_wait([&](const error_code& tec) {
+        if (!tec) { serial.cancel(); done = true; }
+    });
+    io.run();
+    (void)done;
+}
+
+// ---------------------------------------------------------------------------
+// Cold pull as a standalone G-code file (print-job delivery)
+// ---------------------------------------------------------------------------
+
+std::string generate_cold_pull_gcode(const ColdPullOptions& options)
+{
+    const std::string tool  = std::to_string(options.tool);
+    const std::string flush = std::to_string(options.flush_temp_c);
+    const std::string pull  = std::to_string(options.pull_temp_c);
+    // Nozzle number as printed on the machine, for human-facing text only.
+    const std::string nozzle = std::to_string(options.tool + 1);
+
+    std::ostringstream g;
+
+    g << "; ============================================================\n"
+      << "; INDX cold pull - guided, with on-screen prompts\n"
+      << "; Generated by PrusaSlicer. Nozzle " << nozzle
+      << ", flush " << flush << "C, pull " << pull << "C\n"
+      << "; ------------------------------------------------------------\n"
+      << "; BEFORE RUNNING, at the printer:\n"
+      << ";   - Settings: turn the Filament Sensor OFF\n"
+      << ";   - Settings: turn Auto Retract OFF\n"
+      << ";   - Remove the PTFE tube from this tool\n"
+      << ";   - Have light-colored PLA ready and stay at the printer\n"
+      << "; ------------------------------------------------------------\n"
+      << "; The procedure stops at several prompts and waits for a knob\n"
+      << "; press. To bail out, press the knob then Stop the print.\n"
+      << "; If you Stop at the tip check, the restore block never runs -\n"
+      << "; afterwards send M302 S170 and M591 R, or power-cycle, to put\n"
+      << "; back the cold-extrusion guard and stuck-filament detection.\n"
+      << "; A prompt left ~30 min turns the heaters off (safety timer).\n"
+      << "; ============================================================\n\n";
+
+    g << "M117 Cold pull - guided\n"
+      << "M0 Setup check: filament sensor OFF, auto retract OFF, PTFE tube removed. Press to continue\n\n";
+
+    g << "M117 Picking nozzle " << nozzle << "\n"
+      << "T" << tool << " M0                 ; M0 param = ignore tool mapping\n"
+      << "M302 S0               ; allow cold extrusion for the session\n"
+      << "M83                   ; relative E\n"
+      << "M591 S0               ; disable stuck-filament detection\n\n";
+
+    g << "M0 Insert light PLA into the top port until it stops at the drive gears. Do not force it\n\n";
+
+    g << "M117 Heating to " << flush << "\n"
+      << "M109 S" << flush << "\n\n";
+
+    g << "M117 Purging - watch the tip\n";
+    for (int i = 0; i < 3; ++i) {
+        g << "G1 E20 F120\n";
+        if (i < 2) g << "G4 S2\n";
+    }
+    g << "\n";
+
+    g << "M0 Tip check. PLA out: press knob to continue. NOTHING out: press knob then Stop print\n"
+      << "G4 S15                ; grace window to reach Stop before packing starts\n"
+      << "; If nothing extruded, the blockage is above the melt zone and a\n"
+      << "; cold pull cannot reach it.\n\n";
+
+    g << "M117 Cooling - packing\n"
+      << "M104 S180             ; fall toward 180, packing pushes on the way\n";
+    for (int i = 0; i < 8; ++i) {
+        g << "G1 E2 F60\n";
+        if (i < 7) g << "G4 S5\n";
+    }
+    g << "\n";
+
+    g << "M117 Deep cooling to 60\n"
+      << "M104 S0\n"
+      << "M106 S255             ; fan full\n"
+      << "M109 R60              ; regulates AT 60; may exit early on slope-break\n"
+      << "M104 S0               ; heater truly off\n"
+      << "G4 S120               ; dwell covers an early exit above 60\n"
+      << "M107\n\n";
+
+    g << "M117 Reheating to " << pull << "\n"
+      << "M104 S" << pull << "\n"
+      << "M109 R" << pull << "\n\n";
+
+    g << "M0 Pull ready at " << pull
+      << "C. Motor will yank the plug - keep hands clear. Press to pull\n\n";
+
+    g << "M117 PULLING\n"
+      << "M906 E650             ; E current up for the stiff plug\n"
+      << "G1 E-40 F3000         ; 50mm/s yank\n"
+      << "G1 E-30 F1200         ; feed the strand up out of the gear\n"
+      << "M906 E550             ; restore INDX default current\n"
+      << "M591 R                ; restore stuck-filament detection\n"
+      << "M302 S170             ; restore cold-extrusion guard\n"
+      << "M104 S0\n\n";
+
+    g << "M0 Pull done. Remove strand from top port. Pressing knob starts auto wipe and dock\n\n";
+
+    g << "M117 Finishing - hands off\n"
+      << "; The end-of-print sequence runs automatically after the last line:\n"
+      << "; nozzle wipe, tool dock, steppers off. Wait for Finished.\n"
+      << "; Inspect the tip: three thin strands + debris = a good pull.\n"
+      << "; Repeat until the tip comes out clean, then re-enable the\n"
+      << "; Filament Sensor and Auto Retract and refit the PTFE tube.\n";
+
+    return g.str();
+}
+
+// ---------------------------------------------------------------------------
+// Cold pull over serial
+// ---------------------------------------------------------------------------
+
+MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
+                                const ColdPullOptions& options)
+{
+    MaintenanceResult result;
+
+    std::string port = options.explicit_port.empty() ? pick_prusa_port()
+                                                     : options.explicit_port;
+    if (port.empty()) {
+        result.error = "No Prusa printer found on USB serial. "
+                       "Make sure it is connected and not busy with another app.";
+        return result;
+    }
+    result.port_used = port;
+
+    // Combined cancel flag fed by a watchdog, same pattern as the bed probe:
+    // stream_until_ok keeps its single-atomic API while we honor both flags.
+    std::atomic<bool> combined_cancel{ false };
+    std::atomic<bool> watchdog_stop { false };
+    std::thread watchdog([&]() {
+        while (!watchdog_stop.load()) {
+            if (options.cancel_requested && options.cancel_requested->load())
+                combined_cancel.store(true);
+            if (options.force_stop_requested && options.force_stop_requested->load())
+                combined_cancel.store(true);
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+    });
+    struct WatchdogJoiner {
+        std::atomic<bool>& stop; std::thread& t;
+        ~WatchdogJoiner() { stop.store(true); if (t.joinable()) t.join(); }
+    } joiner{ watchdog_stop, watchdog };
+
+    auto is_force_stop = [&]() {
+        return options.force_stop_requested && options.force_stop_requested->load();
+    };
+    auto is_cancel = [&]() {
+        return combined_cancel.load();
+    };
+
+    // Strip firmware chatter prefixes for display.
+    auto clean = [](std::string s) {
+        auto starts_with = [&](const char* p) {
+            return s.compare(0, std::strlen(p), p) == 0;
+        };
+        while (!s.empty() && (s.front() == ' ' || s.front() == '\t'))
+            s.erase(s.begin());
+        if (starts_with("echo:")) s.erase(0, 5);
+        else if (starts_with("// ")) s.erase(0, 3);
+        else if (starts_with("//"))  s.erase(0, 2);
+        while (!s.empty() && (s.front() == ' ' || s.front() == '\t'))
+            s.erase(s.begin());
+        return s;
+    };
+
+    // The procedure has a fixed step list; progress is slicer-driven (we know
+    // which command we're on), with firmware temperature lines as detail.
+    int step = 0;
+    constexpr int kTotalSteps = 12;
+    auto emit = [&](const char* stage, const std::string& detail = {}) {
+        if (progress) {
+            MaintenanceProgress p;
+            p.stage = stage;
+            p.detail = clean(detail);
+            p.step = step;
+            p.total_steps = kTotalSteps;
+            progress(p);
+        }
+    };
+
+    try {
+        asio::io_context io;
+        Serial serial(io, port, 115200);
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        drain_serial(serial, io);
+
+        std::string err;
+
+        auto send_emergency_stop = [&]() {
+            error_code ec;
+            asio::write(serial, asio::buffer(std::string("M112\n")), ec);
+            BOOST_LOG_TRIVIAL(warning) << "[Maintenance] >> M112 (force stop)";
+        };
+
+        // Send one command and stream to "ok". `stage` drives the progress
+        // dialog and `detail` describes the step in plain language. The caption
+        // is emitted ONCE and then left alone: firmware chatter (temperature
+        // reports and the like) goes to the debug log only, so the dialog shows
+        // one stable line instead of a churning wall of text.
+        auto run = [&](const char* stage, const std::string& cmd,
+                       const char* detail,
+                       unsigned overall_ms, unsigned idle_ms) -> bool {
+            emit(stage, detail);
+            error_code ec;
+            asio::write(serial, asio::buffer(cmd + "\n"), ec);
+            if (ec) {
+                result.error = "Write failed (" + cmd + "): " + ec.message();
+                return false;
+            }
+            BOOST_LOG_TRIVIAL(debug) << "[Maintenance] >> " << cmd;
+            if (!stream_until_ok(serial, io, overall_ms, idle_ms, &combined_cancel,
+                    [&](const std::string& line) {
+                        BOOST_LOG_TRIVIAL(debug) << "[Maintenance] << " << line;
+                    }, err)) {
+                if (is_force_stop()) {
+                    send_emergency_stop();
+                    result.error = "Force-stopped by user (printer requires reset).";
+                    return false;
+                }
+                if (is_cancel()) {
+                    result.cancelled = true;
+                    result.error = "Cancelled";
+                    return false;
+                }
+                result.error = std::string(stage) + " failed (" + cmd + "): " + err;
+                return false;
+            }
+            return true;
+        };
+
+        // Best-effort state restore for the cooperative-cancel path. Short
+        // timeouts, errors ignored: if an M0 dialog is still up on the printer
+        // these queue behind it and execute once the user presses the knob.
+        auto restore_printer_state = [&]() {
+            emit("Cancelling", "Restoring printer state");
+            const char* cleanup[] = {
+                "M104 S0",   // heater off
+                "M107",      // fan off
+                "M302 S170", // restore cold-extrusion guard
+                "M591 R",    // restore stuck-filament detection from EEPROM
+                "M906 E550", // restore INDX default E current
+                "M84",       // release steppers
+            };
+            for (const char* cmd : cleanup) {
+                error_code ec;
+                asio::write(serial, asio::buffer(std::string(cmd) + "\n"), ec);
+                if (ec) return; // port gone; nothing more we can do
+                std::string ignore_err;
+                std::vector<std::string> sink;
+                (void)stream_until_ok(serial, io, 5'000, 5'000, nullptr,
+                                      [](const std::string&) {}, ignore_err);
+            }
+        };
+
+        // Timeout tiers. M0 prompt waits are user-paced: Buddy emits
+        // "echo:busy:" keepalives while the dialog is up, so the idle timer
+        // keeps refreshing; the overall cap just bounds a walked-away session
+        // (the printer's own 30-min safety timer will have killed the heaters
+        // long before this expires).
+        constexpr unsigned kQuick   =    10'000; // parameter/setup commands
+        constexpr unsigned kMove    =    60'000; // short E moves, dwells
+        constexpr unsigned kPick    =   240'000; // T<n>: may home + travel
+        constexpr unsigned kHeat    =   900'000; // M109 heat-up
+        constexpr unsigned kCool    = 2'400'000; // M109 R deep-cool (fan-assisted)
+        constexpr unsigned kPrompt  = 7'200'000; // M0 user prompts (2 h)
+        constexpr unsigned kIdle    =    30'000; // per-byte idle cap everywhere
+
+        const std::string tool  = std::to_string(options.tool);
+        const std::string flush = std::to_string(options.flush_temp_c);
+        const std::string pull  = std::to_string(options.pull_temp_c);
+
+        // --- SERIAL-PRINT TIMEOUT DISARM. Read this before touching the
+        // command list below; it caused a BSOD ("E move without tool") on real
+        // hardware.
+        //
+        // Buddy treats any G-command (and M73/M74/M109/M190) arriving over
+        // serial as the start of an implicit "serial print"
+        // (serial_printing.cpp:56-99). The inactivity timestamp is stamped when
+        // that command is QUEUED, but the only thing that refreshes it,
+        // SerialPrinting::print_loop(), runs solely from State::Printing --
+        // which cannot be reached until the arming command finishes
+        // (marlin_server.cpp:2207-2210).
+        //
+        // So arming with a LONG-BLOCKING command (M109 heat-up, or a G1 E move
+        // that takes >5s) means the first timeout evaluation already sees the
+        // whole blocking duration elapsed, instantly exceeding the 5s
+        // serial_printing_screen_timeout (serial_printing.hpp:33). That runs
+        // serial_print_finalize() -> pre_finalize_print(): auto-retract, nozzle
+        // cleaner wipe, tool_change(NoTool) DOCK, disable_e_steppers. Every
+        // later E move then hits bsod("E move without tool") at
+        // planner.cpp:2177.
+        //
+        // Fix: arm with an INSTANT G-command first. G4 P1 (1 millisecond dwell)
+        // is print-indicating via the 'G' branch, completes immediately, and so
+        // lets the state reach Printing with a fresh timestamp. From then on the
+        // timer is refreshed continuously, because GCodeQueue::advance()
+        // decrements the queue length only AFTER process_next_command()
+        // returns -- so has_commands_queued() stays true for the whole of a
+        // blocking M109/M0/G4, and long user prompts are safe.
+        //
+        // Belt and braces: the pre-flight dialog also asks the user to turn off
+        // Settings > Hardware > Experimental Settings > "Serial Printing
+        // Screen", which stops serial_command_hook() from ever arming
+        // (serial_printing.cpp:91-93); and re_pick below re-asserts the tool
+        // before each extrusion block so a dock can never be followed by a
+        // naked E move.
+        const std::string arm_serial_print = "G4 P1";
+
+        // Re-assert the tool immediately before any block of E moves.
+        // tool_change repopulates tools.physical_tool, so even if something
+        // docked the tool behind our back the next E move cannot hit the
+        // assert. Idempotent when the tool is already picked.
+        const std::string re_pick = "T" + tool + " M0";
+
+        // --- The guided procedure. M0 messages: ≤95 chars, plain first word,
+        // --- no semicolons (Buddy parser + MAX_CMD_SIZE rules).
+        // `detail` is what the user reads in the progress dialog -- describe
+        // the intent, never echo the gcode. The raw command still goes to the
+        // debug log for diagnosis.
+        struct Step {
+            const char* stage;
+            std::string cmd;
+            const char* detail;
+            unsigned    overall;
+        };
+        const Step steps[] = {
+            { "Waiting at printer",
+              "M0 Setup check: filament sensor OFF, auto retract OFF, PTFE tube removed. Press to continue",
+              "Confirm the setup prompt on the printer screen", kPrompt },
+            // Arm the serial-print state machine with an instant G-command so
+            // it can never be armed later by a long-blocking one. See the
+            // SERIAL-PRINT TIMEOUT DISARM note above.
+            { "Preparing",    arm_serial_print, "Starting session",                        kQuick },
+            { "Picking tool", "T" + tool + " M0",
+              "Picking nozzle from its dock",                                              kPick  },
+            { "Preparing",    "M302 S0",  "Allowing cold extrusion",                       kQuick },
+            { "Preparing",    "M83",      "Switching to relative extrusion",               kQuick },
+            { "Preparing",    "M591 S0",  "Disabling stuck-filament detection",            kQuick },
+            { "Waiting at printer",
+              "M0 Insert light PLA into the top port until it stops at the drive gears. Do not force it",
+              "Insert filament at the printer, then press the knob",                       kPrompt },
+            { "Heating",      "M109 S" + flush,
+              "Heating nozzle to flush temperature",                                       kHeat  },
+            { "Purging",      re_pick,       "Confirming nozzle is picked",                kPick  },
+            { "Purging",      "G1 E20 F120", "Pushing filament through (1 of 3)",          kMove  },
+            { "Purging",      "G4 S2",       "Letting pressure settle",                    kMove  },
+            { "Purging",      "G1 E20 F120", "Pushing filament through (2 of 3)",          kMove  },
+            { "Purging",      "G4 S2",       "Letting pressure settle",                    kMove  },
+            { "Purging",      "G1 E20 F120", "Pushing filament through (3 of 3)",          kMove  },
+            { "Waiting at printer",
+              // The bail-out here is the slicer's Cancel button: over serial we
+              // can restore printer state on cancel, unlike the print-job flow.
+              "M0 Tip check. PLA out: press knob to continue. NOTHING out: press knob then cancel in slicer",
+              "Check the nozzle tip, then answer the prompt on the printer",               kPrompt },
+            { "Packing",      "M104 S180",   "Cooling toward 180 C while packing",         kQuick },
+            { "Packing",      re_pick,       "Confirming nozzle is picked",                kPick  },
+            { "Packing",      "G1 E2 F60",   "Packing the melt zone (1 of 8)",             kMove  },
+            { "Packing",      "G4 S5",       "Cooling 5 seconds",                          kMove  },
+            { "Packing",      "G1 E2 F60",   "Packing the melt zone (2 of 8)",             kMove  },
+            { "Packing",      "G4 S5",       "Cooling 5 seconds",                          kMove  },
+            { "Packing",      "G1 E2 F60",   "Packing the melt zone (3 of 8)",             kMove  },
+            { "Packing",      "G4 S5",       "Cooling 5 seconds",                          kMove  },
+            { "Packing",      "G1 E2 F60",   "Packing the melt zone (4 of 8)",             kMove  },
+            { "Packing",      "G4 S5",       "Cooling 5 seconds",                          kMove  },
+            { "Packing",      "G1 E2 F60",   "Packing the melt zone (5 of 8)",             kMove  },
+            { "Packing",      "G4 S5",       "Cooling 5 seconds",                          kMove  },
+            { "Packing",      "G1 E2 F60",   "Packing the melt zone (6 of 8)",             kMove  },
+            { "Packing",      "G4 S5",       "Cooling 5 seconds",                          kMove  },
+            { "Packing",      "G1 E2 F60",   "Packing the melt zone (7 of 8)",             kMove  },
+            { "Packing",      "G4 S5",       "Cooling 5 seconds",                          kMove  },
+            { "Packing",      "G1 E2 F60",   "Packing the melt zone (8 of 8)",             kMove  },
+            { "Deep cooling", "M104 S0",     "Turning the heater off",                     kQuick },
+            { "Deep cooling", "M106 S255",   "Fan to full",                                kQuick },
+            { "Deep cooling", "M109 R60",    "Cooling to 60 C",                            kCool  },
+            { "Deep cooling", "M104 S0",     "Turning the heater off",                     kQuick },
+            { "Deep cooling", "G4 S120",     "Holding 2 minutes to finish cooling",        180'000 },
+            { "Deep cooling", "M107",        "Fan off",                                    kQuick },
+            { "Reheating",    "M104 S" + pull, "Setting pull temperature",                 kQuick },
+            { "Reheating",    "M109 R" + pull, "Warming to pull temperature",              kHeat  },
+            { "Waiting at printer",
+              "M0 Pull ready at " + pull + "C. Motor will yank the plug - keep hands clear. Press to pull",
+              "Keep hands clear, then press the knob to pull",                             kPrompt },
+            // Re-assert the tool after the long cool/reheat waits, which are
+            // the likeliest window for an unnoticed dock.
+            { "Pulling",      re_pick,          "Confirming nozzle is picked",             kPick  },
+            { "Pulling",      "M906 E650",      "Raising extruder motor current",          kQuick },
+            { "Pulling",      "G1 E-40 F3000",  "Pulling the plug out",                    kMove  },
+            { "Pulling",      "G1 E-30 F1200",  "Feeding the strand up and out",           kMove  },
+            { "Restoring",    "M906 E550",      "Restoring motor current",                 kQuick },
+            { "Restoring",    "M591 R",         "Restoring stuck-filament detection",      kQuick },
+            { "Restoring",    "M302 S170",      "Restoring cold-extrusion guard",          kQuick },
+            { "Restoring",    "M104 S0",        "Turning the heater off",                  kQuick },
+            { "Waiting at printer",
+              // No end-of-print machinery runs over serial: the tool stays
+              // picked. Parking is a menu action on the printer.
+              "M0 Done. Remove the strand and inspect the tip. Park the tool via Control menu when ready",
+              "Remove the strand at the printer, then press the knob",                     kPrompt },
+            { "Finishing",    "M84",            "Releasing the motors",                    kQuick },
+        };
+
+        // Map command groups onto the coarse 12-step progress scale so the
+        // dialog advances meaningfully instead of once per G4.
+        const char* last_stage = "";
+        for (const Step& s : steps) {
+            if (std::strcmp(s.stage, last_stage) != 0) {
+                last_stage = s.stage;
+                if (step < kTotalSteps)
+                    ++step;
+            }
+            if (is_cancel()) {
+                if (is_force_stop()) {
+                    send_emergency_stop();
+                    result.error = "Force-stopped by user (printer requires reset).";
+                    return result;
+                }
+                restore_printer_state();
+                result.cancelled = true;
+                result.error = "Cancelled";
+                return result;
+            }
+            if (!run(s.stage, s.cmd, s.detail, s.overall, kIdle)) {
+                // On cooperative cancel mid-stream, still restore state.
+                if (result.cancelled && !is_force_stop())
+                    restore_printer_state();
+                return result;
+            }
+        }
+
+        step = kTotalSteps;
+        emit("Done", "Cold pull complete");
+        return result;
+    } catch (const std::exception& e) {
+        result.error = explain_serial_error(port, e.what());
+        return result;
+    }
+}
+
+} // namespace Utils
+} // namespace Slic3r

--- a/src/slic3r/Utils/MaintenanceSerial.hpp
+++ b/src/slic3r/Utils/MaintenanceSerial.hpp
@@ -1,0 +1,116 @@
+///|/ Copyright (c) 2026
+///|/
+///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
+///|/
+#ifndef slic3r_MaintenanceSerial_hpp_
+#define slic3r_MaintenanceSerial_hpp_
+
+#include <atomic>
+#include <functional>
+#include <string>
+
+namespace Slic3r {
+namespace Utils {
+
+// Progress update during a maintenance procedure. Called from the worker
+// thread, so the UI caller is responsible for marshalling to the main thread.
+// Mirrors BedMeshProbeProgress; kept separate so the two features stay
+// decoupled.
+struct MaintenanceProgress
+{
+    std::string stage;   // "Connecting", "Heating", "Purging", "Waiting at printer", ...
+    std::string detail;  // free text: "T:150/290", firmware line, prompt hint, etc.
+    int         step = 0;        // completed steps of the whole procedure
+    int         total_steps = 0; // total steps (fixed per procedure), 0 → pulse
+};
+
+using MaintenanceProgressCallback = std::function<void(const MaintenanceProgress&)>;
+
+struct MaintenanceResult
+{
+    std::string port_used; // the port we connected to, for logging
+    std::string error;     // empty on success, human-readable on failure
+    bool        cancelled = false; // true when the user cancelled cooperatively
+};
+
+// Options for the INDX cold-pull procedure. Defaults match the recipe verified
+// against Buddy v6.6.3 and Prusa support guidance (290 flush / 80 pull).
+struct ColdPullOptions
+{
+    // Physical dock index of the tool (nozzle) to clean, 0-based. Sent as
+    // "T<n> M0" (M0 parameter = bypass tool mapping).
+    int tool = 0;
+
+    // Flush temperature (°C, INDX displayed frame). Buddy clamps settable
+    // targets to 290 on Core One (HEATER_0_MAXTEMP 305 − 15 margin); values
+    // above that would make M109 wait forever, so the dialog caps at 290.
+    int flush_temp_c = 290;
+
+    // Pull temperature (°C). Working band 80–120; 80 is hardware-verified.
+    int pull_temp_c = 80;
+
+    // Explicit USB serial device path. Empty → auto-detect (Prusa VID).
+    std::string explicit_port;
+
+    // Cooperative cancel: polled between phases and honored inside long
+    // streams. On cancel the worker restores printer state (heaters off,
+    // cold-extrusion guard + stuck-filament detection + E current restored)
+    // before disconnecting — this is the supported mid-procedure bail-out,
+    // e.g. when the purge shows the blockage is above the melt zone.
+    std::atomic<bool>* cancel_requested = nullptr;
+
+    // Force stop: sends M112 (emergency stop) and disconnects. The printer
+    // needs a reset afterwards. Use only when cooperative cancel is stuck.
+    std::atomic<bool>* force_stop_requested = nullptr;
+};
+
+// Run the guided INDX cold-pull procedure over USB serial.
+//
+// The interaction prompts (insert filament, tip check, pull confirmation,
+// strand removal) are shown ON THE PRINTER's screen via M0 QuickPause
+// dialogs — the user must be at the machine and confirm each with a knob
+// press; the slicer-side progress dialog mirrors the current stage. Buddy
+// emits "echo:busy:" keepalives while an M0 dialog is up, so the serial
+// stream stays alive for however long the user takes (bounded by generous
+// overall timeouts below).
+//
+// Serial-session differences vs. running the same recipe as a USB print job
+// (both verified against Buddy v6.6.3):
+//  - No end-of-print machinery runs (no auto nozzle-wipe/dock): the procedure
+//    ends with heaters off, steppers disabled, and the tool still picked; the
+//    final prompt tells the user to park it from the printer's Control menu.
+//  - There is no tool-mapping layer; "T<n> M0" is belt-and-braces.
+//  - Print-time systems (runout-triggered pause, in-print nozzle checks) are
+//    inactive; the printer-side Settings prerequisites still apply and are
+//    re-checked by the first on-printer prompt: Filament Sensor OFF (blocks
+//    autoload while hand-inserting filament) and Auto Retract OFF.
+//
+// This is synchronous and typically takes 10–20 minutes end to end (dominated
+// by the deep-cool phase and user response time). Call from a worker thread.
+MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
+                                const ColdPullOptions& options = {});
+
+// Render the same cold-pull procedure as a standalone G-code file, to be run as
+// an ordinary print job from a USB drive or uploaded to the printer.
+//
+// This is the SAFER of the two delivery paths and the one to prefer. A print job
+// is driven by the media queue and managed by the normal print state machine, so
+// it is immune to the serial-print inactivity timeout that makes the streamed
+// variant fragile (see the SERIAL-PRINT TIMEOUT DISARM note in the .cpp).
+//
+// Differences from the streamed variant, all deliberate:
+//  - The bail-out at the tip check is the printer's own Stop, not a host-side
+//    Cancel, so the prompt says so. Stopping there skips the restore block --
+//    the header documents the two commands to run afterwards.
+//  - The end-of-print sequence DOES run when the job finishes (nozzle wipe,
+//    tool dock, steppers off), which is exactly what is wanted at the end, so
+//    the final prompt asks the user to clear the strand before it starts.
+//  - Every M0 message is kept within the 95-character command limit
+//    (MAX_CMD_SIZE 96) and starts with a plain word containing no semicolons,
+//    or the firmware crops it mid-sentence and raises a warning.
+std::string generate_cold_pull_gcode(const ColdPullOptions& options);
+
+} // namespace Utils
+} // namespace Slic3r
+
+#endif // slic3r_MaintenanceSerial_hpp_

--- a/src/slic3r/Utils/MaintenanceSerial.hpp
+++ b/src/slic3r/Utils/MaintenanceSerial.hpp
@@ -31,6 +31,12 @@ struct MaintenanceResult
     std::string port_used; // the port we connected to, for logging
     std::string error;     // empty on success, human-readable on failure
     bool        cancelled = false; // true when the user cancelled cooperatively
+
+    // True only when M112 was actually written to the port. Requesting a force
+    // stop is not the same as delivering one -- the worker can fail and exit
+    // while the user is still choosing -- and the UI must not claim an
+    // emergency stop that never reached the printer.
+    bool        force_stopped = false;
 };
 
 // Options for the INDX cold-pull procedure. Defaults match the recipe verified

--- a/src/slic3r/Utils/MaintenanceSerial.hpp
+++ b/src/slic3r/Utils/MaintenanceSerial.hpp
@@ -90,6 +90,15 @@ struct ColdPullOptions
 MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
                                 const ColdPullOptions& options = {});
 
+// Return the USB serial port of a connected Prusa printer, or an empty string
+// if none is found. Detection only enumerates ports (it does not open one), so
+// it is cheap enough to call while building a dialog.
+//
+// Note this reports that a printer is *plugged in*, not that it is idle or
+// willing to take commands -- a port held by another application still scans
+// as present and only fails when actually opened.
+std::string detect_printer_port();
+
 // Render the same cold-pull procedure as a standalone G-code file, to be run as
 // an ordinary print job from a USB drive or uploaded to the printer.
 //

--- a/src/slic3r/Utils/MaintenanceSerial.hpp
+++ b/src/slic3r/Utils/MaintenanceSerial.hpp
@@ -37,6 +37,14 @@ struct MaintenanceResult
     // while the user is still choosing -- and the UI must not claim an
     // emergency stop that never reached the printer.
     bool        force_stopped = false;
+
+    // Set when a cleanup pass ran. restore_verified is true only if EVERY
+    // safety-critical cleanup command was acknowledged by the printer. If the
+    // port died or a command timed out mid-cleanup the printer may still be
+    // hot with cold extrusion permitted, so the UI must say "check the
+    // printer" rather than "state restored".
+    bool        restore_attempted = false;
+    bool        restore_verified  = false;
 };
 
 // Options for the INDX cold-pull procedure. Defaults match the recipe verified


### PR DESCRIPTION
## What

Adds a **Maintenance** menu with **Cold Pull (INDX)** — a guided nozzle-unclogging procedure for the CORE One INDX.

Prusa's built-in cold-pull wizard (`M1702`) is not enabled for INDX: `ProjectOptions.cmake:716` gates `HAS_COLDPULL` to MK3.5/MK4/XL/COREONE/COREONEL, so `M1702` compiles to an empty stub and INDX owners have no in-firmware way to clear a clog.

## How it works

The procedure — pick tool → hot flush → pack while cooling → deep cool → motorized pull → restore — prompts the user on the **printer's own screen** via `M0` QuickPause dialogs, so their hands are at the machine where the work happens.

Three delivery routes, identical procedure and prompts:

| Route | Notes |
|---|---|
| **USB serial** | PrusaSlicer drives it; live progress, Cancel restores printer state |
| **Save G-code file** | Same procedure as a print job, run from a USB drive |
| **Upload to printer** | Same file over PrusaLink/Connect; never auto-starts |

The dialog probes for a printer on USB serial when it opens and selects accordingly: serial when one is present, G-code file when none is — in which case the serial entry is disabled and labelled *(no printer detected)* rather than left selectable, since choosing it could only fail. Detection enumerates ports without opening one, so it reports that a printer is plugged in, not that it is free.

A **pre-flight gate** lists the prerequisites that are GUI-only on the printer and so unverifiable by the host. Continue stays disabled until each is ticked — these prerequisites fail *silently* rather than loudly (an enabled Auto Retract makes the whole procedure a no-op with a hot nozzle), which is why it is a hard gate rather than a paragraph of text.

## Firmware constraints designed around

All verified against Prusa-Firmware-Buddy `6.6.3+15625` (`ff6658da4`).

**The serial-print inactivity timeout — this crashed a printer during development.** Buddy treats any `G` command (or `M73`/`M74`/`M109`/`M190`) arriving over serial as the start of a print. The inactivity timestamp is stamped when that command is *queued*, but the only code that refreshes it runs solely from `State::Printing`, which cannot be reached until the arming command *finishes*. Arming with a long-blocking `M109` therefore means the first timeout check already sees the entire heat-up as elapsed — instantly exceeding the 5 s limit and running the **end-of-print teardown** (nozzle wipe, **tool dock**, steppers off) mid-procedure. The next `G1 E` then hits `bsod("E move without tool")` at `planner.cpp:2177`.

Worked around two ways: arming with an instant `G4 P1` so the state reaches `Printing` with a fresh timestamp, and re-asserting `T<n>` before each block of E moves so a dock can never be followed by a naked E move. Turning off *Serial Printing Screen* (a pre-flight item) removes the hazard at its source.

Other constraints:
- `M0` messages are capped at **95 chars** (`MAX_CMD_SIZE` 96) and cropped mid-sentence beyond that — every prompt is kept under the limit, which matters most for the safety-critical ones.
- **Heating requires a latched tool**, so `T<n>` must precede any `M109`.
- `M302 S0` is required or `EXTRUDE_MINTEMP` (170) silently strips the pull moves.
- Neither the filament sensor nor auto retract can be set *or read* over G-code — both are GUI-only, which is why the pre-flight gate exists.

## Testing

- **Hardware: the serial route completes successfully on a CORE One INDX**, with no BSOD.
- Generated G-code verified: nozzle 8 correctly emits `T7`, all five `M0` messages land at 80–91 chars.
- Builds clean on macOS arm64.

The G-code file/upload routes are code-complete and generate verified output, but have not yet been run end-to-end on hardware.

## Docs

`doc/Cold_Pull_Guide.md` — prerequisites with consequences, prompt-by-prompt walkthrough, how to read the extracted tip, symptom-driven troubleshooting, and a firmware-reference table pinned to the verified commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
