### PR TITLE
fix(ci): ship OCCTWrapper.so and declare libhidapi-hidraw0 in Linux packages

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -238,14 +238,28 @@ jobs:
             apt-get update -qq
             apt-get install -y ./'$DEB_NAME'
 
+            # NOTE: these must be explicit 'if ...; then exit 1; fi' blocks, NOT
+            # '! grep -q ...'. bash exempts a command whose status is inverted with
+            # '!' from 'set -e', so the bare-negation form would let a missing
+            # library sail straight past and the container would still exit 0 —
+            # i.e. the guard would not catch the very class of bug it exists for.
+
             # Every declared dependency must actually resolve.
             ldd /usr/bin/prusa-slicer > /tmp/ldd-slicer
-            ! grep -q 'not found' /tmp/ldd-slicer
+            if grep -q 'not found' /tmp/ldd-slicer; then
+              echo '::error::prusa-slicer has unresolved shared libraries (undeclared Depends):'
+              grep 'not found' /tmp/ldd-slicer
+              exit 1
+            fi
 
             # The STEP wrapper must be installed next to the binary and loadable.
             test -f /usr/bin/OCCTWrapper.so
             ldd /usr/bin/OCCTWrapper.so > /tmp/ldd-occt
-            ! grep -q 'not found' /tmp/ldd-occt
+            if grep -q 'not found' /tmp/ldd-occt; then
+              echo '::error::OCCTWrapper.so has unresolved shared libraries:'
+              grep 'not found' /tmp/ldd-occt
+              exit 1
+            fi
           "
 
       - name: Show sccache stats

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -118,10 +118,19 @@ jobs:
           mkdir -p AppDir/usr/share/applications
           mkdir -p AppDir/usr/share/icons/hicolor/128x128/apps
 
