### PR TITLE
Bump version to Filament-Edition-1.13.0

### DIFF
--- a/version.inc
+++ b/version.inc
@@ -4,6 +4,6 @@
 set(SLIC3R_APP_NAME "PrusaSlicer")
 set(SLIC3R_APP_KEY "PrusaSlicer")
 set(SLIC3R_VERSION "2.9.6")
-set(SLIC3R_BUILD_ID "PrusaSlicer-${SLIC3R_VERSION}-Filament-Edition-1.12.1")
+set(SLIC3R_BUILD_ID "PrusaSlicer-${SLIC3R_VERSION}-Filament-Edition-1.13.0")
 set(SLIC3R_RC_VERSION "2,9,6,0")
 set(SLIC3R_RC_VERSION_DOTS "2.9.6.0")


### PR DESCRIPTION
Version bump ahead of the `v1.13.0-filament-edition` release, following the same pattern as 1.12.1 (`347f7e1ee`): bump `version.inc`, tag that commit, cut the release.

Minor rather than patch because this release carries feature work that never shipped in the fork, not just a fix:

- The [issue #3](https://github.com/hyiger/indx-cold-pull/issues/3) cold-pull changes — pre-purge briefing prompt, two-stage warm-up to the pull temperature, 170 °C rewarm before the end-of-print wipe, automatic warm dock ending serial runs.
- The firmware 6.9.0 auto-retract workaround (#55) — 6.9.0 removed the Auto Retract switch on INDX, so every route was telling users to turn off a menu that no longer exists.
- Pull length 70 mm → 80 mm.

Creating the release triggers the Linux, macOS and Windows build workflows (`release: types: [created]`), which is why the version has to be right before the tag lands.