### PR TITLE
fix(coldpull): suppress auto retract by filament type on firmware 6.9.0

### DIFF
--- a/doc/Cold_Pull_Guide.md
+++ b/doc/Cold_Pull_Guide.md
@@ -25,7 +25,8 @@ plug comes away with the carbonised material embedded in it.
 6. [Reading the result](#6-reading-the-result)
 7. [Cancelling](#7-cancelling-part-way)
 8. [Troubleshooting](#8-troubleshooting)
-9. [How it works](#9-how-it-works)
+9. [Auto retract](#9-auto-retract)
+10. [How it works](#10-how-it-works)
 
 ---
 
@@ -44,7 +45,7 @@ see [§8](#8-troubleshooting). The procedure includes a check for exactly this,
 early enough to stop before wasting twenty minutes.
 
 Plan for **10–20 minutes**, most of it cooling. You must stay at the printer:
-it stops and waits for knob presses at five points.
+it stops and waits for knob presses at six points.
 
 ---
 
@@ -52,8 +53,10 @@ it stops and waits for knob presses at five points.
 
 After you choose a delivery route, a pre-flight gate lists the relevant items.
 **Continue stays disabled until all boxes are ticked** — that is deliberate.
-None of these can be set or even *read* over G-code; all are GUI-only settings,
-so the host has no way to check them for you.
+Most cannot be set or even *read* over G-code; they are GUI-only settings, so the
+host has no way to check them for you. The filament-type row is the exception: it
+is not something to do beforehand but a change the procedure makes to the
+printer's saved settings, which you need to know about and have to put back.
 
 The list adapts to the route: the *Serial Printing Screen* item below appears
 only for the serial route, since it cannot affect a G-code print job.
@@ -61,10 +64,10 @@ only for the serial route, since it cannot affect a G-code print job.
 | Do this at the printer | Why it matters |
 |---|---|
 | **Settings → Filament Sensor → OFF** | Left on, the printer grabs and autoloads the filament while you are hand-inserting it. |
-| **Settings → Auto Retract → OFF** | Left on, the printer can treat the filament as retracted and **silently discard** the extrusion and pull moves. The procedure appears to run normally while nothing actually moves. |
-| **Remove the PTFE tube** from this tool | The pulled plug travels up and out of the top port. With the tube fitted there is nowhere for it to go. |
+| **Remove the PTFE tube** from this tool | The pulled plug travels 80 mm up and out of the top port. With the tube fitted there is nowhere for it to go. |
 | **Settings → Hardware → Experimental Settings → "Serial Printing Screen" → OFF** | **Serial route only** — this item is not shown for the G-code routes. See the warning below. Leaving this screen prompts you to save and reboot. |
-| Light-coloured PLA on hand; stay at the printer | PLA shows extracted debris clearly. Heaters switch off after ~30 minutes unattended (safety timer). |
+| Light-coloured PLA on hand; stay at the printer | PLA shows extracted debris clearly. Do **not** load it beforehand — a prompt says when. Heaters switch off after ~30 minutes unattended (safety timer). |
+| This nozzle's filament type gets set to **FLEX** | Nothing to do up front. Auto retract has no switch on INDX from firmware 6.9.0 and would **silently discard** the extrusion and pull moves; marking the nozzle FLEX is the only thing that stops it. See [§9](#9-auto-retract). A *persistent* change you have to put back. |
 
 > ### ⚠️ Why "Serial Printing Screen" matters
 >
@@ -76,7 +79,7 @@ only for the serial route, since it cannot affect a G-code print job.
 > **`E move without tool`** (`planner.cpp:2177`).
 >
 > This is a real firmware bug, not a misconfiguration; it was reproduced on
-> hardware. The tool now works around it in code (see [§9](#9-how-it-works))
+> hardware. The tool now works around it in code (see [§10](#10-how-it-works))
 > and the serial route has since completed successfully on hardware — but
 > turning the setting off removes the hazard at its source, so it stays a
 > prerequisite.
@@ -168,7 +171,7 @@ sequence is the same on all three routes.
 Complete every item in [§2](#2-prerequisites-required).
 
 ### Prompt 1 — Setup check
-> *Setup check: filament sensor OFF, auto retract OFF, PTFE tube removed.*
+> *Setup check: filament sensor OFF, PTFE tube removed.*
 
 A last confirmation before anything heats. Press the knob to continue.
 
@@ -182,11 +185,18 @@ geared (~550 steps/mm) and cannot be hand-fed. The motor does the feeding.
 The nozzle is still cold here, deliberately: insertion depth only reaches the
 gears, so there is no reason to have you working near a hot end.
 
-### Heating and purge (automatic)
-The nozzle heats to the flush temperature, then pushes roughly 60 mm of filament
-through in three passes. Watch the tip — fresh PLA should appear.
+### Heating (automatic)
+The nozzle heats to the flush temperature.
 
-### Prompt 3 — Tip check ⚠️ *the decision point*
+### Prompt 3 — Purge briefing
+> *Purge next. Watch the nozzle tip for melted PLA flowing out. Press to start.*
+
+The screen and the nozzle cannot be watched at the same time, so this says what
+to look for before anything starts moving. Press the knob, then watch the tip:
+the printer pushes roughly 60 mm of filament through in three passes and fresh
+PLA should appear.
+
+### Prompt 4 — Tip check ⚠️ *the decision point*
 > *Tip check. PLA out: press knob to continue. NOTHING out: press knob then Stop print.*
 
 - **PLA came out** → press the knob and continue.
@@ -199,29 +209,37 @@ cannot reach it. Continuing wastes twenty minutes and will not help. See
 
 > **If you stop here**, the restore block at the end never runs. Afterwards send
 > `M302 S170` and `M591 R`, or simply power-cycle the printer, to restore the
-> cold-extrusion guard and stuck-filament detection.
+> cold-extrusion guard and stuck-filament detection. The nozzle is also still
+> marked FLEX, which a power cycle does **not** undo — send `M865 S"PLA" L<n>`
+> or fix it from the Filament menu. See [§9](#9-auto-retract).
 
 ### Packing and cooling (automatic)
 The heater drops toward 180 °C while small extrusions pack the melt zone, then
 the fan runs full and the hot end cools to 60 °C with a two-minute hold. This is
 the longest phase — several minutes with nothing visible happening.
 
-### Prompt 4 — Pull ready
+### Prompt 5 — Pull ready
 > *Pull ready at 80C. Motor will yank the plug — keep hands clear.*
 
-**Keep hands clear of the head.** The extruder retracts hard (50 mm/s) on the
-knob press.
+**Keep hands clear of the head.** The extruder retracts hard: 40 mm at 50 mm/s,
+then 40 mm slower to feed the strand up and out — 80 mm in total.
 
-### Prompt 5 — Remove the strand
-> *Pull done. Remove strand from top port. Pressing knob starts auto wipe and dock.*
+### Prompt 6 — Remove the strand
+> *Pull done. Remove strand from top port. Pressing knob warms nozzle, then wipe and dock.*
 
 Lift the strand out of the top port and set it aside **before** pressing the
-knob. The printer then wipes and docks the tool automatically; doing this first
-keeps the strand out of the way of those movements.
+knob. The nozzle is then rewarmed to 170 °C so residue releases instead of
+dragging cold strings, and the tool wipes and docks automatically; doing this
+first keeps the strand out of the way of those movements.
 
 ### Finishing
-The end-of-print sequence runs: nozzle wipe, tool dock, steppers off. Wait for
-*Finished*.
+On the G-code routes the end-of-print sequence runs: nozzle wipe over the
+wastebin, tool dock, steppers off. Wait for *Finished*. The serial route has no
+end-of-print machinery, so it warms and docks the tool itself with `P0 S1` and
+there is no brush wipe.
+
+**Then put the nozzle's filament type back** — see [§9](#9-auto-retract). The
+serial route does this for you; the G-code routes cannot.
 
 ---
 
@@ -242,8 +260,11 @@ Inspect the extracted tip.
 Restore what you changed in [§2](#2-prerequisites-required):
 
 - Filament Sensor → **on**
-- Auto Retract → **on**
 - Refit the PTFE tube
+- This nozzle's filament type → **off FLEX**. The serial route does this for you
+  as the last command of the run; the G-code routes deliberately cannot, so send
+  `M865 S"PLA" L<n>` or set it from the printer's Filament menu once the print
+  has finished. A power cycle does not undo it. See [§9](#9-auto-retract).
 - *Serial Printing Screen* → back on, if you turned it off and want it
 
 ---
@@ -259,7 +280,8 @@ stop that requires a printer reset.
 
 **G-code routes.** Press the knob to dismiss any prompt, then **Stop** on the
 printer. If you stop before the restore block, send `M302 S170` and `M591 R`
-afterwards, or power-cycle.
+afterwards, or power-cycle. The filament type is not covered by a power cycle
+either — send `M865 S"PLA" L<n>` or fix it from the Filament menu.
 
 ---
 
@@ -285,9 +307,13 @@ in [§2](#2-prerequisites-required). Reset the printer (the crash dump is saved
 and safe to discard), turn that setting off, reboot, and prefer a G-code route.
 
 ### The procedure appears to run but nothing moves
-**Auto Retract is still on.** The planner discards E moves when it considers the
-filament retracted, so everything looks normal while nothing happens. Turn it
-off and start again.
+**Auto retract has the filament marked as retracted.** The planner discards
+negative-E printing moves whenever the firmware believes the nozzle is retracted,
+so everything looks normal while nothing happens. The procedure suppresses auto
+retract by marking the nozzle FLEX ([§9](#9-auto-retract)) — check that the
+`M865 S"FLEX"` line was accepted, and that the nozzle is not carrying a
+retraction banked from an earlier print (the purge clears that, but only once the
+nozzle is hot).
 
 ### The printer grabs the filament as I insert it
 **Filament Sensor is still on**, triggering autoload. Turn it off and start
@@ -305,20 +331,96 @@ wrong.
 
 ---
 
-## 9. How it works
+## 9. Auto retract
+
+Firmware **6.9.0** removed the Auto Retract switch on INDX
+([`0dfee5ef1`](https://github.com/prusa3d/Prusa-Firmware-Buddy/commit/0dfee5ef1),
+*"INDX: Remove Auto Retract menu switch (it's not permitted to switch off)"*,
+BFW-8589). The toggle moved behind a new `HAS_SWITCHABLE_AUTO_RETRACT`, which
+lists `COREONE COREONEL MK4 iX XL` — neither INDX variant. On INDX the menu item,
+the global-disable check in `maybe_retract_from_nozzle()` and the
+`auto_retract_enabled` config-store item are all compiled out. There is no menu,
+G-code or config route to it any more.
+
+That matters here because auto retract pulls the plug back out of the melt zone,
+and while the firmware believes a nozzle is retracted the planner silently
+discards negative-E printing moves — so the procedure appears to run while
+nothing happens.
+
+### The escape hatch
+
+What survives is deliberate, not a loophole. `auto_retract.cpp` returns early,
+ahead of any retraction, for anything the firmware considers flexible:
+
+```cpp
+// Do not auto retract flexible filaments, they might get tangled in the extruder (BFW-6953)
+if (filament_parameters.is_flexible) {
+    return;
+}
+```
+
+The same test guards `prepare_for_nozzle_cleaning()` in `probe.cpp`, and
+`standard_ramming_sequence_indx.cpp` states it outright: *"auto_retract is never
+called for flexible filaments (filtered in auto_retract.cpp)"*. `FLEX` is the
+only preset with `is_flexible = true`, and the type is read per tool out of the
+config store — so marking the nozzle FLEX genuinely does disable auto retract.
+The early return is behind no `HAS_*` guard and is present in 6.6.x as well.
+
+The procedure sets it over G-code rather than through the menu:
+
+```gcode
+M865 S"FLEX" L<n>     ; n = 0-based tool index
+```
+
+`M865` cannot rewrite a preset's parameters (`is_customizable()` is false for
+presets), so this changes only which type the tool is recorded as holding.
+
+Side effects of the choice, all checked:
+
+- FLEX's ⅙ feedrate factor applies to firmware-internal load/unload/purge
+  helpers, **not** to the raw `G1 E… F…` moves this procedure uses. The pull runs
+  at the speed the file asks for.
+- Every temperature is set explicitly, so FLEX's 240 °C nozzle and 170 °C preheat
+  never come into play.
+- FLEX has `requires_filtration = true` and PLA does not, so the chamber
+  filtration fan runs while the nozzle is hot. Harmless, but expected.
+
+### Putting it back
+
+The write lands in the printer's persistent settings, and **a power cycle does
+not undo it.**
+
+- **The serial route** reads the nozzle's real filament type first
+  (`M865 I<n>`) and restores exactly that value as the very last command of the
+  run — after the warm dock, so nothing in between can auto-retract — and again
+  in its cleanup path on any early exit. If the nozzle had no filament type set
+  to begin with, there is no G-code that sets one back to "none", so it ends up
+  marked PLA and the completion dialog says so.
+- **The G-code routes cannot**, and do not try. The end-of-print sequence runs
+  after the last line of the file; with the nozzle already back on PLA, that
+  sequence would auto-retract — reheating to 215 °C over the 170 °C the file sets
+  for the warm wipe, and ramming the melt zone just cleared. Send
+  `M865 S"PLA" L<n>` once the print has **finished**, or set it from the
+  printer's Filament menu. The generated file says this in its header and in its
+  closing comment.
+
+---
+
+## 10. How it works
 
 The recipe, and why each step is shaped the way it is:
 
 | Phase | Commands | Rationale |
 |---|---|---|
 | Pick tool | `T<n> M0` | `M0` bypasses tool mapping. **Heating requires a latched tool** — an unlatched hot end never becomes thermally managed, so the heater will not arm. |
+| Suppress auto retract | `M865 S"FLEX" L<n>` | Auto retract has no switch on INDX from 6.9.0 and would discard the pull. Marking the tool FLEX is the only lever left — see [§9](#9-auto-retract). |
 | Prepare | `M302 S0`, `M83`, `M591 S0` | Allow cold extrusion (`EXTRUDE_MINTEMP` is 170 and would otherwise silently strip the pull moves), relative E, and disable stuck-filament detection so the deliberate stall does not trip it. |
 | Flush | `M109 S290`, 3 × `G1 E20 F120` | Melt and displace old material. |
 | Pack | `M104 S180`, 8 × `G1 E2 F60` with dwells | Small extrusions while cooling pack the melt zone so the plug forms a complete cast of the nozzle interior. |
 | Deep cool | `M106 S255`, `M109 R60`, `G4 S120` | The plug must grip before the pull. `M109 R` regulates *at* the target and can exit early if the cooling slope flattens, so a fixed dwell follows it. |
-| Reheat | `M109 R80` | Just enough softening to release from the walls while still gripping the debris. |
-| Pull | `M906 E650`, `G1 E-40 F3000`, `G1 E-30 F1200` | Raised motor current for the stiff plug; a fast yank, then a slower feed to bring the strand up and out. |
-| Restore | `M906 E550`, `M591 R`, `M302 S170` | Undo every session change. |
+| Reheat | `M104 S77`, `M109 C76`, `M109 S80` | Just enough softening to release from the walls while still gripping the debris. Two stages: aimed straight at a target this low the PID overshoots, so the first stage stops short and lets the thermal momentum bleed off. `M109 C` waits for a temperature without changing the target (Buddy 6.6.2+). |
+| Pull | `M906 E650`, `G1 E-40 F3000`, `G1 E-40 F1200` | Raised motor current for the stiff plug; a fast 40 mm yank, then a slower 40 mm feed to bring the strand up and out — 80 mm total. |
+| Restore | `M906 E550`, `M591 R`, `M302 S170` | Undo every session change. The serial route also sends `M865 S"<original>" L<n>` as its last command; the G-code routes deliberately cannot — see [§9](#9-auto-retract). |
 
 ### Why the serial route sends `G4 P1` first
 
@@ -342,7 +444,8 @@ extrusion cannot hit the assert.
 
 ### Firmware references
 
-Verified against Prusa-Firmware-Buddy `6.6.3+15625` (commit `ff6658da4`):
+Verified against Prusa-Firmware-Buddy `6.6.3+15625` (commit `ff6658da4`) and
+`6.9.0` (commit `00ae96876`):
 
 | Behaviour | Location |
 |---|---|
@@ -352,6 +455,11 @@ Verified against Prusa-Firmware-Buddy `6.6.3+15625` (commit `ff6658da4`):
 | End-of-print teardown | `src/common/marlin_server.cpp:983` |
 | `E move without tool` assert | `lib/Marlin/Marlin/src/module/planner.cpp:2177` |
 | Auto-retract planner hook | `lib/Marlin/Marlin/src/module/planner.cpp:2196` |
+| Auto Retract switch removed on INDX | `ProjectOptions.cmake:640` (`HAS_SWITCHABLE_AUTO_RETRACT`) |
+| Flexible-filament early return | `src/feature/auto_retract/auto_retract.cpp:113` |
+| `FLEX` is the only flexible preset | `src/common/filament_presets.cpp:192` |
+| Filament type read per tool | `src/common/filament_tools.cpp:15` |
+| `M865` filament management | `src/marlin_stubs/M865.cpp` |
 | M0 message limit (`MAX_CMD_SIZE` 96) | `include/marlin/Configuration_COREONE_adv.h:578` |
 | Safety timer | `src/feature/safety_timer/safety_timer.hpp:40` |
 

--- a/doc/Cold_Pull_Guide.md
+++ b/doc/Cold_Pull_Guide.md
@@ -67,7 +67,7 @@ only for the serial route, since it cannot affect a G-code print job.
 | **Remove the PTFE tube** from this tool | The pulled plug travels 80 mm up and out of the top port. With the tube fitted there is nowhere for it to go. |
 | **Settings → Hardware → Experimental Settings → "Serial Printing Screen" → OFF** | **Serial route only** — this item is not shown for the G-code routes. See the warning below. Leaving this screen prompts you to save and reboot. |
 | Light-coloured PLA on hand; stay at the printer | PLA shows extracted debris clearly. Do **not** load it beforehand — a prompt says when. Heaters switch off after ~30 minutes unattended (safety timer). |
-| This nozzle's filament type gets set to **FLEX** | Nothing to do up front. Auto retract has no switch on INDX from firmware 6.9.0 and would **silently discard** the extrusion and pull moves; marking the nozzle FLEX is the only thing that stops it. See [§9](#9-auto-retract). A *persistent* change you have to put back. |
+| This nozzle's filament type gets set to **FLEX** — **note what it is now** | Auto retract has no switch on INDX from firmware 6.9.0 and would **silently discard** the extrusion and pull moves; marking the nozzle FLEX is the only thing that stops it. See [§9](#9-auto-retract). A *persistent* change you have to put back — the serial route reads the current type and restores it for you, the G-code routes cannot read anything, so write down what *Settings → Filament* shows for this nozzle first. |
 
 > ### ⚠️ Why "Serial Printing Screen" matters
 >
@@ -210,8 +210,9 @@ cannot reach it. Continuing wastes twenty minutes and will not help. See
 > **If you stop here**, the restore block at the end never runs. Afterwards send
 > `M302 S170` and `M591 R`, or simply power-cycle the printer, to restore the
 > cold-extrusion guard and stuck-filament detection. The nozzle is also still
-> marked FLEX, which a power cycle does **not** undo — send `M865 S"PLA" L<n>`
-> or fix it from the Filament menu. See [§9](#9-auto-retract).
+> marked FLEX, which a power cycle does **not** undo — send
+> `M865 S"<TYPE>" L<n>` with the type you noted before starting, or fix it from
+> the Filament menu. See [§9](#9-auto-retract).
 
 ### Packing and cooling (automatic)
 The heater drops toward 180 °C while small extrusions pack the melt zone, then
@@ -263,8 +264,10 @@ Restore what you changed in [§2](#2-prerequisites-required):
 - Refit the PTFE tube
 - This nozzle's filament type → **off FLEX**. The serial route does this for you
   as the last command of the run; the G-code routes deliberately cannot, so send
-  `M865 S"PLA" L<n>` or set it from the printer's Filament menu once the print
-  has finished. A power cycle does not undo it. See [§9](#9-auto-retract).
+  `M865 S"<TYPE>" L<n>` with the type you noted before starting, or set it from
+  the printer's Filament menu, once the print has finished. **Do not assume it
+  was PLA** — sending PLA to a nozzle configured as PETG or ASA overwrites that.
+  A power cycle does not undo it. See [§9](#9-auto-retract).
 - *Serial Printing Screen* → back on, if you turned it off and want it
 
 ---
@@ -281,7 +284,8 @@ stop that requires a printer reset.
 **G-code routes.** Press the knob to dismiss any prompt, then **Stop** on the
 printer. If you stop before the restore block, send `M302 S170` and `M591 R`
 afterwards, or power-cycle. The filament type is not covered by a power cycle
-either — send `M865 S"PLA" L<n>` or fix it from the Filament menu.
+either — send `M865 S"<TYPE>" L<n>` with the type from before, or fix it from
+the Filament menu.
 
 ---
 
@@ -400,9 +404,11 @@ not undo it.**
   after the last line of the file; with the nozzle already back on PLA, that
   sequence would auto-retract — reheating to 215 °C over the 170 °C the file sets
   for the warm wipe, and ramming the melt zone just cleared. Send
-  `M865 S"PLA" L<n>` once the print has **finished**, or set it from the
-  printer's Filament menu. The generated file says this in its header and in its
-  closing comment.
+  `M865 S"<TYPE>" L<n>` once the print has **finished**, with the type you noted
+  before starting, or set it from the printer's Filament menu. **Do not assume it
+  was PLA**: the nozzle may well have been configured as PETG or ASA, and sending
+  PLA overwrites that silently. The generated file asks for the note up front and
+  repeats the warning in its header and closing comment.
 
 ---
 

--- a/doc/Cold_Pull_Guide.md
+++ b/doc/Cold_Pull_Guide.md
@@ -400,6 +400,15 @@ not undo it.**
   in its cleanup path on any early exit. If the nozzle had no filament type set
   to begin with, there is no G-code that sets one back to "none", so it ends up
   marked PLA and the completion dialog says so.
+
+  One exception: a name that cannot be quoted back into `M865` — one containing
+  a space or punctuation. The firmware will store one, because an NFC
+  abbreviation that fails its own name validation is kept anyway with the
+  dataset merely flagged unsafe (`openprinttag/data_utils.cpp`). Rather than
+  overwrite it with a value nobody chose, the run writes **nothing** back: the
+  nozzle is left marked FLEX and the dialog hands you the exact name to set by
+  hand. Watch for that message — a nozzle left FLEX will not auto-retract at the
+  end of your next print.
 - **The G-code routes cannot**, and do not try. The end-of-print sequence runs
   after the last line of the file; with the nozzle already back on PLA, that
   sequence would auto-retract — reheating to 215 °C over the 170 °C the file sets

--- a/src/slic3r/GUI/MaintenanceColdPullDialog.cpp
+++ b/src/slic3r/GUI/MaintenanceColdPullDialog.cpp
@@ -92,9 +92,11 @@ MaintenanceColdPullPreflightDialog::MaintenanceColdPullPreflightDialog(wxWindow*
              "for flexible filaments, so this marks the nozzle FLEX. It is a "
              "write to the printer's saved settings, and a power cycle does not "
              "undo it. The serial run reads the current type and puts that exact "
-             "value back for you; the G-code file cannot read anything, so write "
-             "down what Settings → Filament shows for this nozzle before you "
-             "start, and set it back to that afterwards.") });
+             "value back for you — unless it is a name that cannot be sent over "
+             "G-code, in which case it writes nothing and tells you what to set "
+             "by hand. The G-code file cannot read anything, so write down what "
+             "Settings → Filament shows for this nozzle before you start, and "
+             "set it back to that afterwards.") });
 
     for (const Item& it : items) {
         auto* cb = new wxCheckBox(this, wxID_ANY, it.label);

--- a/src/slic3r/GUI/MaintenanceColdPullDialog.cpp
+++ b/src/slic3r/GUI/MaintenanceColdPullDialog.cpp
@@ -84,15 +84,17 @@ MaintenanceColdPullPreflightDialog::MaintenanceColdPullPreflightDialog(wxWindow*
     // tool FLEX -- a persistent write the user has to know about and, on the
     // G-code route, put back themselves.
     items.push_back(
-        { _L("This nozzle's filament type will be set to FLEX"),
+        { _L("This nozzle's filament type will be set to FLEX — note what it is now"),
           _L("Firmware 6.9.0 removed the Auto Retract switch on INDX. Left to "
              "itself, auto retract treats the filament as retracted and "
              "silently discards the extrusion and pull moves — the procedure "
              "appears to run but nothing moves. The firmware skips auto retract "
              "for flexible filaments, so this marks the nozzle FLEX. It is a "
-             "write to the printer's saved settings: the serial run puts it "
-             "back for you, the G-code file cannot, and a power cycle does "
-             "not.") });
+             "write to the printer's saved settings, and a power cycle does not "
+             "undo it. The serial run reads the current type and puts that exact "
+             "value back for you; the G-code file cannot read anything, so write "
+             "down what Settings → Filament shows for this nozzle before you "
+             "start, and set it back to that afterwards.") });
 
     for (const Item& it : items) {
         auto* cb = new wxCheckBox(this, wxID_ANY, it.label);

--- a/src/slic3r/GUI/MaintenanceColdPullDialog.cpp
+++ b/src/slic3r/GUI/MaintenanceColdPullDialog.cpp
@@ -34,7 +34,9 @@ MaintenanceColdPullPreflightDialog::MaintenanceColdPullPreflightDialog(wxWindow*
 
     auto* intro = new wxStaticText(this, wxID_ANY,
         _L("Nothing has been sent to the printer yet. Do these at the printer "
-           "first — the host cannot check or change them for you."));
+           "first — the host cannot check or change them for you. The last item "
+           "is different: it is a change this procedure makes to the printer's "
+           "saved settings, and you need to know it is coming."));
     intro->Wrap(text_width);
     top->Add(intro, 0, wxALL, 10);
 
@@ -48,10 +50,6 @@ MaintenanceColdPullPreflightDialog::MaintenanceColdPullPreflightDialog(wxWindow*
         { _L("Filament Sensor is turned OFF"),
           _L("Settings → Filament Sensor. If left on, the printer grabs and "
              "autoloads the filament while you are hand-inserting it.") },
-        { _L("Auto Retract is turned OFF"),
-          _L("Settings → Auto Retract. If left on, the printer can treat the "
-             "filament as retracted and silently discard the extrusion and "
-             "pull moves — the procedure appears to run but nothing moves.") },
         { _L("The PTFE tube is removed from this tool"),
           _L("The pulled plug travels up and out of the top port. With the "
              "tube fitted there is nowhere for it to go.") },
@@ -74,10 +72,27 @@ MaintenanceColdPullPreflightDialog::MaintenanceColdPullPreflightDialog(wxWindow*
 
     items.push_back(
         { _L("Light-colored PLA is on hand, and you will stay at the printer"),
-          _L("PLA shows the extracted debris clearly. The procedure stops and "
-             "waits for knob presses on the printer's screen at several "
-             "points, and the printer turns the heaters off after 30 minutes "
-             "unattended.") });
+          _L("PLA shows the extracted debris clearly. Do not load it yet — a "
+             "prompt on the printer's screen says when to insert it. The "
+             "procedure stops and waits for knob presses on the printer's "
+             "screen at six points, and the printer turns the heaters off "
+             "after 30 minutes unattended.") });
+
+    // Last, and a consent rather than an action: firmware 6.9.0 removed the
+    // Auto Retract switch on INDX, so the only remaining way to stop the
+    // firmware retracting the plug back out of the melt zone is to mark the
+    // tool FLEX -- a persistent write the user has to know about and, on the
+    // G-code route, put back themselves.
+    items.push_back(
+        { _L("This nozzle's filament type will be set to FLEX"),
+          _L("Firmware 6.9.0 removed the Auto Retract switch on INDX. Left to "
+             "itself, auto retract treats the filament as retracted and "
+             "silently discards the extrusion and pull moves — the procedure "
+             "appears to run but nothing moves. The firmware skips auto retract "
+             "for flexible filaments, so this marks the nozzle FLEX. It is a "
+             "write to the printer's saved settings: the serial run puts it "
+             "back for you, the G-code file cannot, and a power cycle does "
+             "not.") });
 
     for (const Item& it : items) {
         auto* cb = new wxCheckBox(this, wxID_ANY, it.label);

--- a/src/slic3r/GUI/MaintenanceColdPullDialog.hpp
+++ b/src/slic3r/GUI/MaintenanceColdPullDialog.hpp
@@ -20,8 +20,10 @@ namespace Slic3r { namespace GUI {
 //
 // This is deliberately a hard gate rather than a wall of text: skipping a
 // prerequisite doesn't fail loudly, it fails subtly (an enabled filament
-// sensor grabs the filament during hand-insertion; auto retract silently
-// discards the pull's E moves), and by then the nozzle is already hot.
+// sensor grabs the filament during hand-insertion), and by then the nozzle is
+// already hot. The last item is not an action but consent: auto retract has no
+// switch on INDX from firmware 6.9.0, so the procedure suppresses it by marking
+// the tool FLEX -- a persistent change to the printer's settings.
 class MaintenanceColdPullPreflightDialog : public wxDialog
 {
 public:

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -7540,19 +7540,24 @@ void Plater::cold_pull_maintenance()
     // claim the printer had been restored while quietly leaving a tool that had
     // no filament type set reading as PLA.
     wxString filament_note;
-    if (result.filament_type_written) {
-        if (result.restore_attempted && !result.restore_verified) {
-            filament_note += _L("\n\nThis nozzle was marked FLEX to suppress auto retract "
-                                "and the printer did not confirm putting it back, so it may "
-                                "still read FLEX — a power cycle will not undo that. Check "
-                                "Settings > Filament on the printer.");
-        }
-        if (result.filament_type_was_unset) {
-            filament_note += _L("\n\nThis nozzle had no filament type set before the run, "
-                                "and there is no way to set one back to \"none\", so it is now "
-                                "marked PLA. Clear it from the printer's Filament menu if you "
-                                "want it empty.");
-        }
+    if (result.filament_type_written && !result.filament_type_restored) {
+        // Keyed on the restore never being ACKNOWLEDGED, not on cleanup having
+        // been attempted: a force stop returns before cleanup runs at all, so
+        // "not attempted" is the case that most needs the warning, not the one
+        // that excuses it. M865 is persistent -- the reset a force stop calls
+        // for will not undo it.
+        filament_note = _L("\n\nThis nozzle was marked FLEX to suppress auto retract and "
+                           "the printer never confirmed putting it back, so it may still "
+                           "read FLEX — which disables auto retract for later prints, and "
+                           "neither a power cycle nor a reset undoes it. Check "
+                           "Settings > Filament on the printer.");
+    } else if (result.filament_type_written && result.filament_type_was_unset) {
+        // The restore landed, but the tool had nothing set to begin with and
+        // there is no G-code that sets one back to "none", so it now reads PLA.
+        filament_note = _L("\n\nThis nozzle had no filament type set before the run, and "
+                           "there is no way to set one back to \"none\", so it is now marked "
+                           "PLA. Clear it from the printer's Filament menu if you want it "
+                           "empty.");
     }
 
     wxString msg;

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -7397,9 +7397,10 @@ void Plater::cold_pull_maintenance()
                    "The file marks this nozzle FLEX to suppress auto retract, "
                    "which has no switch on INDX from firmware 6.9.0, and cannot "
                    "safely set it back before the end-of-print sequence runs. "
-                   "Once the print has FINISHED, put the nozzle's filament type "
-                   "back from the printer's Filament menu — a power cycle does "
-                   "not do it."),
+                   "Note what Settings > Filament shows for this nozzle now, and "
+                   "set it back to that once the print has FINISHED — do not "
+                   "assume it was PLA, and note that a power cycle does not do "
+                   "it for you."),
                 out_path.string()),
                 _L("Cold Pull (INDX)"), wxOK | wxICON_INFORMATION);
         } else {
@@ -7424,9 +7425,10 @@ void Plater::cold_pull_maintenance()
                    "The file marks this nozzle FLEX to suppress auto retract, "
                    "which has no switch on INDX from firmware 6.9.0, and cannot "
                    "safely set it back before the end-of-print sequence runs. "
-                   "Once the print has FINISHED, put the nozzle's filament type "
-                   "back from the printer's Filament menu — a power cycle does "
-                   "not do it."),
+                   "Note what Settings > Filament shows for this nozzle now, and "
+                   "set it back to that once the print has FINISHED — do not "
+                   "assume it was PLA, and note that a power cycle does not do "
+                   "it for you."),
                 fname),
                 _L("Cold Pull (INDX)"), wxOK | wxICON_INFORMATION);
         }

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -7393,8 +7393,13 @@ void Plater::cold_pull_maintenance()
                    "Copy it to a USB drive and start it on the printer like any "
                    "other print. It will stop and wait for knob presses at each "
                    "step.\n\n"
-                   "Check first: Filament Sensor OFF, Auto Retract OFF, PTFE "
-                   "tube removed."),
+                   "Check first: Filament Sensor OFF, PTFE tube removed.\n\n"
+                   "The file marks this nozzle FLEX to suppress auto retract, "
+                   "which has no switch on INDX from firmware 6.9.0, and cannot "
+                   "safely set it back before the end-of-print sequence runs. "
+                   "Once the print has FINISHED, put the nozzle's filament type "
+                   "back from the printer's Filament menu — a power cycle does "
+                   "not do it."),
                 out_path.string()),
                 _L("Cold Pull (INDX)"), wxOK | wxICON_INFORMATION);
         } else {
@@ -7415,8 +7420,13 @@ void Plater::cold_pull_maintenance()
                    "It is NOT started automatically — start it from the "
                    "printer's menu when you are ready. It will stop and wait "
                    "for knob presses at each step.\n\n"
-                   "Check first: Filament Sensor OFF, Auto Retract OFF, PTFE "
-                   "tube removed."),
+                   "Check first: Filament Sensor OFF, PTFE tube removed.\n\n"
+                   "The file marks this nozzle FLEX to suppress auto retract, "
+                   "which has no switch on INDX from firmware 6.9.0, and cannot "
+                   "safely set it back before the end-of-print sequence runs. "
+                   "Once the print has FINISHED, put the nozzle's filament type "
+                   "back from the printer's Filament menu — a power cycle does "
+                   "not do it."),
                 fname),
                 _L("Cold Pull (INDX)"), wxOK | wxICON_INFORMATION);
         }
@@ -7522,12 +7532,21 @@ void Plater::cold_pull_maintenance()
     dlg.Update(100);
 
     if (result.error.empty()) {
-        wxMessageBox(_L("Cold pull complete. Inspect the extracted tip: three thin "
-                        "strands with visible debris means a good pull. Repeat 1–2 "
-                        "more times until the tip comes out clean, then re-enable "
-                        "the Filament Sensor and Auto Retract on the printer and "
-                        "refit the PTFE tube."),
-                     _L("Cold Pull (INDX)"), wxOK | wxICON_INFORMATION);
+        wxString done = _L("Cold pull complete. Inspect the extracted tip: three thin "
+                           "strands with visible debris means a good pull. Repeat 1–2 "
+                           "more times until the tip comes out clean, then re-enable "
+                           "the Filament Sensor on the printer and refit the PTFE "
+                           "tube.");
+        // The nozzle had no filament type before the run and there is no G-code
+        // that sets one back to "no filament", so it is now marked PLA. True of
+        // what was in it during the procedure, but not what was there before --
+        // say so rather than let the printer quietly describe a spool that was
+        // never declared.
+        if (result.filament_type_was_unset)
+            done += _L("\n\nThis nozzle had no filament type set before the run, so it "
+                       "is now marked PLA. Clear it from the printer's Filament menu if "
+                       "you want it empty.");
+        wxMessageBox(done, _L("Cold Pull (INDX)"), wxOK | wxICON_INFORMATION);
     } else if (result.force_stopped) {
         wxMessageBox(_L("Emergency stop sent. Reset the printer before continuing."),
                      _L("Cold Pull (INDX)"), wxOK | wxICON_WARNING);

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -7540,10 +7540,15 @@ void Plater::cold_pull_maintenance()
     // claim the printer had been restored while quietly leaving a tool that had
     // no filament type set reading as PLA.
     wxString filament_note;
-    if (!result.unrestorable_filament_name.empty()) {
+    if (result.filament_type_written && !result.unrestorable_filament_name.empty()) {
         // The tool carries a name this host cannot quote back into M865, so
         // nothing was written back. Hand the exact name over rather than
         // paraphrase it -- it is the only copy the user now has.
+        //
+        // Gated on the FLEX write like the branches below: the name is read
+        // before the procedure starts, so a cancel at the setup prompt or a
+        // failed tool pick would otherwise announce a persistent change that
+        // never happened.
         filament_note = GUI::format_wxstr(
             _L("\n\nThis nozzle reports its filament type as \"%1%\", which cannot be "
                "sent back over G-code, so nothing was written back and it is still "

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -7533,57 +7533,73 @@ void Plater::cold_pull_maintenance()
     worker.join();
     dlg.Update(100);
 
+    // Suppressing auto retract writes the tool's filament type, which is a
+    // PERSISTENT printer setting -- so every terminal path below has to own up
+    // to it, not just the successful one. A cancelled or failed run changes it
+    // just as permanently, and the cancellation message in particular used to
+    // claim the printer had been restored while quietly leaving a tool that had
+    // no filament type set reading as PLA.
+    wxString filament_note;
+    if (result.filament_type_written) {
+        if (result.restore_attempted && !result.restore_verified) {
+            filament_note += _L("\n\nThis nozzle was marked FLEX to suppress auto retract "
+                                "and the printer did not confirm putting it back, so it may "
+                                "still read FLEX — a power cycle will not undo that. Check "
+                                "Settings > Filament on the printer.");
+        }
+        if (result.filament_type_was_unset) {
+            filament_note += _L("\n\nThis nozzle had no filament type set before the run, "
+                                "and there is no way to set one back to \"none\", so it is now "
+                                "marked PLA. Clear it from the printer's Filament menu if you "
+                                "want it empty.");
+        }
+    }
+
+    wxString msg;
+    long icon = wxICON_INFORMATION;
+
     if (result.error.empty()) {
-        wxString done = _L("Cold pull complete. Inspect the extracted tip: three thin "
-                           "strands with visible debris means a good pull. Repeat 1–2 "
-                           "more times until the tip comes out clean, then re-enable "
-                           "the Filament Sensor on the printer and refit the PTFE "
-                           "tube.");
-        // The nozzle had no filament type before the run and there is no G-code
-        // that sets one back to "no filament", so it is now marked PLA. True of
-        // what was in it during the procedure, but not what was there before --
-        // say so rather than let the printer quietly describe a spool that was
-        // never declared.
-        if (result.filament_type_was_unset)
-            done += _L("\n\nThis nozzle had no filament type set before the run, so it "
-                       "is now marked PLA. Clear it from the printer's Filament menu if "
-                       "you want it empty.");
-        wxMessageBox(done, _L("Cold Pull (INDX)"), wxOK | wxICON_INFORMATION);
+        msg = _L("Cold pull complete. Inspect the extracted tip: three thin "
+                 "strands with visible debris means a good pull. Repeat 1–2 "
+                 "more times until the tip comes out clean, then re-enable "
+                 "the Filament Sensor on the printer and refit the PTFE "
+                 "tube.");
     } else if (result.force_stopped) {
-        wxMessageBox(_L("Emergency stop sent. Reset the printer before continuing."),
-                     _L("Cold Pull (INDX)"), wxOK | wxICON_WARNING);
+        msg  = _L("Emergency stop sent. Reset the printer before continuing.");
+        icon = wxICON_WARNING;
     } else if (force_stop_requested.load()) {
         // Requested but never delivered -- the worker had already stopped. Say
         // so plainly: the printer may still be hot with its guards down.
-        wxMessageBox(GUI::format_wxstr(
+        msg = GUI::format_wxstr(
             _L("Force stop was requested but NOT sent — the procedure had "
                "already stopped on its own:\n\n%1%\n\n"
                "No emergency stop reached the printer. Check it directly: the "
                "nozzle may still be hot. If needed, turn the heaters off from "
                "the printer's menu."),
-            wxString::FromUTF8(result.error.empty() ? "unknown error" : result.error)),
-            _L("Cold Pull (INDX)"), wxOK | wxICON_WARNING);
+            wxString::FromUTF8(result.error.empty() ? "unknown error" : result.error));
+        icon = wxICON_WARNING;
     } else if (result.restore_attempted && !result.restore_verified) {
         // Cleanup ran but the printer did not acknowledge all of it. Never
         // claim the machine is safe in this state.
-        wxMessageBox(GUI::format_wxstr(
+        msg = GUI::format_wxstr(
             _L("Cold pull stopped, but the printer did NOT confirm the cleanup "
                "commands:\n\n%1%\n\n"
                "CHECK THE PRINTER DIRECTLY. The nozzle may still be hot, and "
                "cold extrusion and stuck-filament detection may still be "
                "disabled. Turn the heaters off from the printer's menu, and "
                "power-cycle it to restore the guards."),
-            wxString::FromUTF8(result.error.empty() ? "cancelled" : result.error)),
-            _L("Cold Pull (INDX)"), wxOK | wxICON_WARNING);
+            wxString::FromUTF8(result.error.empty() ? "cancelled" : result.error));
+        icon = wxICON_WARNING;
     } else if (result.cancelled) {
-        wxMessageBox(_L("Cold pull cancelled. Printer state was restored (heaters "
-                        "off, guards re-enabled). If a dialog is still on the "
-                        "printer screen, press the knob to dismiss it."),
-                     _L("Cold Pull (INDX)"), wxOK | wxICON_INFORMATION);
+        msg = _L("Cold pull cancelled. Printer state was restored (heaters "
+                 "off, guards re-enabled). If a dialog is still on the "
+                 "printer screen, press the knob to dismiss it.");
     } else {
-        wxMessageBox(wxString::FromUTF8(result.error),
-                     _L("Cold Pull (INDX)"), wxOK | wxICON_ERROR);
+        msg  = wxString::FromUTF8(result.error);
+        icon = wxICON_ERROR;
     }
+
+    wxMessageBox(msg + filament_note, _L("Cold Pull (INDX)"), wxOK | icon);
 }
 
 void Plater::save_bed_mesh_csv()

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -7540,7 +7540,17 @@ void Plater::cold_pull_maintenance()
     // claim the printer had been restored while quietly leaving a tool that had
     // no filament type set reading as PLA.
     wxString filament_note;
-    if (result.filament_type_written && !result.filament_type_restored) {
+    if (!result.unrestorable_filament_name.empty()) {
+        // The tool carries a name this host cannot quote back into M865, so
+        // nothing was written back. Hand the exact name over rather than
+        // paraphrase it -- it is the only copy the user now has.
+        filament_note = GUI::format_wxstr(
+            _L("\n\nThis nozzle reports its filament type as \"%1%\", which cannot be "
+               "sent back over G-code, so nothing was written back and it is still "
+               "marked FLEX. Set it to \"%1%\" yourself under Settings > Filament on "
+               "the printer — neither a power cycle nor a reset undoes it."),
+            wxString::FromUTF8(result.unrestorable_filament_name));
+    } else if (result.filament_type_written && !result.filament_type_restored) {
         // Keyed on the restore never being ACKNOWLEDGED, not on cleanup having
         // been attempted: a force stop returns before cleanup runs at all, so
         // "not attempted" is the case that most needs the warning, not the one

--- a/src/slic3r/Utils/MaintenanceSerial.cpp
+++ b/src/slic3r/Utils/MaintenanceSerial.cpp
@@ -1014,7 +1014,7 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
             // read off this very tool before the write, so re-sending it is a
             // no-op if the write never landed.
             if (s.cmd.rfind("M865 S\"FLEX\"", 0) == 0)
-                flex_applied = true;
+                flex_applied = result.filament_type_written = true;
             if (!run(s.stage, s.cmd, s.detail, s.overall, kIdle)) {
                 // Any failure past this point can leave the printer hot with
                 // its guards down -- a heating timeout is the obvious case:

--- a/src/slic3r/Utils/MaintenanceSerial.cpp
+++ b/src/slic3r/Utils/MaintenanceSerial.cpp
@@ -636,6 +636,9 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
         // than silently defaulted.
         std::string orig_filament = "PLA";
         bool flex_applied = false;
+        // Cleared when the tool reports a name this host cannot quote back into
+        // M865; nothing is then written back. See the read-back below.
+        bool restore_filament_type = true;
         {
             emit("Connecting", "Reading the tool's filament type");
             const std::string query = "M865 I" + std::to_string(options.tool);
@@ -651,30 +654,29 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
                     [&](const std::string& line) {
                         BOOST_LOG_TRIVIAL(debug) << "[Maintenance] M865 << " << line;
                         constexpr std::string_view kKey = "name:";
-                        const auto pos = line.find(kKey);
-                        if (pos == std::string::npos)
+                        if (line.compare(0, kKey.size(), kKey) != 0)
                             return;
-                        std::string tail = line.substr(pos + kKey.size());
+                        // Capture VERBATIM. Filtering by character class here
+                        // would make an odd name indistinguishable from no name
+                        // at all, and the two want opposite handling.
+                        std::string tail = line.substr(kKey.size());
                         while (!tail.empty() && std::isspace(static_cast<unsigned char>(tail.back())))
                             tail.pop_back();
-                        // Filament names are alphanumeric plus '_' and '-'
-                        // (FilamentType::can_be_renamed_to), so anything else
-                        // is firmware chatter that merely contained "name:".
-                        if (!tail.empty()
-                            && std::all_of(tail.begin(), tail.end(), [](unsigned char c) {
-                                   return std::isalnum(c) || c == '_' || c == '-';
-                               }))
-                            name = tail;
+                        while (!tail.empty() && std::isspace(static_cast<unsigned char>(tail.front())))
+                            tail.erase(tail.begin());
+                        name = tail;
                     }, query_err)) {
                 result.error = "The printer did not answer " + query + " (" + query_err
                              + "). Cannot tell what filament type to restore, so nothing was sent.";
                 return result;
             }
-            if (!name.empty()) {
-                orig_filament = name;
-                BOOST_LOG_TRIVIAL(info) << "[Maintenance] tool " << options.tool
-                                        << " filament type: " << orig_filament;
-            } else {
+
+            // Three outcomes, and only the first may end in a value we chose.
+            const bool sendable = !name.empty()
+                && std::all_of(name.begin(), name.end(), [](unsigned char c) {
+                       return std::isalnum(c) || c == '_' || c == '-';
+                   });
+            if (name.empty()) {
                 // Not fatal, but the user has to know: there is no G-code that
                 // sets a tool back to "no filament", so the tool ends up marked
                 // PLA -- the filament this procedure has them insert.
@@ -682,6 +684,19 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
                 BOOST_LOG_TRIVIAL(warning)
                     << "[Maintenance] tool " << options.tool
                     << " has no filament type set; it will be left as PLA";
+            } else if (sendable) {
+                orig_filament = name;
+                BOOST_LOG_TRIVIAL(info) << "[Maintenance] tool " << options.tool
+                                        << " filament type: " << orig_filament;
+            } else {
+                // Cannot be quoted back into M865 (spaces, punctuation, a quote
+                // character). Write nothing rather than overwrite it: the tool
+                // stays FLEX and the UI hands the user the exact name back.
+                restore_filament_type = false;
+                result.unrestorable_filament_name = name;
+                BOOST_LOG_TRIVIAL(warning)
+                    << "[Maintenance] tool " << options.tool << " reports filament name \""
+                    << name << "\", which cannot be sent back; leaving it marked FLEX";
             }
         }
 
@@ -748,7 +763,7 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
             // good PETG setting with a value we invented.
             const std::string filament_restore_cmd_for_cleanup =
                 "M865 S\"" + orig_filament + "\" L" + std::to_string(options.tool);
-            if (flex_applied)
+            if (flex_applied && restore_filament_type)
                 cleanup.push_back(filament_restore_cmd_for_cleanup);
             cleanup.push_back("M84"); // release steppers
             bool all_confirmed = true;
@@ -1003,6 +1018,11 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
         // dialog advances meaningfully instead of once per G4.
         const char* last_stage = "";
         for (const Step& s : steps) {
+            // Skip the restore outright when the reported name cannot be sent
+            // back. Leaving the tool FLEX with a loud message in the result
+            // beats writing a filament type nobody chose.
+            if (!restore_filament_type && s.cmd == filament_restore_cmd)
+                continue;
             if (std::strcmp(s.stage, last_stage) != 0) {
                 last_stage = s.stage;
                 if (step < kTotalSteps)

--- a/src/slic3r/Utils/MaintenanceSerial.cpp
+++ b/src/slic3r/Utils/MaintenanceSerial.cpp
@@ -17,7 +17,7 @@
 #include <vector>
 
 // The cold-pull recipe below was verified line-by-line against
-// Prusa-Firmware-Buddy v6.6.3 (COREONE_INDX):
+// Prusa-Firmware-Buddy v6.6.3 and v6.9.0 (COREONE_INDX):
 //  - Heating requires a picked/latched tool (base_hotend.cpp:50) → T<n> first.
 //  - G1 E below EXTRUDE_MINTEMP 170 is silently stripped unless M302 S0
 //    (planner.cpp:2280).
@@ -31,6 +31,12 @@
 //    mechanical and dock-gated (toolchanger_indx.cpp:525-575).
 //  - Firmware E current default is 550 mA; 650 is what the firmware itself
 //    uses for lock moves, safe for the stiff-plug pull (M906).
+//  - v6.9.0 removed the Auto Retract switch on INDX (0dfee5ef1): the toggle
+//    moved behind HAS_SWITCHABLE_AUTO_RETRACT, which does not list either INDX
+//    variant. auto_retract.cpp:113 still returns early for filaments marked
+//    is_flexible, and FLEX is the only such preset (filament_presets.cpp:192),
+//    so M865 S"FLEX" L<n> is what suppresses it -> see the AUTO RETRACT note in
+//    run_cold_pull() and the header of the generated file.
 
 namespace Slic3r {
 namespace Utils {
@@ -238,6 +244,9 @@ std::string generate_cold_pull_gcode(const ColdPullOptions& options)
     const std::string pull  = std::to_string(options.pull_temp_c);
     // Nozzle number as printed on the machine, for human-facing text only.
     const std::string nozzle = std::to_string(options.tool + 1);
+    // Two-stage warm-up stops short of the target so the PID does not overshoot.
+    const std::string pull_minus_3 = std::to_string(options.pull_temp_c - 3);
+    const std::string pull_minus_4 = std::to_string(options.pull_temp_c - 4);
 
     std::ostringstream g;
 
@@ -248,15 +257,33 @@ std::string generate_cold_pull_gcode(const ColdPullOptions& options)
       << "; ------------------------------------------------------------\n"
       << "; BEFORE RUNNING, at the printer:\n"
       << ";   - Settings: turn the Filament Sensor OFF\n"
-      << ";   - Settings: turn Auto Retract OFF\n"
       << ";   - Remove the PTFE tube from this tool\n"
-      << ";   - Have light-colored PLA ready and stay at the printer\n"
+      << ";   - Have light-colored PLA ready and stay at the printer.\n"
+      << ";     Do NOT preload it - a prompt says when to insert it.\n"
       << "; ------------------------------------------------------------\n"
-      << "; The procedure stops at several prompts and waits for a knob\n"
+      << "; AUTO RETRACT: there is no longer a switch for it on INDX.\n"
+      << "; Firmware 6.9.0 moved the toggle behind HAS_SWITCHABLE_AUTO_RETRACT,\n"
+      << "; which lists COREONE, COREONEL, MK4, iX and XL but neither INDX\n"
+      << "; variant, so the menu item and the stored setting are both compiled\n"
+      << "; out. The one lever left is the filament type: auto retract returns\n"
+      << "; early for any filament marked flexible, and FLEX is the only preset\n"
+      << "; that is. So the M865 line below marks this tool FLEX for the run.\n"
+      << "; This file does NOT put it back, deliberately: the end-of-print\n"
+      << "; sequence runs after the last line, and with the tool back on PLA\n"
+      << "; that sequence would auto-retract - reheating the nozzle to 215C,\n"
+      << "; overriding the warm-wipe temperature this file sets, and ramming\n"
+      << "; the melt zone you just cleared. Put it back once the print has\n"
+      << "; FINISHED - send M865 S\"PLA\" L" << tool << " or use the Filament menu. The\n"
+      << "; write is PERSISTENT; a power cycle does not undo it.\n"
+      << "; ------------------------------------------------------------\n"
+      << "; The procedure stops at six prompts and waits for a knob\n"
       << "; press. To bail out, press the knob then Stop the print.\n"
       << "; If you Stop at the tip check, the restore block never runs -\n"
       << "; afterwards send M302 S170 and M591 R, or power-cycle, to put\n"
       << "; back the cold-extrusion guard and stuck-filament detection.\n"
+      << "; The filament type is not covered by a power cycle either, because\n"
+      << "; it lives in the printer's settings: send M865 S\"PLA\" L" << tool << ", or\n"
+      << "; set this tool's filament back from the Filament menu.\n"
       << "; A prompt left ~30 min turns the heaters off (safety timer); the\n"
       << "; procedure re-asserts temperature after each prompt to cover that.\n"
       << "; ------------------------------------------------------------\n"
@@ -273,10 +300,22 @@ std::string generate_cold_pull_gcode(const ColdPullOptions& options)
     g << "M862.3 P\"COREONEINDX\"   ; refuse to run on a non-INDX printer\n\n";
 
     g << "M117 Cold pull - guided\n"
-      << "M0 Setup check: filament sensor OFF, auto retract OFF, PTFE tube removed. Press to continue\n\n";
+      << "M0 Setup check: filament sensor OFF, PTFE tube removed. Press to continue\n\n";
 
+    // M865 S"FLEX" L<n> is the whole auto-retract workaround. Firmware 6.9.0
+    // dropped the Auto Retract switch on INDX (0dfee5ef1, BFW-8589): the toggle
+    // moved behind HAS_SWITCHABLE_AUTO_RETRACT, which lists COREONE COREONEL
+    // MK4 iX XL and neither INDX variant, so the menu item, the global-disable
+    // check in maybe_retract_from_nozzle() and the auto_retract_enabled
+    // config-store item are all compiled out. What survives is an early return
+    // for filaments marked is_flexible (BFW-6953), and FLEX is the only preset
+    // with the flag. M865 cannot rewrite a preset's parameters
+    // (is_customizable() is false for presets), so this changes only which type
+    // the tool is recorded as holding. It is a PERSISTENT write; see the header
+    // above for why this file must not undo it.
     g << "M117 Picking nozzle " << nozzle << "\n"
       << "T" << tool << " M0                 ; M0 param = ignore tool mapping\n"
+      << "M865 S\"FLEX\" L" << tool << "       ; suppress auto retract - see the note above\n"
       << "M302 S0               ; allow cold extrusion for the session\n"
       << "M83                   ; relative E\n"
       << "M591 S0               ; disable stuck-filament detection\n\n";
@@ -286,7 +325,13 @@ std::string generate_cold_pull_gcode(const ColdPullOptions& options)
     g << "M117 Heating to " << flush << "\n"
       << "M109 S" << flush << "\n\n";
 
-    g << "M117 Purging - watch the tip\n";
+    g << "; The briefing must come BEFORE the purge: the screen and the nozzle\n"
+      << "; cannot be watched at the same time, so tell the user what to look\n"
+      << "; for, let them press, and only then start extruding.\n"
+      << "M0 Purge next. Watch the nozzle tip for melted PLA flowing out. Press to start\n"
+      << "M109 S" << flush << "             ; re-assert - the prompt is unbounded and the\n"
+      << "                      ; safety timer may have cleared the target\n"
+      << "M117 Purging - watch the tip\n";
     for (int i = 0; i < 3; ++i) {
         g << "G1 E20 F120\n";
         if (i < 2) g << "G4 S2\n";
@@ -325,31 +370,56 @@ std::string generate_cold_pull_gcode(const ColdPullOptions& options)
       << "M107\n\n";
 
     g << "M117 Reheating to " << pull << "\n"
-      << "M104 S" << pull << "\n"
-      << "M109 R" << pull << "\n\n";
+      << "; Two-stage warm-up. Aimed straight at the target, the PID (not tuned\n"
+      << "; for temperatures this low) overshoots, then waits ~30s to settle\n"
+      << "; back down. Stop the first stage just short so the thermal momentum\n"
+      << "; bleeds off, then close the last degrees under control. M109 C waits\n"
+      << "; for a temperature WITHOUT changing the target (Buddy 6.6.2+; older\n"
+      << "; firmware ignores it and just heats and waits as before).\n"
+      << "M104 S" << pull_minus_3 << "\n"
+      << "M109 C" << pull_minus_4 << "\n"
+      << "M109 S" << pull << "\n\n";
 
     g << "M0 Pull ready at " << pull
       << "C. Motor will yank the plug - keep hands clear. Press to pull\n\n";
 
     g << "M117 PULLING\n"
-      << "M104 S" << pull << "              ; re-assert: yanking at high current against a\n"
-      << "M109 R" << pull << "              ; room-temperature plug can snap it or strain the drive\n"
+      << "; Re-assert before committing: the prompt above is unbounded, and\n"
+      << "; yanking at high current against a plug that has cooled back to\n"
+      << "; room temperature can snap it or strain the drive. Two stages for\n"
+      << "; the same overshoot reason as above; at temperature already, all\n"
+      << "; three return immediately.\n"
+      << "M104 S" << pull_minus_3 << "\n"
+      << "M109 C" << pull_minus_4 << "\n"
+      << "M109 S" << pull << "\n"
       << "M906 E650             ; E current up for the stiff plug\n"
       << "G1 E-40 F3000         ; 50mm/s yank\n"
-      << "G1 E-30 F1200         ; feed the strand up out of the gear\n"
+      << "G1 E-40 F1200         ; feed the strand up out of the gear\n"
       << "M906 E550             ; restore INDX default current\n"
       << "M591 R                ; restore stuck-filament detection\n"
       << "M302 S170             ; restore cold-extrusion guard\n"
       << "M104 S0\n\n";
 
-    g << "M0 Pull done. Remove strand from top port. Pressing knob starts auto wipe and dock\n\n";
+    g << "M0 Pull done. Remove strand from top port. Pressing knob warms nozzle, then wipe and dock\n\n";
+
+    g << "; Rewarm before the end-of-print wipe. The pull left the nozzle near\n"
+      << "; " << pull << "C and the unbounded prompt above lets it fall to ambient, where\n"
+      << "; the wipe just drags solid strings around the printer. 170 softens\n"
+      << "; PLA residue so the wiper takes it off; the heater then goes straight\n"
+      << "; off and residual heat carries the few seconds of wipe and dock.\n"
+      << "M117 Warming for the wipe\n"
+      << "M109 S170\n"
+      << "M104 S0               ; off before the teardown - nothing relies on the\n"
+      << "                      ; firmware to switch the heater off afterwards\n\n";
 
     g << "M117 Finishing - hands off\n"
       << "; The end-of-print sequence runs automatically after the last line:\n"
       << "; nozzle wipe, tool dock, steppers off. Wait for Finished.\n"
       << "; Inspect the tip: three thin strands + debris = a good pull.\n"
-      << "; Repeat until the tip comes out clean, then re-enable the\n"
-      << "; Filament Sensor and Auto Retract and refit the PTFE tube.\n";
+      << "; Repeat until the tip comes out clean. Then, at the printer:\n"
+      << "; re-enable the Filament Sensor, refit the PTFE tube, and set this\n"
+      << "; tool's filament type back to PLA (M865 S\"PLA\" L" << tool << ", or the\n"
+      << "; Filament menu). Nothing else puts that one back for you.\n";
 
     return g.str();
 }
@@ -543,6 +613,73 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
             BOOST_LOG_TRIVIAL(info) << "[Maintenance] confirmed INDX: " << machine_type;
         }
 
+        // --- AUTO RETRACT. Firmware 6.9.0 removed the switch on INDX
+        // (0dfee5ef1, BFW-8589): the toggle moved behind
+        // HAS_SWITCHABLE_AUTO_RETRACT, which lists COREONE COREONEL MK4 iX XL
+        // and neither INDX variant, so the menu item, the global-disable check
+        // in maybe_retract_from_nozzle() and the auto_retract_enabled
+        // config-store item are all compiled out. The only remaining lever is
+        // the filament type: auto_retract.cpp returns early, ahead of any
+        // retraction, for filaments marked is_flexible (BFW-6953), and FLEX is
+        // the only preset with the flag.
+        //
+        // Marking the tool FLEX is a PERSISTENT write, so read the tool's real
+        // filament type back first and put exactly that value back afterwards,
+        // rather than assuming PLA and leaving the printer describing a spool
+        // it does not have. M865 I<n> echoes "name:<TYPE>"; a tool with no
+        // filament type set echoes nothing at all, which is reported rather
+        // than silently defaulted.
+        std::string orig_filament = "PLA";
+        bool flex_applied = false;
+        {
+            emit("Connecting", "Reading the tool's filament type");
+            const std::string query = "M865 I" + std::to_string(options.tool);
+            error_code ec;
+            asio::write(serial, asio::buffer(query + "\n"), ec);
+            if (ec) {
+                result.error = "Could not read the tool's filament type: " + ec.message();
+                return result;
+            }
+            std::string name;
+            std::string query_err;
+            if (!stream_until_ok(serial, io, 10'000, 10'000, nullptr,
+                    [&](const std::string& line) {
+                        BOOST_LOG_TRIVIAL(debug) << "[Maintenance] M865 << " << line;
+                        constexpr std::string_view kKey = "name:";
+                        const auto pos = line.find(kKey);
+                        if (pos == std::string::npos)
+                            return;
+                        std::string tail = line.substr(pos + kKey.size());
+                        while (!tail.empty() && std::isspace(static_cast<unsigned char>(tail.back())))
+                            tail.pop_back();
+                        // Filament names are alphanumeric plus '_' and '-'
+                        // (FilamentType::can_be_renamed_to), so anything else
+                        // is firmware chatter that merely contained "name:".
+                        if (!tail.empty()
+                            && std::all_of(tail.begin(), tail.end(), [](unsigned char c) {
+                                   return std::isalnum(c) || c == '_' || c == '-';
+                               }))
+                            name = tail;
+                    }, query_err)) {
+                result.error = "The printer did not answer " + query + " (" + query_err
+                             + "). Cannot tell what filament type to restore, so nothing was sent.";
+                return result;
+            }
+            if (!name.empty()) {
+                orig_filament = name;
+                BOOST_LOG_TRIVIAL(info) << "[Maintenance] tool " << options.tool
+                                        << " filament type: " << orig_filament;
+            } else {
+                // Not fatal, but the user has to know: there is no G-code that
+                // sets a tool back to "no filament", so the tool ends up marked
+                // PLA -- the filament this procedure has them insert.
+                result.filament_type_was_unset = true;
+                BOOST_LOG_TRIVIAL(warning)
+                    << "[Maintenance] tool " << options.tool
+                    << " has no filament type set; it will be left as PLA";
+            }
+        }
+
         // Send one command and stream to "ok". `stage` drives the progress
         // dialog and `detail` describes the step in plain language. The caption
         // is emitted ONCE and then left alone: firmware chatter (temperature
@@ -593,16 +730,23 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
         auto restore_printer_state = [&]() {
             emit("Restoring", "Putting the printer back to a safe state");
             result.restore_attempted = true;
-            const char* cleanup[] = {
+            std::vector<std::string> cleanup = {
                 "M104 S0",   // heater off
                 "M107",      // fan off
                 "M302 S170", // restore cold-extrusion guard
                 "M591 R",    // restore stuck-filament detection from EEPROM
                 "M906 E550", // restore INDX default E current
-                "M84",       // release steppers
             };
+            // Conditional: M865 writes to the printer's persistent settings, so
+            // sending it when the FLEX step never ran would change a tool this
+            // session never touched. flex_applied is only set once the printer
+            // has acknowledged the FLEX write.
+            if (flex_applied)
+                cleanup.push_back("M865 S\"" + orig_filament + "\" L"
+                                  + std::to_string(options.tool));
+            cleanup.push_back("M84"); // release steppers
             bool all_confirmed = true;
-            for (const char* cmd : cleanup) {
+            for (const std::string& cmd : cleanup) {
                 // Escalation must work FROM here. Cleanup can block behind an
                 // M0 prompt the user never answers, which is precisely when
                 // they reach for Force Stop -- so poll the flag between
@@ -614,7 +758,7 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
                     return; // restore_verified stays false: cleanup is incomplete
                 }
                 error_code ec;
-                asio::write(serial, asio::buffer(std::string(cmd) + "\n"), ec);
+                asio::write(serial, asio::buffer(cmd + "\n"), ec);
                 if (ec) {
                     BOOST_LOG_TRIVIAL(warning)
                         << "[Maintenance] cleanup write failed (" << cmd << "): " << ec.message();
@@ -657,6 +801,10 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
         const std::string tool  = std::to_string(options.tool);
         const std::string flush = std::to_string(options.flush_temp_c);
         const std::string pull  = std::to_string(options.pull_temp_c);
+        // Two-stage warm-up stops short of the target so the PID does not
+        // overshoot; see the Reheating steps below.
+        const std::string pull_minus_3 = std::to_string(options.pull_temp_c - 3);
+        const std::string pull_minus_4 = std::to_string(options.pull_temp_c - 4);
 
         // --- SERIAL-PRINT TIMEOUT DISARM. Read this before touching the
         // command list below; it caused a BSOD ("E move without tool") on real
@@ -714,7 +862,7 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
         };
         const Step steps[] = {
             { "Waiting at printer",
-              "M0 Setup check: filament sensor OFF, auto retract OFF, PTFE tube removed. Press to continue",
+              "M0 Setup check: filament sensor OFF, PTFE tube removed. Press to continue",
               "Confirm the setup prompt on the printer screen", kPrompt },
             // Arm the serial-print state machine with an instant G-command so
             // it can never be armed later by a long-blocking one. See the
@@ -722,6 +870,10 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
             { "Preparing",    arm_serial_print, "Starting session",                        kQuick },
             { "Picking tool", "T" + tool + " M0",
               "Picking nozzle from its dock",                                              kPick  },
+            // Suppress auto retract for the run. See the AUTO RETRACT note at
+            // the model gate above for why this is the only lever left on 6.9.0.
+            { "Preparing",    "M865 S\"FLEX\" L" + tool,
+              "Marking the tool FLEX to suppress auto retract",                            kQuick },
             { "Preparing",    "M302 S0",  "Allowing cold extrusion",                       kQuick },
             { "Preparing",    "M83",      "Switching to relative extrusion",               kQuick },
             { "Preparing",    "M591 S0",  "Disabling stuck-filament detection",            kQuick },
@@ -730,6 +882,14 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
               "Insert filament at the printer, then press the knob",                       kPrompt },
             { "Heating",      "M109 S" + flush,
               "Heating nozzle to flush temperature",                                       kHeat  },
+            // Briefing before the purge: the screen and the nozzle cannot be
+            // watched at once, so say what to look for, wait for the press,
+            // then extrude. The prompt is unbounded, so re-assert after it.
+            { "Waiting at printer",
+              "M0 Purge next. Watch the nozzle tip for melted PLA flowing out. Press to start",
+              "Read the purge prompt, then watch the nozzle tip",                          kPrompt },
+            { "Purging",      "M109 S" + flush,
+              "Confirming nozzle is still at temperature",                                 kHeat  },
             { "Purging",      re_pick,       "Confirming nozzle is picked",                kPick  },
             { "Purging",      "G1 E20 F120", "Pushing filament through (1 of 3)",          kMove  },
             { "Purging",      "G4 S2",       "Letting pressure settle",                    kMove  },
@@ -769,8 +929,14 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
             { "Deep cooling", "M104 S0",     "Turning the heater off",                     kQuick },
             { "Deep cooling", "G4 S120",     "Holding 2 minutes to finish cooling",        180'000 },
             { "Deep cooling", "M107",        "Fan off",                                    kQuick },
-            { "Reheating",    "M104 S" + pull, "Setting pull temperature",                 kQuick },
-            { "Reheating",    "M109 R" + pull, "Warming to pull temperature",              kHeat  },
+            // Two-stage warm-up: aimed straight at the pull temperature, the
+            // PID (not tuned for temperatures this low) overshoots and then
+            // spends ~30s settling back. M109 C waits for a temperature without
+            // changing the target (Buddy 6.6.2+; older firmware ignores it and
+            // the next step waits as before).
+            { "Reheating",    "M104 S" + pull_minus_3, "Warming toward pull temperature",  kQuick },
+            { "Reheating",    "M109 C" + pull_minus_4, "Approaching from just below",      kHeat  },
+            { "Reheating",    "M109 S" + pull,         "Settling at pull temperature",     kHeat  },
             { "Waiting at printer",
               "M0 Pull ready at " + pull + "C. Motor will yank the plug - keep hands clear. Press to pull",
               "Keep hands clear, then press the knob to pull",                             kPrompt },
@@ -778,24 +944,42 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
             // current against a plug that has cooled to room temperature can
             // snap the filament or strain the drive. Re-establish the pull
             // temperature before committing to the pull.
-            { "Pulling",      "M104 S" + pull,  "Restoring pull temperature",              kQuick },
-            { "Pulling",      "M109 R" + pull,  "Confirming pull temperature",             kHeat  },
+            { "Pulling",      "M104 S" + pull_minus_3, "Restoring pull temperature",       kQuick },
+            { "Pulling",      "M109 C" + pull_minus_4, "Approaching from just below",      kHeat  },
+            { "Pulling",      "M109 S" + pull,         "Confirming pull temperature",      kHeat  },
             // Re-assert the tool after the long cool/reheat waits, which are
             // the likeliest window for an unnoticed dock.
             { "Pulling",      re_pick,          "Confirming nozzle is picked",             kPick  },
             { "Pulling",      "M906 E650",      "Raising extruder motor current",          kQuick },
             { "Pulling",      "G1 E-40 F3000",  "Pulling the plug out",                    kMove  },
-            { "Pulling",      "G1 E-30 F1200",  "Feeding the strand up and out",           kMove  },
+            { "Pulling",      "G1 E-40 F1200",  "Feeding the strand up and out",           kMove  },
             { "Restoring",    "M906 E550",      "Restoring motor current",                 kQuick },
             { "Restoring",    "M591 R",         "Restoring stuck-filament detection",      kQuick },
             { "Restoring",    "M302 S170",      "Restoring cold-extrusion guard",          kQuick },
             { "Restoring",    "M104 S0",        "Turning the heater off",                  kQuick },
             { "Waiting at printer",
-              // No end-of-print machinery runs over serial: the tool stays
-              // picked. Parking is a menu action on the printer.
-              "M0 Done. Remove the strand and inspect the tip. Park the tool via Control menu when ready",
+              "M0 Done. Remove the strand and inspect the tip. Press to warm the nozzle and dock the tool",
               "Remove the strand at the printer, then press the knob",                     kPrompt },
+            // Warm dock, no manual parking. P0 S1 is the firmware's park-tool
+            // G-code (what Prusa's own end G-code sends); it docks the picked
+            // tool, stops its heater and is a no-op if nothing is picked.
+            // Warming first matters: docked at ambient, solidified strings drag
+            // through the dock instead of releasing. The wastebin brush wipe is
+            // end-of-print machinery that never runs over serial, so the dock is
+            // the only pass the nozzle gets here.
+            { "Finishing",    re_pick,          "Confirming nozzle is picked",             kPick  },
+            { "Finishing",    "M109 S170",
+              "Warming the nozzle so residue releases in the dock",                        kHeat  },
+            { "Finishing",    "M104 S0",        "Turning the heater off",                  kQuick },
+            { "Finishing",    "P0 S1",          "Docking the tool",                        kPick  },
             { "Finishing",    "M84",            "Releasing the motors",                    kQuick },
+            // Last, deliberately: FLEX has to stay in force through the warm-up
+            // and the dock above, or the firmware would auto-retract the moment
+            // the tool reads as PLA again. Safe to do at all here, unlike in the
+            // G-code file, because a serial session has no end-of-print
+            // sequence after it.
+            { "Finishing",    "M865 S\"" + orig_filament + "\" L" + tool,
+              "Restoring the tool's filament type",                                        kQuick },
         };
 
         // Map command groups onto the coarse 12-step progress scale so the
@@ -833,6 +1017,10 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
                     restore_printer_state();
                 return result;
             }
+            // Only after the printer has acknowledged it: an unconfirmed write
+            // must not license cleanup to change a tool it may not have changed.
+            if (s.cmd.rfind("M865 S\"FLEX\"", 0) == 0)
+                flex_applied = true;
         }
 
         step = kTotalSteps;

--- a/src/slic3r/Utils/MaintenanceSerial.cpp
+++ b/src/slic3r/Utils/MaintenanceSerial.cpp
@@ -746,9 +746,10 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
             // sending it when the FLEX step was never reached would change a
             // tool this session never touched -- overwriting, say, a perfectly
             // good PETG setting with a value we invented.
+            const std::string filament_restore_cmd_for_cleanup =
+                "M865 S\"" + orig_filament + "\" L" + std::to_string(options.tool);
             if (flex_applied)
-                cleanup.push_back("M865 S\"" + orig_filament + "\" L"
-                                  + std::to_string(options.tool));
+                cleanup.push_back(filament_restore_cmd_for_cleanup);
             cleanup.push_back("M84"); // release steppers
             bool all_confirmed = true;
             for (const std::string& cmd : cleanup) {
@@ -774,8 +775,10 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
                 // Pass the force-stop flag (NOT the combined cancel: we are
                 // already cancelling, and cooperative cancel must not abort
                 // the very cleanup it asked for).
-                if (!stream_until_ok(serial, io, 5'000, 5'000, options.force_stop_requested,
-                                     [](const std::string&) {}, cleanup_err)) {
+                const bool acked = stream_until_ok(serial, io, 5'000, 5'000,
+                                                   options.force_stop_requested,
+                                                   [](const std::string&) {}, cleanup_err);
+                if (!acked) {
                     if (is_force_stop()) {
                         send_emergency_stop();
                         return; // restore_verified stays false
@@ -785,6 +788,8 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
                     all_confirmed = false;
                     // Keep going: a later command may still land, and each one
                     // that does leaves the printer safer than stopping here.
+                } else if (cmd == filament_restore_cmd_for_cleanup) {
+                    result.filament_type_restored = true;
                 }
             }
             result.restore_verified = all_confirmed;
@@ -810,6 +815,13 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
         // overshoot; see the Reheating steps below.
         const std::string pull_minus_3 = std::to_string(options.pull_temp_c - 3);
         const std::string pull_minus_4 = std::to_string(options.pull_temp_c - 4);
+
+        // Built once so the step table and the loop that watches it agree on the
+        // exact strings. If the tool genuinely held FLEX to begin with the two
+        // are identical, which is harmless: the tool ends up FLEX either way,
+        // and that IS its original state.
+        const std::string flex_cmd            = "M865 S\"FLEX\" L" + tool;
+        const std::string filament_restore_cmd = "M865 S\"" + orig_filament + "\" L" + tool;
 
         // --- SERIAL-PRINT TIMEOUT DISARM. Read this before touching the
         // command list below; it caused a BSOD ("E move without tool") on real
@@ -877,7 +889,7 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
               "Picking nozzle from its dock",                                              kPick  },
             // Suppress auto retract for the run. See the AUTO RETRACT note at
             // the model gate above for why this is the only lever left on 6.9.0.
-            { "Preparing",    "M865 S\"FLEX\" L" + tool,
+            { "Preparing",    flex_cmd,
               "Marking the tool FLEX to suppress auto retract",                            kQuick },
             { "Preparing",    "M302 S0",  "Allowing cold extrusion",                       kQuick },
             { "Preparing",    "M83",      "Switching to relative extrusion",               kQuick },
@@ -983,7 +995,7 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
             // the tool reads as PLA again. Safe to do at all here, unlike in the
             // G-code file, because a serial session has no end-of-print
             // sequence after it.
-            { "Finishing",    "M865 S\"" + orig_filament + "\" L" + tool,
+            { "Finishing",    filament_restore_cmd,
               "Restoring the tool's filament type",                                        kQuick },
         };
 
@@ -1013,7 +1025,7 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
             // after a failed run. Over-approximating is safe: orig_filament was
             // read off this very tool before the write, so re-sending it is a
             // no-op if the write never landed.
-            if (s.cmd.rfind("M865 S\"FLEX\"", 0) == 0)
+            if (s.cmd == flex_cmd)
                 flex_applied = result.filament_type_written = true;
             if (!run(s.stage, s.cmd, s.detail, s.overall, kIdle)) {
                 // Any failure past this point can leave the printer hot with
@@ -1030,6 +1042,8 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
                     restore_printer_state();
                 return result;
             }
+            if (s.cmd == filament_restore_cmd)
+                result.filament_type_restored = true;
         }
 
         step = kTotalSteps;

--- a/src/slic3r/Utils/MaintenanceSerial.cpp
+++ b/src/slic3r/Utils/MaintenanceSerial.cpp
@@ -260,6 +260,8 @@ std::string generate_cold_pull_gcode(const ColdPullOptions& options)
       << ";   - Remove the PTFE tube from this tool\n"
       << ";   - Have light-colored PLA ready and stay at the printer.\n"
       << ";     Do NOT preload it - a prompt says when to insert it.\n"
+      << ";   - Note what this nozzle's filament type is set to right now.\n"
+      << ";     You need it to undo the change described below.\n"
       << "; ------------------------------------------------------------\n"
       << "; AUTO RETRACT: there is no longer a switch for it on INDX.\n"
       << "; Firmware 6.9.0 moved the toggle behind HAS_SWITCHABLE_AUTO_RETRACT,\n"
@@ -273,8 +275,11 @@ std::string generate_cold_pull_gcode(const ColdPullOptions& options)
       << "; that sequence would auto-retract - reheating the nozzle to 215C,\n"
       << "; overriding the warm-wipe temperature this file sets, and ramming\n"
       << "; the melt zone you just cleared. Put it back once the print has\n"
-      << "; FINISHED - send M865 S\"PLA\" L" << tool << " or use the Filament menu. The\n"
-      << "; write is PERSISTENT; a power cycle does not undo it.\n"
+      << "; FINISHED: send M865 S\"<TYPE>\" L" << tool << " with the type you noted\n"
+      << "; above, or set it from the printer's Filament menu. Do NOT assume\n"
+      << "; it was PLA - sending PLA to a nozzle that was set to PETG or ASA\n"
+      << "; overwrites that. The write is PERSISTENT; a power cycle does not\n"
+      << "; undo it.\n"
       << "; ------------------------------------------------------------\n"
       << "; The procedure stops at six prompts and waits for a knob\n"
       << "; press. To bail out, press the knob then Stop the print.\n"
@@ -282,8 +287,8 @@ std::string generate_cold_pull_gcode(const ColdPullOptions& options)
       << "; afterwards send M302 S170 and M591 R, or power-cycle, to put\n"
       << "; back the cold-extrusion guard and stuck-filament detection.\n"
       << "; The filament type is not covered by a power cycle either, because\n"
-      << "; it lives in the printer's settings: send M865 S\"PLA\" L" << tool << ", or\n"
-      << "; set this tool's filament back from the Filament menu.\n"
+      << "; it lives in the printer's settings: send M865 S\"<TYPE>\" L" << tool << " with\n"
+      << "; the type you noted, or set it back from the Filament menu.\n"
       << "; A prompt left ~30 min turns the heaters off (safety timer); the\n"
       << "; procedure re-asserts temperature after each prompt to cover that.\n"
       << "; ------------------------------------------------------------\n"
@@ -418,8 +423,8 @@ std::string generate_cold_pull_gcode(const ColdPullOptions& options)
       << "; Inspect the tip: three thin strands + debris = a good pull.\n"
       << "; Repeat until the tip comes out clean. Then, at the printer:\n"
       << "; re-enable the Filament Sensor, refit the PTFE tube, and set this\n"
-      << "; tool's filament type back to PLA (M865 S\"PLA\" L" << tool << ", or the\n"
-      << "; Filament menu). Nothing else puts that one back for you.\n";
+      << "; tool's filament type back to what it was (M865 S\"<TYPE>\" L" << tool << ", or\n"
+      << "; the Filament menu). Nothing else puts that one back for you.\n";
 
     return g.str();
 }
@@ -738,9 +743,9 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
                 "M906 E550", // restore INDX default E current
             };
             // Conditional: M865 writes to the printer's persistent settings, so
-            // sending it when the FLEX step never ran would change a tool this
-            // session never touched. flex_applied is only set once the printer
-            // has acknowledged the FLEX write.
+            // sending it when the FLEX step was never reached would change a
+            // tool this session never touched -- overwriting, say, a perfectly
+            // good PETG setting with a value we invented.
             if (flex_applied)
                 cleanup.push_back("M865 S\"" + orig_filament + "\" L"
                                   + std::to_string(options.tool));
@@ -1002,6 +1007,14 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
                 result.error = "Cancelled";
                 return result;
             }
+            // Set BEFORE dispatch, not after the ok. If the write lands but
+            // its ok is lost or arrives after the timeout, treating it as
+            // un-applied would skip the restore and leave the tool marked FLEX
+            // after a failed run. Over-approximating is safe: orig_filament was
+            // read off this very tool before the write, so re-sending it is a
+            // no-op if the write never landed.
+            if (s.cmd.rfind("M865 S\"FLEX\"", 0) == 0)
+                flex_applied = true;
             if (!run(s.stage, s.cmd, s.detail, s.overall, kIdle)) {
                 // Any failure past this point can leave the printer hot with
                 // its guards down -- a heating timeout is the obvious case:
@@ -1017,10 +1030,6 @@ MaintenanceResult run_cold_pull(const MaintenanceProgressCallback& progress,
                     restore_printer_state();
                 return result;
             }
-            // Only after the printer has acknowledged it: an unconfirmed write
-            // must not license cleanup to change a tool it may not have changed.
-            if (s.cmd.rfind("M865 S\"FLEX\"", 0) == 0)
-                flex_applied = true;
         }
 
         step = kTotalSteps;

--- a/src/slic3r/Utils/MaintenanceSerial.hpp
+++ b/src/slic3r/Utils/MaintenanceSerial.hpp
@@ -69,6 +69,15 @@ struct MaintenanceResult
     // cleanup at all -- so "cleanup was not attempted" must not be mistaken for
     // "nothing was left changed".
     bool        filament_type_restored = false;
+
+    // The tool reported a filament name this host cannot quote back into M865 --
+    // the firmware will store an NFC abbreviation that fails its own name
+    // validation (openprinttag/data_utils.cpp keeps the name and marks the data
+    // unsafe), so this is reachable in practice. Nothing is written back in that
+    // case: the tool is left marked FLEX and the UI hands the user the exact
+    // name to restore by hand, because overwriting it with a value we chose
+    // would destroy the very thing the read-back exists to preserve.
+    std::string unrestorable_filament_name;
 };
 
 // Options for the INDX cold-pull procedure. Defaults match the recipe verified

--- a/src/slic3r/Utils/MaintenanceSerial.hpp
+++ b/src/slic3r/Utils/MaintenanceSerial.hpp
@@ -52,6 +52,14 @@ struct MaintenanceResult
     // the tool ends up marked PLA -- the filament this procedure has the user
     // insert. Accurate, but not what was there before, so the UI says so.
     bool        filament_type_was_unset = false;
+
+    // The M865 filament-type write was dispatched, so this session may have
+    // changed a persistent printer setting. Pairs with the two flags above: it
+    // is what makes the "now marked PLA" notice worth showing, and what makes an
+    // unverified restore worth warning about (the tool may still read FLEX).
+    // Every terminal path has to disclose this, not just the successful one --
+    // a cancelled run changes the setting just as permanently.
+    bool        filament_type_written = false;
 };
 
 // Options for the INDX cold-pull procedure. Defaults match the recipe verified

--- a/src/slic3r/Utils/MaintenanceSerial.hpp
+++ b/src/slic3r/Utils/MaintenanceSerial.hpp
@@ -45,6 +45,13 @@ struct MaintenanceResult
     // printer" rather than "state restored".
     bool        restore_attempted = false;
     bool        restore_verified  = false;
+
+    // The tool had no filament type set when the procedure started. Auto retract
+    // is suppressed by marking the tool FLEX (see the AUTO RETRACT note in the
+    // .cpp), and there is no G-code that sets a tool back to "no filament", so
+    // the tool ends up marked PLA -- the filament this procedure has the user
+    // insert. Accurate, but not what was there before, so the UI says so.
+    bool        filament_type_was_unset = false;
 };
 
 // Options for the INDX cold-pull procedure. Defaults match the recipe verified
@@ -90,14 +97,19 @@ struct ColdPullOptions
 //
 // Serial-session differences vs. running the same recipe as a USB print job
 // (both verified against Buddy v6.6.3):
-//  - No end-of-print machinery runs (no auto nozzle-wipe/dock): the procedure
-//    ends with heaters off, steppers disabled, and the tool still picked; the
-//    final prompt tells the user to park it from the printer's Control menu.
+//  - No end-of-print machinery runs, so there is no wastebin brush wipe. The
+//    procedure warms the nozzle and docks the tool itself with P0 S1, ending
+//    with heaters off, steppers disabled and the tool parked. It is also why
+//    the serial path CAN restore the filament type it changed (see below):
+//    nothing runs after the last command that could auto-retract.
 //  - There is no tool-mapping layer; "T<n> M0" is belt-and-braces.
 //  - Print-time systems (runout-triggered pause, in-print nozzle checks) are
 //    inactive; the printer-side Settings prerequisites still apply and are
 //    re-checked by the first on-printer prompt: Filament Sensor OFF (blocks
-//    autoload while hand-inserting filament) and Auto Retract OFF.
+//    autoload while hand-inserting filament). Auto Retract has no switch on
+//    INDX from firmware 6.9.0 (0dfee5ef1); the procedure suppresses it by
+//    marking the tool FLEX, reads the tool's real filament type first and
+//    restores it as the very last command of the run.
 //
 // This is synchronous and typically takes 10–20 minutes end to end (dominated
 // by the deep-cool phase and user response time). Call from a worker thread.
@@ -127,7 +139,14 @@ std::string detect_printer_port();
 //    the header documents the two commands to run afterwards.
 //  - The end-of-print sequence DOES run when the job finishes (nozzle wipe,
 //    tool dock, steppers off), which is exactly what is wanted at the end, so
-//    the final prompt asks the user to clear the strand before it starts.
+//    the final prompt asks the user to clear the strand before it starts. The
+//    file rewarms the nozzle to 170 first so the wipe lifts softened residue
+//    instead of dragging cold strings.
+//  - It CANNOT restore the filament type it changes to suppress auto retract:
+//    the end-of-print sequence runs after the last line, and a tool reading as
+//    PLA there would auto-retract, reheating over the warm-wipe temperature
+//    and ramming the melt zone just cleared. The header of the generated file
+//    and the final on-screen text both tell the user to put it back.
 //  - Every M0 message is kept within the 95-character command limit
 //    (MAX_CMD_SIZE 96) and starts with a plain word containing no semicolons,
 //    or the firmware crops it mid-sentence and raises a warning.

--- a/src/slic3r/Utils/MaintenanceSerial.hpp
+++ b/src/slic3r/Utils/MaintenanceSerial.hpp
@@ -60,6 +60,15 @@ struct MaintenanceResult
     // Every terminal path has to disclose this, not just the successful one --
     // a cancelled run changes the setting just as permanently.
     bool        filament_type_written = false;
+
+    // The tool's original filament type was written back AND acknowledged,
+    // either by the run's own last step or by cleanup. Paired with
+    // filament_type_written this is what tells the UI whether the tool is back
+    // where it started or may still read FLEX. It has to be tracked separately
+    // from restore_verified, because a force stop returns without attempting
+    // cleanup at all -- so "cleanup was not attempted" must not be mistaken for
+    // "nothing was left changed".
+    bool        filament_type_restored = false;
 };
 
 // Options for the INDX cold-pull procedure. Defaults match the recipe verified


### PR DESCRIPTION
Companion to [hyiger/indx-cold-pull#5](https://github.com/hyiger/indx-cold-pull/pull/5). Brings the fork back in step with the web tool and restores the byte-identical invariant between `generate_cold_pull_gcode()` and the page's `generateGcode()`.

## The problem

Firmware **6.9.0** removed the Auto Retract switch on INDX ([`0dfee5ef1`](https://github.com/prusa3d/Prusa-Firmware-Buddy/commit/0dfee5ef1), *"INDX: Remove Auto Retract menu switch (it's not permitted to switch off)"*, BFW-8589). The toggle moved behind a new `HAS_SWITCHABLE_AUTO_RETRACT`, which lists `COREONE COREONEL MK4 iX XL` — neither INDX variant. On INDX the menu item, the global-disable check in `maybe_retract_from_nozzle()` and the `auto_retract_enabled` config-store item are **all compiled out**.

Every route here — the pre-flight gate, the generated file's header, the `M0` setup prompt, the two Plater confirmations, and the guide — has been telling users to turn off a menu that no longer exists. That is the worst kind of instruction in this procedure: one they believe they have satisfied, while auto retract quietly pulls the plug back out of the melt zone and the planner discards the extrusion and pull moves.

## The workaround

Deliberate escape hatch, not a loophole. `auto_retract.cpp` returns early, ahead of any retraction, for filaments marked flexible:

```cpp
// Do not auto retract flexible filaments, they might get tangled in the extruder (BFW-6953)
if (filament_parameters.is_flexible) { return; }
```

`probe.cpp` guards `prepare_for_nozzle_cleaning()` with the same test, and `standard_ramming_sequence_indx.cpp` says outright that *"auto_retract is never called for flexible filaments (filtered in auto_retract.cpp)"*. `FLEX` is the only preset with the flag, the type is read per tool from the config store, and the early return is behind no `HAS_*` guard — present in 6.6.x too.

So: `M865 S"FLEX" L<n>` after the pick. `M865` cannot rewrite a preset's parameters (`is_customizable()` is false for presets), so it changes only which type the tool is recorded as holding. FLEX's ⅙ feedrate factor applies to firmware-internal load/unload helpers, not the raw `G1 E…` moves used here; the one visible side effect is that `requires_filtration` runs the chamber filtration fan while hot.

## Restoring it — asymmetric on purpose

- **Serial** reads the tool's real type first (`M865 I<n>`) and puts *that* value back rather than assuming PLA and leaving the printer describing a spool it does not have. It goes **last, after the warm dock**, so nothing in between can auto-retract; `restore_printer_state()` repeats it on every early exit, gated on `flex_applied` so a run that failed before the FLEX write never touches a tool it did not change. If the tool had no type to begin with there is no G-code that sets one back to "none", so it ends up marked PLA and the completion dialog says so — new `MaintenanceResult::filament_type_was_unset`.
- **The G-code file does not**, deliberately. The end-of-print sequence runs after the last line, and a tool reading as PLA there would auto-retract — reheating to 215 °C over the 170 °C the file sets for the warm wipe, and ramming the melt zone just cleared.

## Also ported from the page (issue #3 work, previously fork-only drift)

Pre-purge briefing prompt · two-stage warm-up (`M104 S<pull-3>`, `M109 C<pull-4>`, `M109 S<pull>`) so the PID does not overshoot · 170 °C rewarm before EOF so the wastebin wipe runs warm · warm `P0 S1` dock ending serial runs · do-not-preload wording · six prompts throughout.

Pull raised **70 mm → 80 mm**, the extra 10 mm on the slow guide-out move rather than the yank: 3000 mm/min against a cold plug is the move that can snap it, while the added travel is about clearing the drive gears and the top port.

## Verification

- `generate_cold_pull_gcode()` is **byte-identical** to the page's `generateGcode()` again — diffed across `(tool, flush, pull)` = `(0,290,80)`, `(2,290,80)`, `(7,250,95)`.
- All three changed translation units compile clean: `MaintenanceSerial.cpp`, `MaintenanceColdPullDialog.cpp`, `Plater.cpp`.
- No stale "Auto Retract OFF" instruction survives in the sources, the generated G-code, the dialog, the Plater strings, or the guide.

⚠️ **Not run on hardware.** Neither this nor the issue #3 changes it builds on have been tested on a printer.

## Files

| File | What changed |
|---|---|
| `src/slic3r/Utils/MaintenanceSerial.cpp` | Generator rewrite, filament read-back, step table, conditional restore |
| `src/slic3r/Utils/MaintenanceSerial.hpp` | `filament_type_was_unset`, corrected route-difference notes |
| `src/slic3r/GUI/MaintenanceColdPullDialog.{cpp,hpp}` | Auto Retract item → FLEX consent item |
| `src/slic3r/GUI/Plater.cpp` | Save/upload confirmations, completion message |
| `doc/Cold_Pull_Guide.md` | New §9 "Auto retract"; prerequisites, walkthrough (6 prompts), recipe and firmware tables |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