-          # Copy binary and resources
-          cp build-default/dist/bin/prusa-slicer AppDir/usr/bin/
-          [ -L build-default/dist/bin/prusa-gcodeviewer ] && \
-            cp -P build-default/dist/bin/prusa-gcodeviewer AppDir/usr/bin/ || true
+          # Copy the WHOLE install bindir, don't cherry-pick. It holds exactly three
+          # entries: prusa-slicer, the prusa-gcodeviewer symlink, and OCCTWrapper.so
+          # (src/occt_wrapper/CMakeLists.txt: install(TARGETS OCCTWrapper DESTINATION
+          # ${CMAKE_INSTALL_BINDIR})). The wrapper is dlopen()ed from the binary's own
+          # directory — src/libslic3r/Format/STEP.cpp computes
+          # program_location().parent_path() / "OCCTWrapper.so" — so it must sit next
+          # to prusa-slicer or every STEP import fails at runtime (#48).
+          # cp -a preserves the relative gcodeviewer symlink.
+          cp -a build-default/dist/bin/. AppDir/usr/bin/
+          test -f AppDir/usr/bin/OCCTWrapper.so || {
+            echo "::error::OCCTWrapper.so missing from the install tree — STEP import would be broken"
+            exit 1
+          }
           cp -r build-default/dist/resources/* AppDir/usr/resources/ 2>/dev/null || \
             cp -r resources/* AppDir/usr/resources/
 
@@ -133,15 +142,30 @@ jobs:
 
           # Build AppImage
           APPIMAGE_NAME="${{ steps.version.outputs.build_id }}-linux-${{ matrix.arch }}.AppImage"
+          # No "|| echo ..." here: swallowing a linuxdeploy failure is what let a
+          # broken package ship silently once already, and there is no tarball step
+          # in this workflow for the old message to fall back to.
           OUTPUT="$APPIMAGE_NAME" ./linuxdeploy-${{ matrix.linuxdeploy_arch }}.AppImage \
             --appdir AppDir \
             --desktop-file src/platform/unix/PrusaSlicer.desktop \
-            --output appimage || echo "AppImage creation failed, tarball is still available"
+            --output appimage
 
           # Rename if output name differs
           if [ -f PrusaSlicer*.AppImage ] && [ ! -f "$APPIMAGE_NAME" ]; then
             mv PrusaSlicer*.AppImage "$APPIMAGE_NAME"
           fi
+
+          # Assert the wrapper survived packaging. linuxdeploy rewrites RPATHs of ELF
+          # files it finds in the AppDir; this turns "it should still be there" into a
+          # build failure rather than a runtime one for users.
+          # --appimage-extract needs no FUSE.
+          rm -rf squashfs-root
+          ./"$APPIMAGE_NAME" --appimage-extract usr/bin/OCCTWrapper.so >/dev/null
+          test -f squashfs-root/usr/bin/OCCTWrapper.so || {
+            echo "::error::OCCTWrapper.so did not survive AppImage packaging"
+            exit 1
+          }
+          rm -rf squashfs-root
 
       - name: Package deb
         run: |
@@ -174,15 +198,18 @@ jobs:
            advance, retraction, and more.
           Section: graphics
           Priority: optional
-          Depends: libgtk-3-0 | libgtk-3-0t64, libwebkit2gtk-4.1-0, libglu1-mesa, libdbus-1-3
+          Depends: libgtk-3-0 | libgtk-3-0t64, libwebkit2gtk-4.1-0, libglu1-mesa, libdbus-1-3, libhidapi-hidraw0
           CTRL
           # Strip leading whitespace from control file (heredoc was indented)
           sed -i 's/^          //' deb/DEBIAN/control
 
-          # Copy binary and resources
-          cp build-default/dist/bin/prusa-slicer deb/usr/bin/
-          [ -L build-default/dist/bin/prusa-gcodeviewer ] && \
-            cp -P build-default/dist/bin/prusa-gcodeviewer deb/usr/bin/ || true
+          # Copy the WHOLE install bindir — see the AppImage step for why cherry-picking
+          # dropped OCCTWrapper.so and broke STEP import (#48).
+          cp -a build-default/dist/bin/. deb/usr/bin/
+          test -f deb/usr/bin/OCCTWrapper.so || {
+            echo "::error::OCCTWrapper.so missing from the install tree — STEP import would be broken"
+            exit 1
+          }
           cp -r build-default/dist/resources/* deb/usr/resources/ 2>/dev/null || \
             cp -r resources/* deb/usr/resources/
 
@@ -194,6 +221,33 @@ jobs:
           dpkg-deb --build deb "$DEB_NAME"
           echo "Created $DEB_NAME"
 
+      # Nothing in this workflow ever executed the produced binary, which is how a
+      # missing runtime dependency (#44: libhidapi-hidraw0) and a missing module
+      # (#48: OCCTWrapper.so) both shipped without CI noticing. Installing the .deb
+      # into a clean container resolves ONLY the declared Depends:, so an omission
+      # fails right here. The `ldd | ! grep 'not found'` check is the precise
+      # invariant that was violated in #44.
+      #
+      # Do not gate on prusa-slicer's exit code: with no $DISPLAY,
+      # src/CLI/GuiParams.cpp returns 1 by design.
+      - name: Smoke test deb in a clean container
+        run: |
+          DEB_NAME="${{ steps.version.outputs.build_id }}-linux-${{ matrix.arch }}.deb"
+          docker run --rm -v "$PWD:/w" -w /w ubuntu:24.04 bash -eux -c "
+            export DEBIAN_FRONTEND=noninteractive
+            apt-get update -qq
+            apt-get install -y ./'$DEB_NAME'
+
+            # Every declared dependency must actually resolve.
+            ldd /usr/bin/prusa-slicer > /tmp/ldd-slicer
+            ! grep -q 'not found' /tmp/ldd-slicer
+
+            # The STEP wrapper must be installed next to the binary and loadable.
+            test -f /usr/bin/OCCTWrapper.so
+            ldd /usr/bin/OCCTWrapper.so > /tmp/ldd-occt
+            ! grep -q 'not found' /tmp/ldd-occt
+          "
+
       - name: Show sccache stats
         if: always()
         run: sccache --show-stats
@@ -204,7 +258,6 @@ jobs:
         with:
           name: linux-${{ matrix.arch }}-appimage
           path: ${{ steps.version.outputs.build_id }}-linux-${{ matrix.arch }}.AppImage
-          if-no-files-found: ignore
 
       - name: Upload deb
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Two shipped Linux packaging defects. Same file, same root cause for why neither was caught.

## #48 — STEP import broken (AppImage + .deb)

```
Cannot load OCCTWrapper.so:
/tmp/.mount_PrusaSLjKiEA/usr/bin/OCCTWrapper.so: cannot open shared object file
```

**Not a build-config problem.** Ruled out in order:

- STEP is enabled — `CMakeLists.txt` defaults `SLIC3R_ENABLE_FORMAT_STEP=ON` and the CI `default` preset never overrides it (the `no-occt` preset is unused by Linux CI)
- OCCT was found — `find_package(OpenCASCADE 7.6.1 REQUIRED)` would have hard-failed configure, and an AppImage was produced
- The module *is* installed — `install(TARGETS OCCTWrapper DESTINATION ${CMAKE_INSTALL_BINDIR})` puts it at `dist/bin/OCCTWrapper.so`, corroborated by `build-windows.yml` moving `$dist/bin/OCCTWrapper.dll` from that exact path
- Not a missing-transitive-dep — glibc names the missing *soname* when a `DT_NEEDED` can't resolve, and names the requested path only when the path itself is absent. The report shows the path. (OCCT is also built `BUILD_LIBRARY_TYPE=Static`.)

The packaging steps just cherry-picked two entries out of the install tree and never copied the module. Now copying the whole bindir with `cp -a` — which also preserves the relative `prusa-gcodeviewer` symlink more robustly than the old `[ -L ] && cp -P || true` — plus an assertion. `STEP.cpp` dlopens from `program_location().parent_path()`, so it must sit beside the binary.

## #44 — .deb won't start

```
error while loading shared libraries: libhidapi-hidraw.so.0
```

hidapi is the **only** dependency dynamically linked from the system despite `SLIC3R_STATIC=true`: upstream dropped the vendored Linux backend, and `bundled_deps/hidapi/CMakeLists.txt` now resolves it via `pkg_check_modules`, ignoring `SLIC3R_STATIC`. `Mouse3DController` references `hid_init()` unconditionally, so `--as-needed` can't drop it and the loader fails **before `main()`** — no SpaceMouse required, no graceful degradation possible.

A previous commit added `libhidapi-dev` to the CI build deps but never touched the runtime `Depends:`, leaving it the only `-dev` package with no runtime counterpart. Declaring `libhidapi-hidraw0`, which is correct on both jammy and noble (hidapi wasn't renamed in the t64 transition, and the reporter confirmed that exact package fixes it on Mint 22.3).

Note this is a *different* bug from upstream `prusa3d/PrusaSlicer#15520`, despite the same trigger: that one is build-time (`Build-Depends`, configure aborts without the `.pc` files); this is runtime (`Depends`, undeclared `DT_NEEDED`). Fixing either does not fix the other.

## Why both shipped unnoticed — and the guard

**No step in this workflow ever executed the produced binary or inspected the artifact**, and failures were actively swallowed:

- linuxdeploy errors went to `|| echo "AppImage creation failed, tarball is still available"` — there is no tarball step in this workflow, so that message was simply false
- the AppImage upload used `if-no-files-found: ignore`

Both removed. Added a smoke test that installs the .deb into a clean `ubuntu:24.04` container:

- `apt-get install ./file.deb` resolves **only** the declared `Depends:`, so an omission fails right there
- `ldd | ! grep 'not found'` is precisely the invariant #44 violated
- also asserts `OCCTWrapper.so` is installed and its own deps resolve

It deliberately does **not** gate on `prusa-slicer`'s exit code — `src/CLI/GuiParams.cpp` returns 1 when `$DISPLAY` is unset, by design. The AppImage separately verifies the wrapper survived packaging via `--appimage-extract` (needs no FUSE), which also covers the one thing I can't check from a macOS checkout: whether linuxdeploy preserves a `.so` living in `usr/bin`.

## Verification

- Workflow YAML parses; all 19 steps enumerate correctly with the smoke test in position
- All three modified `run:` blocks pass `bash -n` (with `${{ }}` expressions stubbed)
- `cp -a` verified against a mock install tree: relative symlink preserved, module copied, exec bit kept

The real proof is the CI run itself — the new assertions either pass or fail the job. Worth watching the first run on both matrix legs, since the arm64 leg exercises the same paths on a different runner.

## Follow-up, deliberately not in this PR

Auto-deriving `Depends:` via `dpkg-shlibdeps` would structurally prevent this class of drift (and would self-correct if the runner ever resolves `hidapi-libusb` instead of `hidapi-hidraw`). But it also emits build-host-derived version floors, which would make the .deb *uninstallable* on older distros rather than installing and failing — a visible product change that deserves its own decision and a noble-container test first.

Fixes #48
Fixes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)