### PR TITLE
Bump version to Filament-Edition-1.12.0

### DIFF
--- a/version.inc
+++ b/version.inc
@@ -4,6 +4,6 @@
 set(SLIC3R_APP_NAME "PrusaSlicer")
 set(SLIC3R_APP_KEY "PrusaSlicer")
 set(SLIC3R_VERSION "2.9.6")
-set(SLIC3R_BUILD_ID "PrusaSlicer-${SLIC3R_VERSION}-Filament-Edition-1.11.1")
+set(SLIC3R_BUILD_ID "PrusaSlicer-${SLIC3R_VERSION}-Filament-Edition-1.12.0")
 set(SLIC3R_RC_VERSION "2,9,6,0")
 set(SLIC3R_RC_VERSION_DOTS "2.9.6.0")


### PR DESCRIPTION
Minor version bump for the guided INDX cold pull feature merged in #45.

`version.inc`: `Filament-Edition-1.11.1` → `Filament-Edition-1.12.0`

Minor rather than patch: #45 adds a feature (Maintenance menu, three delivery routes, on-printer guided procedure, `doc/Cold_Pull_Guide.md`) rather than fixing existing behaviour.

Going through a PR because `master` requires the `codex-review` status check, which correctly rejected a direct push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)